### PR TITLE
Require 3.0 of all packages except npo02

### DIFF
--- a/src/classes/ACCT_Accounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_Accounts_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Account_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Account_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Addresses_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Contact_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Contact_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Validation_Gateway_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Validation_Gateway_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Validator_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Validator_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
@@ -2,13 +2,13 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
@@ -2,13 +2,13 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/AFFL_Affiliations_UTIL.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_UTIL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/AFFL_BulkTests_TEST.cls-meta.xml
+++ b/src/classes/AFFL_BulkTests_TEST.cls-meta.xml
@@ -2,13 +2,13 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CAO_Constants.cls-meta.xml
+++ b/src/classes/CAO_Constants.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge.cls-meta.xml
+++ b/src/classes/CON_ContactMerge.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge_TEST.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/ERR_Handler_CTRL_TEST.cls-meta.xml
+++ b/src/classes/ERR_Handler_CTRL_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ERR_Handler_TEST.cls-meta.xml
+++ b/src/classes/ERR_Handler_TEST.cls-meta.xml
@@ -2,13 +2,13 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ERR_Notifier.cls-meta.xml
+++ b/src/classes/ERR_Notifier.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/HH_Households.cls-meta.xml
+++ b/src/classes/HH_Households.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/HH_Households_TDTM.cls-meta.xml
+++ b/src/classes/HH_Households_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/HH_Households_TEST.cls-meta.xml
+++ b/src/classes/HH_Households_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/HH_ManageHHAccount_TEST.cls-meta.xml
+++ b/src/classes/HH_ManageHHAccount_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/HH_ManageHousehold_TEST.cls-meta.xml
+++ b/src/classes/HH_ManageHousehold_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
+++ b/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentCreator.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentCreator_TEST.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_AddDonationsBTN_CTRL.cls-meta.xml
+++ b/src/classes/RD_AddDonationsBTN_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_BulkTests_TEST.cls-meta.xml
+++ b/src/classes/RD_BulkTests_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_RecurringDonations.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_RecurringDonations_BATCH.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_BATCH.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_RecurringDonations_Opp_TDTM.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_Opp_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_RecurringDonations_SCHED.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_SCHED.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_RecurringDonations_TDTM.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_RecurringDonations_TEST.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_TEST.cls-meta.xml
@@ -2,13 +2,13 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/REL_RelationshipsViewer_CTRL.cls-meta.xml
+++ b/src/classes/REL_RelationshipsViewer_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/REL_Relationships_Con_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_Con_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/REL_Relationships_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_TDTM.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/REL_Relationships_TEST.cls-meta.xml
+++ b/src/classes/REL_Relationships_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/REL_Utils.cls-meta.xml
+++ b/src/classes/REL_Utils.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/STG_InstallScript.cls-meta.xml
+++ b/src/classes/STG_InstallScript.cls-meta.xml
@@ -2,23 +2,23 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/STG_InstallScript_TEST.cls-meta.xml
+++ b/src/classes/STG_InstallScript_TEST.cls-meta.xml
@@ -2,23 +2,23 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/STG_Panel.cls-meta.xml
+++ b/src/classes/STG_Panel.cls-meta.xml
@@ -2,13 +2,13 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRDBatch_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRDBatch_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRDCustomFieldMapping_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRDCustomFieldMapping_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRDCustomInstallment_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRDCustomInstallment_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRD_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRD_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRelAuto_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRelAuto_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRelReciprocal_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRelReciprocal_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRel_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRel_CTRL.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_SettingsManager_TEST.cls-meta.xml
+++ b/src/classes/STG_SettingsManager_TEST.cls-meta.xml
@@ -2,23 +2,23 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/STG_SettingsService.cls-meta.xml
+++ b/src/classes/STG_SettingsService.cls-meta.xml
@@ -2,23 +2,23 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
@@ -2,23 +2,23 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
+++ b/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
@@ -2,8 +2,8 @@
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/components/STG_DataBoundMultiSelect.component-meta.xml
+++ b/src/components/STG_DataBoundMultiSelect.component-meta.xml
@@ -4,23 +4,23 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>STG_DataBoundMultiSelect</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/components/UTIL_JobProgress.component-meta.xml
+++ b/src/components/UTIL_JobProgress.component-meta.xml
@@ -4,23 +4,23 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_JobProgress</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/components/UTIL_SoqlListView.component-meta.xml
+++ b/src/components/UTIL_SoqlListView.component-meta.xml
@@ -4,23 +4,23 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_SoqlListView</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/components/UTIL_Typeahead.component-meta.xml
+++ b/src/components/UTIL_Typeahead.component-meta.xml
@@ -4,23 +4,23 @@
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_Typeahead</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/ACCT_ViewOverride.page-meta.xml
+++ b/src/pages/ACCT_ViewOverride.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>ACCT_ViewOverride</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/ADDR_CopyAddrHHObjBTN.page-meta.xml
+++ b/src/pages/ADDR_CopyAddrHHObjBTN.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>29.0</apiVersion>
     <label>ADDR_CopyAddrHHObjBTN</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/BDE_BatchEntry.page-meta.xml
