### PR TITLE
Require npe01 2.96 and npo02 2.98

### DIFF
--- a/scripts/cumulus.cfg
+++ b/scripts/cumulus.cfg
@@ -1,14 +1,14 @@
 [npe01]
 name: Contacts_and_Organizations
 major: 2
-minor: 95
+minor: 96
 api_version: 28.0
 install_url: https://login.salesforce.com/packaging/installPackage.apexp?p0=04t80000000cdEe
 
 [npo02]
 name: Households
 major: 2
-minor: 96
+minor: 98
 api_version: 28.0
 install_url: https://login.salesforce.com/packaging/installPackage.apexp?p0=04t80000000lNu5
 

--- a/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <packageVersions>
+        <namespace>npe5</namespace>
         <majorNumber>1</majorNumber>
         <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <packageVersions>
+        <namespace>npe5</namespace>
         <majorNumber>1</majorNumber>
         <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/AFFL_BulkTests_TEST.cls-meta.xml
+++ b/src/classes/AFFL_BulkTests_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <packageVersions>
+        <namespace>npe5</namespace>
         <majorNumber>1</majorNumber>
         <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CAO_Constants.cls-meta.xml
+++ b/src/classes/CAO_Constants.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_ContactMerge.cls-meta.xml
+++ b/src/classes/CON_ContactMerge.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_ContactMerge_TEST.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_CampaignDedupeBTN_CTRL.cls-meta.xml
+++ b/src/classes/HH_CampaignDedupeBTN_CTRL.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_CampaignDedupeBTN_TEST.cls-meta.xml
+++ b/src/classes/HH_CampaignDedupeBTN_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_HHObject_TDTM.cls-meta.xml
+++ b/src/classes/HH_HHObject_TDTM.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_HouseholdNaming.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_HouseholdNaming_BATCH.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming_BATCH.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_Households.cls-meta.xml
+++ b/src/classes/HH_Households.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_Households_TDTM.cls-meta.xml
+++ b/src/classes/HH_Households_TDTM.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_Households_TEST.cls-meta.xml
+++ b/src/classes/HH_Households_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_ManageHHAccount_TEST.cls-meta.xml
+++ b/src/classes/HH_ManageHHAccount_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_ManageHousehold_EXT.cls-meta.xml
+++ b/src/classes/HH_ManageHousehold_EXT.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_ManageHousehold_TEST.cls-meta.xml
+++ b/src/classes/HH_ManageHousehold_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
+++ b/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PMT_PaymentCreator.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppRollup.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppRollup_BATCH.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_BATCH.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_Panel.cls-meta.xml
+++ b/src/classes/STG_Panel.cls-meta.xml
@@ -2,14 +2,14 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <packageVersions>
+        <namespace>npe4</namespace>
         <majorNumber>2</majorNumber>
         <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelUserRollup_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelUserRollup_CTRL.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_SettingsManager_TEST.cls-meta.xml
+++ b/src/classes/STG_SettingsManager_TEST.cls-meta.xml
@@ -2,29 +2,29 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_SettingsService.cls-meta.xml
+++ b/src/classes/STG_SettingsService.cls-meta.xml
@@ -2,29 +2,29 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STTG_InstallScript.cls-meta.xml
+++ b/src/classes/STTG_InstallScript.cls-meta.xml
@@ -2,29 +2,29 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STTG_InstallScript_TEST.cls-meta.xml
+++ b/src/classes/STTG_InstallScript_TEST.cls-meta.xml
@@ -2,24 +2,24 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
+++ b/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
@@ -2,9 +2,9 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>96</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/components/STG_DataBoundMultiSelect.component-meta.xml
+++ b/src/components/STG_DataBoundMultiSelect.component-meta.xml
@@ -4,28 +4,28 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>STG_DataBoundMultiSelect</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_JobProgress.component-meta.xml
+++ b/src/components/UTIL_JobProgress.component-meta.xml
@@ -4,28 +4,28 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_JobProgress</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_SoqlListView.component-meta.xml
+++ b/src/components/UTIL_SoqlListView.component-meta.xml
@@ -4,28 +4,28 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_SoqlListView</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_Typeahead.component-meta.xml
+++ b/src/components/UTIL_Typeahead.component-meta.xml
@@ -4,28 +4,28 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_Typeahead</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexComponent>

