### PR TITLE
Trying to retrieve the label with prefix, if if failed without it.

### DIFF
--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -156,7 +156,12 @@ public with sharing class ERR_Notifier {
     	
     	Error_Settings__c es = getErrorSettings();
         String errorNotifRecipient = es.Error_Notifications_To__c;
-        string strSetting = UTIL_Describe.getFieldLabel('Error_Settings__c', 'Error_Notifications_To__c');
+        string strSetting;
+        try {
+            strSetting = UTIL_Describe.getFieldLabel('Error_Settings__c', 'Error_Notifications_To__c');
+        } catch(Exception e) {
+        	strSetting = UTIL_Describe.getFieldLabel('npsp_Error_Settings__c', 'npsp_Error_Notifications_To__c');
+        }
             
         if (es.Error_Notifications_On__c && errorNotifRecipient != null) {
         	if (!(errorNotifRecipient instanceof id)) {


### PR DESCRIPTION
Let's give this a try as soon as the feature build job finishes. I'm pretty sure this should fix #678.