+++ b/src/pages/BDE_BatchEntry.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>BDE_BatchEntry</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/CON_ContactMerge.page-meta.xml
+++ b/src/pages/CON_ContactMerge.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>CON_ContactMerge</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/HH_CampaignDedupeBTN.page-meta.xml
+++ b/src/pages/HH_CampaignDedupeBTN.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>HH_CampaignDedupeBTN</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/HH_ManageHHAccount.page-meta.xml
+++ b/src/pages/HH_ManageHHAccount.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>HH_ManageHHAccount</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/HH_ManageHousehold.page-meta.xml
+++ b/src/pages/HH_ManageHousehold.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>HH_ManageHousehold</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/LD_LeadConvertOverride.page-meta.xml
+++ b/src/pages/LD_LeadConvertOverride.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>LD_LeadConvertOverride</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
+++ b/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>OPP_MatchingDonationsBTN</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/PMT_PaymentWizard.page-meta.xml
+++ b/src/pages/PMT_PaymentWizard.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>PMT_PaymentWizard</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/RD_AddDonationsBTN.page-meta.xml
+++ b/src/pages/RD_AddDonationsBTN.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>RD_AddDonationsBTN</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/REL_RelationshipsViewer.page-meta.xml
+++ b/src/pages/REL_RelationshipsViewer.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>REL_RelationshipsViewer</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelAddrVerification.page-meta.xml
+++ b/src/pages/STG_PanelAddrVerification.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_PanelAddrVerification</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelAffiliations.page-meta.xml
+++ b/src/pages/STG_PanelAffiliations.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelAffiliations</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelBDE.page-meta.xml
+++ b/src/pages/STG_PanelBDE.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelBDE</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelContactRoles.page-meta.xml
+++ b/src/pages/STG_PanelContactRoles.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelContactRoles</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelContacts.page-meta.xml
+++ b/src/pages/STG_PanelContacts.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelContacts</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelERR.page-meta.xml
+++ b/src/pages/STG_PanelERR.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_PanelERR</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelErrorLog.page-meta.xml
+++ b/src/pages/STG_PanelErrorLog.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelErrorLog</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelHome.page-meta.xml
+++ b/src/pages/STG_PanelHome.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelHome</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelHouseholds.page-meta.xml
+++ b/src/pages/STG_PanelHouseholds.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelHouseholds</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelLeads.page-meta.xml
+++ b/src/pages/STG_PanelLeads.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelLeads</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelMembership.page-meta.xml
+++ b/src/pages/STG_PanelMembership.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelMembership</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelOppBatch.page-meta.xml
+++ b/src/pages/STG_PanelOppBatch.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelOppBatch</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelOppRollups.page-meta.xml
+++ b/src/pages/STG_PanelOppRollups.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelOppRollups</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelOpps.page-meta.xml
+++ b/src/pages/STG_PanelOpps.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_PanelOpps</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelPaymentMapping.page-meta.xml
+++ b/src/pages/STG_PanelPaymentMapping.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelPaymentMapping</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelRD.page-meta.xml
+++ b/src/pages/STG_PanelRD.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_PanelRD</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelRDBatch.page-meta.xml
+++ b/src/pages/STG_PanelRDBatch.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRDBatch</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRDCustomFieldMapping</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRDCustomInstallment</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelRel.page-meta.xml
+++ b/src/pages/STG_PanelRel.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRel</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelRelAuto.page-meta.xml
+++ b/src/pages/STG_PanelRelAuto.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRelAuto</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelRelReciprocal.page-meta.xml
+++ b/src/pages/STG_PanelRelReciprocal.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelRelReciprocal</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelTDTM.page-meta.xml
+++ b/src/pages/STG_PanelTDTM.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelTDTM</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_PanelUserRollup.page-meta.xml
+++ b/src/pages/STG_PanelUserRollup.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>28.0</apiVersion>
     <label>STG_PanelUserRollup</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/pages/STG_SettingsManager.page-meta.xml
+++ b/src/pages/STG_SettingsManager.page-meta.xml
@@ -3,23 +3,23 @@
     <apiVersion>29.0</apiVersion>
     <label>STG_SettingsManager</label>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>97</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/triggers/TDTM_Affiliation.trigger-meta.xml
+++ b/src/triggers/TDTM_Affiliation.trigger-meta.xml
@@ -2,8 +2,8 @@
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/triggers/TDTM_RecurringDonation.trigger-meta.xml
+++ b/src/triggers/TDTM_RecurringDonation.trigger-meta.xml
@@ -2,8 +2,8 @@
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>94</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe03</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/triggers/TDTM_Relationship.trigger-meta.xml
+++ b/src/triggers/TDTM_Relationship.trigger-meta.xml
@@ -2,8 +2,8 @@
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>93</minorNumber>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
         <namespace>npe4</namespace>
     </packageVersions>
     <status>Active</status>

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
-version.npe01=2.97
+version.npe01=3.0
 version.npo02=2.99
-version.npe03=2.94
-version.npe4=2.93
-version.npe5=1.94
+version.npe03=3.0
+version.npe4=3.0
+version.npe5=3.0
 version.npsp=Not Installed


### PR DESCRIPTION
The 3.0 version of all the original NPSP packages are now created.  However, the npo02 package fails due to an issue similar to the issue discussed in the link below:

https://success.salesforce.com/issues_view?id=a1p30000000T1p0AAC

Until this issue is resolved, we need to keep npo02 at version 2.99.  Once the issue is fixed, I will upload 3.1 of npo02 and link to it.
