### PR TITLE
Move destroyStaleMetadata after deploy in deployCIPackageOrg

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -149,9 +149,6 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
          There are a few assumptions.  We never downgrade a dependent managed package in the packaging org.  This removes the need to completely remove
          all metadata to allow a package downgrade.  In the package org, we can't delete all metadata once a production managed release is cut so this approach is required -->
     <target name="deployCIPackageOrg">
-      <!-- First, delete any metadata from the org which is not in the repo -->
-      <antcall target="destroyStaleMetadata" />
-
       <!-- Deploy any unpackaged metadata needed for builds -->
       <antcall target="deployUnpackaged" />
 
@@ -161,8 +158,12 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <!-- Update the package.xml to managed package mode, adding install and uninstall script classes -->
       <antcall target="updatePackageXmlManaged" />
 
-      <!-- Finally, do a deploy with all tests -->
+      <!-- Do a deploy with all tests -->
       <antcall target="deploy" />
+
+      <!-- Finally, delete any metadata from the org which is not in the repo -->
+      <antcall target="destroyStaleMetadata" />
+
     </target>
 
     <!-- Deploys the latest managed beta (UAT) release to an org -->


### PR DESCRIPTION
We have hit an issue a few times where destroyStaleMetadata fails to run before the deployment to the packaging org.  Most of the time, this is caused by one of two things:
1. Metadata in the package which was deleted but can't be deleted from the Metadata API such as RecordTypes.  In this case, the solution is to manually delete the offending metadata from the packaging org and re-run the build.
2. A class from the previous deployment references metadata which doesn't exist in the repository of the current deployment.  A good example is CustomLabels which have been removed.  In this instance, the destroyStaleMetadata target tried to delete the unused CustomLabel before deploying the code but failed because the old classes which referenced the CustomLabel were still in the org.  This branch aims to solve this scenario by moving the destroyStaleMetadata target to after the deployment to the packaging org.  This way, the new classes without reference to the delete metadata are deployed first allowing the destroy to run since all references to the metadata to be deleted should be gone.
