### PR TITLE
Change back to purgeOnDelete="true"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -411,7 +411,7 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <delete dir="uninstall" />
       <retrievePackaged dir="uninstallsrc" package="${cumulusci.package.name}" />
       <buildPackagedDestructiveChanges srcdir="uninstallsrc" dir="uninstall" package="${cumulusci.package.name}" />
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" deployRoot="uninstall" runAllTests="false" purgeOnDelete="false" maxPoll="${cumulusci.maxPoll.notest}" />
+      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" deployRoot="uninstall" runAllTests="false" purgeOnDelete="true" maxPoll="${cumulusci.maxPoll.notest}" />
       <delete dir="uninstallsrc" />
       <delete dir="uninstall" />
       <antcall target="uninstallUnpackagedPre" />


### PR DESCRIPTION
We had temporarily changed to purgeOnDelete="true" due to the following platform bug which seems to now be resolved via a patch release:

https://success.salesforce.com/issues_view?id=a1p30000000T4w3AAC

This branch reverts the change so the build scripts use purgeOnDelete="true" again.
# Warning
# Info
# Issues
