### PR TITLE
Remove Number_of_Household_Members__c reference

### DIFF
--- a/unpackaged/post/first/objects/Account.object
+++ b/unpackaged/post/first/objects/Account.object
@@ -3,7 +3,6 @@
     <compactLayouts>
         <fullName>NPSP_Household_Account</fullName>
         <fields>Name</fields>
-        <fields>Number_of_Household_Members__c</fields>
         <fields>npo02__TotalOppAmount__c</fields>
         <label>NPSP Household Account</label>
     </compactLayouts>


### PR DESCRIPTION
This field being referenced in a post-deployment bundle was causing failures when testing against the beta managed package and thus would have caused issues in the installer.  We will need to address the namespacing issues with post-deployment packages at some point soon but I want to get this build working again.
