### PR TITLE
Feature/660 mobile research

### DIFF
--- a/src/quickActions/New_Campaign.quickAction
+++ b/src/quickActions/New_Campaign.quickAction
@@ -11,6 +11,11 @@
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
+                <field>IsActive</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
                 <field>ParentId</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>


### PR DESCRIPTION
We tried to override the IsActive field to always set it to True.  This was causing build failures in the packaging org:
http://ci.salesforcefoundation.org/view/uat/job/Cumulus_uat/450/console

I tried changing the formula value to TRUE instead of true to match the quickActions documentation but still got the same failure.  It seems this cannot be packaged though we could make the change in the DOT.

@njjc or @davidhabib I remember we decided to have @ceiroa remove the Active field from the quick action's layout since we were defaulting it to True.  I think not having it would mean all campaigns created through the quick action would be inactive to start.  I added it back to show up after the Name field so hopefully it highlights that you should check it.  We can hide that field in the DOT when we default the value.
