### PR TITLE
deployManagedUAT should use tag's managed package versions rather than local repo's

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -10,18 +10,10 @@
          resource="net/sf/antcontrib/antlib.xml"
          classpath="${basedir}/lib/ant-contrib-1.0b2.jar" />
 
-    <property name="version.npe01" value="2.95" />
-    <property name="version.npo02" value="2.96" />
-    <property name="version.npe03" value="2.92" />
-    <property name="version.npe4" value="2.91" />
-    <property name="version.npe5" value="1.92" />
-    <!-- If the managed package version of Cumulus is installed, uninstall it -->
-    <property name="version.npsp" value="Not Installed" />
-
+    <!-- Load up the version.properties file to get desired versions -->
+    <loadproperties srcFile="${basedir}/version.properties"/>
 
     <!-- Cumulus specific macros -->
-
-
     <macrodef name="getPackageVersions" description="Gets the version for all installed packages">
       <sequential>
         <delete dir="${basedir}/installedPackages"/>
@@ -141,6 +133,23 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <!-- In case the unpackaged code was deployed previously, clean the unpackaged metadata from the target org -->
       <antcall target="uninstallCumulus" />
       
+      <!-- Get the latest beta release tag name -->
+      <get src="http://guarded-hamlet-8069.herokuapp.com/mrbelvedere/repo/Cumulus/version/beta/tag" dest="${basedir}/managed_uat_tag" />
+      <loadfile property="managed_uat_tag" srcfile="${basedir}/managed_uat_tag" />
+      <delete file="${basedir}/managed_uat_tag" />
+
+      <!-- Fetch the version.properties file for the release from GitHub -->
+      <get src="https://raw.github.com/SalesforceFoundation/Cumulus/${managed_uat_tag}/version.properties" dest="${basedir}/managed/version.properties.uat" />
+
+      <!-- Since we want to use the versions required by the tag rather than the currently checked out code, unset all version properties and load the version.properties.uat file -->
+      <var name="version.npe01" unset="true" />
+      <var name="version.npo02" unset="true" />
+      <var name="version.npe03" unset="true" />
+      <var name="version.npe4" unset="true" />
+      <var name="version.npe5" unset="true" />
+      <loadproperties srcFile="${basedir}/version.properties.uat"/>
+      <delete file="${basedir}/version.properties.uat" />
+
       <!-- Get the latest beta release version number -->
       <get src="http://guarded-hamlet-8069.herokuapp.com/mrbelvedere/repo/Cumulus/version/beta" dest="${basedir}/version_uat" />
       <loadfile property="version.npsp.uat" srcfile="${basedir}/version_uat" />

--- a/scripts/set_dependent_versions.py
+++ b/scripts/set_dependent_versions.py
@@ -13,7 +13,8 @@ config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),'cumulus.c
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__),os.path.pardir,os.path.pardir))
 src_dir = os.path.join(root_dir,'src')
 readme_file = os.path.join(root_dir,'README.md')
-build_xml_file = os.path.join(root_dir,'build.xml')
+#build_xml_file = os.path.join(root_dir,'build.xml')
+version_properties_file = os.path.join(root_dir,'version.properties')
 
 def get_meta_files():
     matches = []
@@ -110,18 +111,31 @@ def update_readme_links():
         print 'Updated install urls in README.md'
         open(readme_file, 'w').write(readme)    
 
-def update_build_xml_versions():
-    print 'Checking installPackage versions in build.xml'
-    build_xml = open(build_xml_file, 'r').read()
-    orig_build_xml = build_xml
+#def update_build_xml_versions():
+#    print 'Checking installPackage versions in build.xml'
+#    build_xml = open(build_xml_file, 'r').read()
+#    orig_build_xml = build_xml
+#    for section in config.sections():
+#        search = r'(<property.*name="version.%s".*value=)"(\d+\.\d+)"' % section
+#        full_version = '%s.%s' % (config.get(section, 'major'), config.get(section, 'minor')) 
+#        replace = r'\1"%s"' % full_version
+#        build_xml = re.sub(search, replace, build_xml)
+#    if orig_build_xml != build_xml:
+#        print 'Updated installPackage versions in build.xml'
+#        open(build_xml_file, 'w').write(build_xml)
+
+def update_version_properties():
+    print "Checking version.properties file"
+    props = open(version_properties_file, 'r').read()
+    orig_props = props
     for section in config.sections():
-        search = r'(<property.*name="version.%s".*value=)"(\d+\.\d+)"' % section
+        search = r'version\.%s=(.*)' % section
         full_version = '%s.%s' % (config.get(section, 'major'), config.get(section, 'minor')) 
-        replace = r'\1"%s"' % full_version
-        build_xml = re.sub(search, replace, build_xml)
-    if orig_build_xml != build_xml:
-        print 'Updated installPackage versions in build.xml'
-        open(build_xml_file, 'w').write(build_xml)
+        replace = r'version.%s=%s' % (section, full_version)
+        props = re.sub(search, replace, props)
+    if orig_props != props:
+        print 'Updated version.properites with new managed package versions'
+        open(version_properties_file, 'w').write(props)
     
 def main():
     # Parse the config file
@@ -132,7 +146,7 @@ def main():
     files = get_meta_files()
     update_meta_files(files)
     update_readme_links()
-    update_build_xml_versions()
+    update_version_properties()
 
 if __name__ == '__main__':
   main()

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,6 @@
+version.npe01=2.95
+version.npo02=2.96
+version.npe03=2.92
+version.npe4=2.91
+version.npe5=1.92
+version.npsp=Not Installed


### PR DESCRIPTION
- Moved build.xml managed package version properties into external version.properties file
- Updated scripts/set_dependent_versions.py to update version.properties instead of build.xml
- Changed deployManagedUAT to fetch version.properties from GitHub for the tag and use the tag's version.properties instead of local repo's version.properties
