### PR TITLE
Switch back to running tests as part of packaging org deployment

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -208,7 +208,7 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <antcall target="updatePackageXmlManaged" />
 
       <!-- Do a deploy skipping tests for now since the upload will run tests -->
-      <antcall target="deployWithoutTest" />
+      <antcall target="deploy" />
 
       <!-- Finally, delete any metadata from the org which is not in the repo -->
       <antcall target="destroyStaleMetadata" />


### PR DESCRIPTION
We decided to try out skipping the execution of tests as part of the deployment to the packaging org since the upload also runs tests.  However, there are two issues this seems to have introduced:
1. The build passes which means there is no record in Jenkins of which test fails.  The test fails in the Cumulus_uat_package step which doesn't do a very good job of logging which test actually failed.
2. It is possible this is causing issues in Cumulus_uat_package's Selenium call via mrbelvedere.  This pull request may or may not fix that problem.
