### PR TITLE
Feature/487 managed beta package per commit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -256,10 +256,8 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <retrievePackaged dir="uninstallsrc" package="Cumulus" />
       <buildPackagedDestructiveChanges srcdir="uninstallsrc" dir="uninstall" package="Cumulus" />
       <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" deployRoot="uninstall" runAllTests="false" purgeOnDelete="true" maxPoll="200" />
-<!--
       <delete dir="uninstallsrc" />
       <delete dir="uninstall" />
--->
     </target>
 
     <!-- uninstallCumulus: Removes all non-standard unpackaged metadata from the org for the metadata types used in Cumulus -->


### PR DESCRIPTION
This branch modifies the deployManagedUAT target per #487 to allow for the package version and revision to be passed in via environment variables.  This removes the need to create a Github release for code which has not yet passed a test when bundled as a managed beta release.
