### PR TITLE
Fix for Cumulus_uat build script

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -190,6 +190,16 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <!-- Deploy any unpackaged metadata bundles needed before the deployment -->
       <antcall target="deployUnpackagedPre" />
 
+      <!-- Attempt to destroy any stale metadata but continue even if this fails -->
+      <trycatch>
+        <try>
+          <antcall target="destroyStaleMetadata" />
+        </try>
+        <catch>
+          <echo>First run of destroyStaleMetadata failed.  Ignoring for now but it may cause build failures in other targets.</echo>
+        </catch>
+      </trycatch>
+
       <!-- Update the package.xml to managed package mode, adding install and uninstall script classes -->
       <antcall target="updatePackageXmlManaged" />
 


### PR DESCRIPTION
The build target used by Cumulus_uat was not running destroyStaleMetadata before the deployment.  This caused issues in some cases where Cumulus_feature_managed_flow was run before Cumulus_uat and left stale metadata in the packaging org causing the Cumulus_uat deploy with test to fail.

The fix is to run destroyStaleMetadata in a try/catch block before the deployment.  If it fails, the deployment will still proceed but the second run of destroyStaleMetadata would also fail causing the build to be marked as failed.
