### PR TITLE
We were missing an underscore. Also, we realized better to use the UTIL ...

### DIFF
--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -157,11 +157,7 @@ public with sharing class ERR_Notifier {
     	Error_Settings__c es = getErrorSettings();
         String errorNotifRecipient = es.Error_Notifications_To__c;
         string strSetting;
-        try {
-            strSetting = UTIL_Describe.getFieldLabel('Error_Settings__c', 'Error_Notifications_To__c');
-        } catch(Exception e) {
-        	strSetting = UTIL_Describe.getFieldLabel('npsp_Error_Settings__c', 'npsp_Error_Notifications_To__c');
-        }
+        strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Error_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Error_Notifications_To__c'));
             
         if (es.Error_Notifications_On__c && errorNotifRecipient != null) {
         	if (!(errorNotifRecipient instanceof id)) {


### PR DESCRIPTION
...method to add the prefix. - Fix for #678.

@jlantz, could you confirm that's how you intended the utility method to be used?
