### PR TITLE
Using a reentrant flag for contacts in AFFL_Affiliations_TDTM.

### DIFF
--- a/src/classes/AFFL_Affiliations_TDTM.cls
+++ b/src/classes/AFFL_Affiliations_TDTM.cls
@@ -29,17 +29,26 @@
 */
 public class AFFL_Affiliations_TDTM extends TDTM_Runnable {
 
+    // static flags to prevent recursive call 
+    public static boolean hasRunForContacts = false;
+    public static boolean hasRunForAffiliations = false;
+    
     // the main entry point for TDTM to invoke our trigger handlers.
     public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_TriggerActionHelper.Action triggerAction, Schema.DescribeSObjectResult objResult) {
-    
+            
         // dispatch to the correct handler
-    	if (objResult == Schema.Sobjecttype.Contact)
-            return runContactTriggerHandler(newlist, oldlist, triggerAction, objResult);
-    	else if (objResult == Schema.Sobjecttype.npe5__Affiliation__c)
-            return runAfflTriggerHandler(newlist, oldlist, triggerAction, objResult);
-        else
+    	if (objResult == Schema.Sobjecttype.Contact && !hasRunForContacts) {
+            DmlWrapper wrapper = runContactTriggerHandler(newlist, oldlist, triggerAction, objResult);
+            hasRunForContacts = true;
+            return wrapper;
+    	} else if (objResult == Schema.Sobjecttype.npe5__Affiliation__c && !hasRunForAffiliations) {
+            DmlWrapper wrapper = runAfflTriggerHandler(newlist, oldlist, triggerAction, objResult);
+            hasRunForAffiliations = true;
+            return wrapper;
+    	} else {
             return null;
+    	}
     }
         		
     // the trigger handler on Contact for managing Affiliations        
@@ -269,21 +278,10 @@ public class AFFL_Affiliations_TDTM extends TDTM_Runnable {
        }
     }
     
