### PR TITLE
Update links to mrbelvedere for deployManagedUAT target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -134,7 +134,7 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <antcall target="uninstallCumulus" />
       
       <!-- Get the latest beta release tag name -->
-      <get src="http://guarded-hamlet-8069.herokuapp.com/mrbelvedere/repo/Cumulus/version/beta/tag" dest="${basedir}/managed_uat_tag" />
+      <get src="http://mrbelvedere.salesforcefoundation.org/mrbelvedere/repo/SalesforceFoundation/Cumulus/version/beta/tag" dest="${basedir}/managed_uat_tag" />
       <loadfile property="managed_uat_tag" srcfile="${basedir}/managed_uat_tag" />
       <delete file="${basedir}/managed_uat_tag" />
 
@@ -151,7 +151,7 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <delete file="${basedir}/version.properties.uat" />
 
       <!-- Get the latest beta release version number -->
-      <get src="http://guarded-hamlet-8069.herokuapp.com/mrbelvedere/repo/Cumulus/version/beta" dest="${basedir}/version_uat" />
+      <get src="http://mrbelvedere.salesforcefoundation.org/mrbelvedere/repo/SalesforceFoundation/Cumulus/version/beta" dest="${basedir}/version_uat" />
       <loadfile property="version.npsp.uat" srcfile="${basedir}/version_uat" />
       <var name="version.npsp" value="${version.npsp.uat}" />
       <delete file="${basedir}/version_uat" />


### PR DESCRIPTION
As part of implementing #218, some changes were required in the mrbelvedere app.  To maintain consistency, some of the old urls were changes to a new structure.  This change adjusts the links to use the new structure and to point to the site via it's new domain name, mrbelvedere.salesforcefoundation.org

Fixes #218
