### PR TITLE
Don't delete Global-Global Layout.layout in build

### DIFF
--- a/lib/whitelists/metadata.txt
+++ b/lib/whitelists/metadata.txt
@@ -6,6 +6,7 @@ SiteFooter.component
 SitePoweredBy.component
 SiteLogin.component
 SiteHeader.component
+Global-Global Layout.layout
 Account.object
 Contact.object
 Lead.object


### PR DESCRIPTION
The build scripts were trying to delete the newly introduced Global-Global Layout.layout file which generates an error that you can't delete the only layout.  This branch whitelists that layout so the build scripts will not try to delete it.
