### PR TITLE
Remove compactLayoutAssignment to allow deployUnpackaged before Cumulus

### DIFF
--- a/unpackaged/objects/Opportunity.object
+++ b/unpackaged/objects/Opportunity.object
@@ -49,7 +49,6 @@
         <fullName>NPSP_Default</fullName>
         <active>true</active>
         <businessProcess>NPSP_Default</businessProcess>
-        <compactLayoutAssignment>Donation_Compact_Layout</compactLayoutAssignment>
         <label>NPSP Default</label>
     </recordTypes>
 </CustomObject>


### PR DESCRIPTION
Cumulus_uat_managed failed because the org does not yet have the compact layouts created when deployUnpackaged is installed.  However, we need deployUnpackaged to run before Cumulus ever installs so we can ensure the target org has Opportunity record types to pass the Cumulus deployment tests.  The easiest solution is to remove the compactLayoutAssignment from the Opportunity.object file.
