### PR TITLE
Remove Account.Active__c from manage household fieldset

### DIFF
--- a/src/objects/Account.object
+++ b/src/objects/Account.object
@@ -688,11 +688,6 @@
             <isRequired>false</isRequired>
         </availableFields>
         <availableFields>
-            <field>Active__c</field>
-            <isFieldManaged>false</isFieldManaged>
-            <isRequired>false</isRequired>
-        </availableFields>
-        <availableFields>
             <field>Description</field>
             <isFieldManaged>false</isFieldManaged>
             <isRequired>false</isRequired>


### PR DESCRIPTION
Account.Active__c was a field which was in the object files of the repository before we switched to deploying into an unmanaged package.

The field was incorrectly included in the available fields on the manage household fieldset and caused build failures.
