### PR TITLE
Added back old compact layouts on Account and Opportunity

### DIFF
--- a/src/objects/Account.object
+++ b/src/objects/Account.object
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <compactLayouts>
+        <fullName>Account_Compact_Layout</fullName>
+        <fields>Name</fields>
+        <label>DEPRICATED: Account Compact Layout</label>
+    </compactLayouts>
     <fieldSets>
         <fullName>BDE_Entry_FS</fullName>
         <description>Batch Data Entry</description>

--- a/src/objects/Opportunity.object
+++ b/src/objects/Opportunity.object
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <compactLayouts>
+        <fullName>Donation_Compact_Layout</fullName>
+        <fields>AccountId</fields>
+        <fields>Amount</fields>
+        <fields>CloseDate</fields>
+        <fields>StageName</fields>
+        <label>DEPRICATED: Donation Compact Layout</label>
+    </compactLayouts>
+    <compactLayouts>
+        <fullName>Membership_Compact_Layout</fullName>
+        <fields>AccountId</fields>
+        <fields>Amount</fields>
+        <fields>StageName</fields>
+        <fields>npe01__Membership_Start_Date__c</fields>
+        <fields>npe01__Membership_End_Date__c</fields>
+        <fields>npe01__Member_Level__c</fields>
+        <label>DEPRICATED: Membership Compact Layout</label>
+    </compactLayouts>
+    <compactLayouts>
         <fullName>NPSP_Donation_Compact_Layout</fullName>
         <fields>Name</fields>
         <fields>Amount</fields>

--- a/src/package.xml
+++ b/src/package.xml
@@ -228,9 +228,12 @@
     <name>ApexTrigger</name>
   </types>
   <types>
+    <members>Account.Account_Compact_Layout</members>
     <members>Address__c.NPSP_Address_Compact_Layout</members>
     <members>Contact.Contact_Compact_Layout</members>
     <members>Contact.NPSP_Contact_Compact_Layout</members>
+    <members>Opportunity.Donation_Compact_Layout</members>
+    <members>Opportunity.Membership_Compact_Layout</members>
     <members>Opportunity.NPSP_Donation_Compact_Layout</members>
     <members>npe01__OppPayment__c.NPSP_Payment_Compact_Layout</members>
     <members>npe03__Recurring_Donation__c.NPSP_Recurring_Donation_Compact_Layout</members>


### PR DESCRIPTION
they be deleted from the packaging org.  Set the labels to start with DEPRICATED: to indicate they are not to be used