-    // static to prevent recursive call to runAfflTriggerHandler
-    public static boolean hasRanAfflTriggerHandler = false;
-    
     // the trigger handler on Affiliation for managing Affiliations        
     private DmlWrapper runAfflTriggerHandler(List<SObject> newlist, List<SObject> oldlist, 
         TDTM_TriggerActionHelper.Action triggerAction, Schema.DescribeSObjectResult objResult) {
-        	
-        // prevent a recursive call into this trigger handler.
-        // scenario is user changes fPrimary on the Affiliations object.
-        // this handler will update the contact.
-        // the Contact Affiliations trigger will then update the Affiliations.
-        // we need to prevent that update from causing us to update the contacts again!!
-        if (hasRanAfflTriggerHandler)
-            return null;
-        
+
         DmlWrapper dmlWrapper = new DmlWrapper();
         
         map<Id, Id> mapConIdAccIdPrimary = new map<Id, Id>();
@@ -327,8 +325,7 @@ public class AFFL_Affiliations_TDTM extends TDTM_Runnable {
             listCon.add(con);
         }
     
-        if (listCon.size() > 0) {        
-	        hasRanAfflTriggerHandler = true;
+        if (listCon.size() > 0) {
 	        dmlWrapper.objectsToUpdate.putAll(listCon);
         }
         return dmlWrapper;

--- a/src/classes/AFFL_Affiliations_TEST.cls
+++ b/src/classes/AFFL_Affiliations_TEST.cls
@@ -53,8 +53,12 @@ public class AFFL_Affiliations_TEST {
         
         Account acc2 = new Account(Name='test88');
         insert acc2;
+        
+        Test.startTest();
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         contact.AccountId = acc2.id;
         update contact;
+        Test.stopTest();
             
         npe5__Affiliation__c[] createdAffiliations2 = [select id, npe5__Status__c, npe5__StartDate__c, npe5__Role__c, 
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c from npe5__Affiliation__c 
@@ -185,6 +189,7 @@ public class AFFL_Affiliations_TEST {
         
         con.AccountId = acc2.id;
         Test.startTest();      
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         update con;
         Test.stopTest();
           
@@ -312,10 +317,13 @@ public class AFFL_Affiliations_TEST {
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];       
         System.assertEquals(2, listAffl.size());
 
+        Test.startTest();
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         // now update our contacts with a Primary Affiliation
         for (Contact con : listCon) 
             con.Primary_Affiliation__c = listAcc[4].Id; // Org1  
         update listCon;            
+        Test.stopTest();
         
         listAffl = [select id, npe5__Status__c, npe5__StartDate__c, npe5__Role__c, 
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];
@@ -372,12 +380,15 @@ public class AFFL_Affiliations_TEST {
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];       
         System.assertEquals(2, listAffl.size());
 
+        Test.startTest();
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         // now update our contacts with a Primary Affiliation and a different account
         for (Contact con : listCon) {
             con.AccountId = listAcc[4].Id; // Org1  
             con.Primary_Affiliation__c = listAcc[4].Id; // Org1
         }  
         update listCon;            
+        Test.stopTest();
         
         listAffl = [select id, npe5__Status__c, npe5__StartDate__c, npe5__Role__c, 
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];
@@ -440,11 +451,14 @@ public class AFFL_Affiliations_TEST {
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];       
         System.assertEquals(9, listAffl.size());
 
+        Test.startTest();
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         // now update our contacts to a different account
         for (Contact con : listCon) {
             con.AccountId = listAcc[5].Id; // Org2  
         }  
         update listCon;            
+        Test.stopTest();
         
         listAffl = [select id, npe5__Status__c, npe5__StartDate__c, npe5__Role__c, 
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];
@@ -514,11 +528,14 @@ public class AFFL_Affiliations_TEST {
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];       
         System.assertEquals(9, listAffl.size());
 
+        Test.startTest();
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         // now clear our primary affilation
         for (Contact con : listCon) {
             con.Primary_Affiliation__c = null; 
         }  
-        update listCon;            
+        update listCon;
+        Test.stopTest();
         
         listAffl = [select id, npe5__Status__c, npe5__StartDate__c, npe5__Role__c, 
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];
@@ -582,7 +599,7 @@ public class AFFL_Affiliations_TEST {
         	listAffl.add(affl);
         }
         // must manually clear this, since our context is still active
-        AFFL_Affiliations_TDTM.hasRanAfflTriggerHandler = false;
+        AFFL_Affiliations_TDTM.hasRunForAffiliations = false;
         insert listAffl;
         
         // make sure primary affiliation set on Contacts
@@ -597,7 +614,7 @@ public class AFFL_Affiliations_TEST {
         	affl.npe5__Primary__c = false;
         }
         // must manually clear this, since our context is still active
-        AFFL_Affiliations_TDTM.hasRanAfflTriggerHandler = false;
+        AFFL_Affiliations_TDTM.hasRunForAffiliations = false;
         update listAffl;
         
         // make sure cleared on the contacts
@@ -644,6 +661,7 @@ public class AFFL_Affiliations_TEST {
         listCon[7].AccountId = listAcc[6].Id;   // Bucket account        
         insert listCon;
         
+        //Which ones cause an affiliation to be created? Is it listAcc[4] and listAcc[5]? 
         npe5__Affiliation__c[] listAffl = [select id, npe5__Status__c, npe5__StartDate__c, npe5__Role__c, 
             npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c, npe5__Primary__c from npe5__Affiliation__c];
         System.assertEquals(2, listAffl.size());
@@ -660,7 +678,7 @@ public class AFFL_Affiliations_TEST {
             listAffl.add(affl);
         }
         // must manually clear this, since our context is still active
-        AFFL_Affiliations_TDTM.hasRanAfflTriggerHandler = false;
+        AFFL_Affiliations_TDTM.hasRunForAffiliations = false;
         insert listAffl;
         
         // make sure primary affiliation set on Contacts
@@ -682,7 +700,8 @@ public class AFFL_Affiliations_TEST {
             listAffl.add(affl);
         }
         // must manually clear this, since our context is still active
-        AFFL_Affiliations_TDTM.hasRanAfflTriggerHandler = false;
+        AFFL_Affiliations_TDTM.hasRunForAffiliations = false;
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         insert listAffl;
                 
         // make sure primary affiliation set on Contacts

--- a/src/classes/AFFL_BulkTests_TEST.cls
+++ b/src/classes/AFFL_BulkTests_TEST.cls
@@ -24,8 +24,7 @@
 public with sharing class AFFL_BulkTests_TEST {
 
     static testMethod void newContactOnOrgAccount() {
-    	//AFFL_Affiliations_TEST.setupTDTM();
-    	
+    	    	
         Account acc = new Account(Name='test77');
         insert acc;
         
@@ -43,7 +42,7 @@ public with sharing class AFFL_BulkTests_TEST {
             );
             cons.add(con);
         }
-        Test.startTest();
+        
         insert cons;
         
         Id firstAffiliationId;
@@ -61,11 +60,14 @@ public with sharing class AFFL_BulkTests_TEST {
         Account acc2 = new Account(Name='test88');
         insert acc2;
         
+        Test.startTest();
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         for(Contact thisContact : cons){    
             thisContact.AccountId = acc2.id;
         }
         update cons;
         Test.stopTest();
+        
         npe5__Affiliation__c[] createdAffiliations2 = [select id, npe5__Status__c, npe5__StartDate__c, npe5__Role__c, npe5__Organization__c, npe5__EndDate__c, npe5__Contact__c from npe5__Affiliation__c where npe5__Contact__c IN :cons AND npe5__Organization__c = :acc2.id];
         
         system.assertEquals(conCount,createdAffiliations2.size());
@@ -174,7 +176,6 @@ public with sharing class AFFL_BulkTests_TEST {
     
     //Modifying the test above to have only two DMLs, one before StartTest and one after
     static testMethod void contactWithMultipleAffiliations_v2() {
-        //AFFL_Affiliations_TEST.setupTDTM();
         
         Account acc = new Account(Name='test77');
         insert acc;
@@ -206,6 +207,7 @@ public with sharing class AFFL_BulkTests_TEST {
         }
         
         Test.startTest();
+        AFFL_Affiliations_TDTM.hasRunForContacts = false;
         update cons;
         Test.stopTest();
                 


### PR DESCRIPTION
Fixes #282. I have tried to be very careful and make sure no functionality was affected with this bugfix. As far as I can tell the different sections in the AFFL tests should be different contexts, and thus manually resetting the reentrant flag is ok.