--- a/src/pages/ACCT_ViewOverride.page-meta.xml
+++ b/src/pages/ACCT_ViewOverride.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>ACCT_ViewOverride</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/BDE_BatchEntry.page-meta.xml
+++ b/src/pages/BDE_BatchEntry.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>BDE_BatchEntry</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/CON_ContactMerge.page-meta.xml
+++ b/src/pages/CON_ContactMerge.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>CON_ContactMerge</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/HH_CampaignDedupeBTN.page-meta.xml
+++ b/src/pages/HH_CampaignDedupeBTN.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>HH_CampaignDedupeBTN</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/HH_ManageHHAccount.page-meta.xml
+++ b/src/pages/HH_ManageHHAccount.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>HH_ManageHHAccount</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/HH_ManageHousehold.page-meta.xml
+++ b/src/pages/HH_ManageHousehold.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>HH_ManageHousehold</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/LD_LeadConvertOverride.page-meta.xml
+++ b/src/pages/LD_LeadConvertOverride.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>LD_LeadConvertOverride</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
+++ b/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>OPP_MatchingDonationsBTN</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/PMT_PaymentWizard.page-meta.xml
+++ b/src/pages/PMT_PaymentWizard.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>PMT_PaymentWizard</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/RD_AddDonationsBTN.page-meta.xml
+++ b/src/pages/RD_AddDonationsBTN.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>RD_AddDonationsBTN</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/REL_RelationshipsViewer.page-meta.xml
+++ b/src/pages/REL_RelationshipsViewer.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>REL_RelationshipsViewer</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/RLLP_OppRollup.page-meta.xml
+++ b/src/pages/RLLP_OppRollup.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>RLLP_OppRollup</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelAffiliations.page-meta.xml
+++ b/src/pages/STG_PanelAffiliations.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelAffiliations</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelBDE.page-meta.xml
+++ b/src/pages/STG_PanelBDE.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelBDE</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelContactRoles.page-meta.xml
+++ b/src/pages/STG_PanelContactRoles.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelContactRoles</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelContacts.page-meta.xml
+++ b/src/pages/STG_PanelContacts.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelContacts</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelERR.page-meta.xml
+++ b/src/pages/STG_PanelERR.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_PanelERR</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelErrorLog.page-meta.xml
+++ b/src/pages/STG_PanelErrorLog.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelErrorLog</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelHome.page-meta.xml
+++ b/src/pages/STG_PanelHome.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelHome</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelHouseholds.page-meta.xml
+++ b/src/pages/STG_PanelHouseholds.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelHouseholds</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelLeads.page-meta.xml
+++ b/src/pages/STG_PanelLeads.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelLeads</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelMembership.page-meta.xml
+++ b/src/pages/STG_PanelMembership.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelMembership</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOppBatch.page-meta.xml
+++ b/src/pages/STG_PanelOppBatch.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelOppBatch</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOppRollups.page-meta.xml
+++ b/src/pages/STG_PanelOppRollups.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelOppRollups</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOpps.page-meta.xml
+++ b/src/pages/STG_PanelOpps.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_PanelOpps</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelPaymentMapping.page-meta.xml
+++ b/src/pages/STG_PanelPaymentMapping.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelPaymentMapping</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRD.page-meta.xml
+++ b/src/pages/STG_PanelRD.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_PanelRD</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRDBatch.page-meta.xml
+++ b/src/pages/STG_PanelRDBatch.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRDBatch</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRDCustomFieldMapping</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRDCustomInstallment</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRel.page-meta.xml
+++ b/src/pages/STG_PanelRel.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRel</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRelAuto.page-meta.xml
+++ b/src/pages/STG_PanelRelAuto.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRelAuto</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRelReciprocal.page-meta.xml
+++ b/src/pages/STG_PanelRelReciprocal.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRelReciprocal</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelTDTM.page-meta.xml
+++ b/src/pages/STG_PanelTDTM.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelTDTM</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelUserRollup.page-meta.xml
+++ b/src/pages/STG_PanelUserRollup.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelUserRollup</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_SettingsManager.page-meta.xml
+++ b/src/pages/STG_SettingsManager.page-meta.xml
@@ -3,28 +3,28 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_SettingsManager</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>95</minorNumber>
         <namespace>npe01</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe03</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>91</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>92</minorNumber>
-        <namespace>npe5</namespace>
-    </packageVersions>
-    <packageVersions>
         <majorNumber>2</majorNumber>
         <minorNumber>96</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe03</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe4</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>91</minorNumber>
+    </packageVersions>
+    <packageVersions>
+        <namespace>npe5</namespace>
+        <majorNumber>1</majorNumber>
+        <minorNumber>92</minorNumber>
+    </packageVersions>
+    <packageVersions>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
 </ApexPage>

--- a/src/triggers/TDTM_HouseholdObject.trigger-meta.xml
+++ b/src/triggers/TDTM_HouseholdObject.trigger-meta.xml
@@ -2,9 +2,9 @@
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>96</minorNumber>
         <namespace>npo02</namespace>
+        <majorNumber>2</majorNumber>
+        <minorNumber>98</minorNumber>
     </packageVersions>
     <status>Active</status>
 </ApexTrigger>

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-version.npe01=2.95
-version.npo02=2.96
+version.npe01=2.96
+version.npo02=2.98
 version.npe03=2.92
 version.npe4=2.91
 version.npe5=1.92


### PR DESCRIPTION
Fixes #399 

The main purpose of this pull request is to get all feature branches requiring the same version so we can temporarily work around the apparent platform bug with installing npo02 via the InstalledPackage metadata type.
