### PR TITLE
Allow extending CustomObject from another package

### DIFF
--- a/lib/ant-salesforce.xml
+++ b/lib/ant-salesforce.xml
@@ -272,7 +272,8 @@
               <!-- Loop through files in the type's dir and add <members /> element for each file -->
               <for param="file">
                 <path>
-                  <fileset dir="@{typedir}" includes="**/*" excludes="*.xml @{exclude}" />
+                  <!-- exclude xml files and namespaced metadata files as well as any manual excludes -->
+                  <fileset dir="@{typedir}" includes="**/*" excludes="*.xml *__*__c.* @{exclude}" />
                 </path>
                 <sequential>
                   <!-- get basename and basename without suffix for file. propertyregex is used since we don't know the file suffix from only the dir name (i.e. classes vs .class) -->


### PR DESCRIPTION
Skip metadata files which start with a namespace and end in __c.  This specifically applies to extending a custom object from another namespace to add subtypes to it.  In that case, we don't want the CustomObject
included in package.xml as it will cause a deployment failure
