### PR TITLE
Adding back line break in meta xml files

### DIFF
--- a/src/classes/ACCT_Accounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_Accounts_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_Account_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Account_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_Addresses_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_Contact_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Contact_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_CopyAddrHHObjBTN_CTRL.cls-meta.xml
+++ b/src/classes/ADDR_CopyAddrHHObjBTN_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls-meta.xml
+++ b/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_IValidator.cls-meta.xml
+++ b/src/classes/ADDR_IValidator.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_MockHttpRespGenerator_TEST.cls-meta.xml
+++ b/src/classes/ADDR_MockHttpRespGenerator_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Seasonal_SCHED.cls-meta.xml
+++ b/src/classes/ADDR_Seasonal_SCHED.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_SmartyStreets_Gateway.cls-meta.xml
+++ b/src/classes/ADDR_SmartyStreets_Gateway.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_SmartyStreets_Validator.cls-meta.xml
+++ b/src/classes/ADDR_SmartyStreets_Validator.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Validation_Gateway_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Validation_Gateway_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_Validator.cls-meta.xml
+++ b/src/classes/ADDR_Validator.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Validator_Batch.cls-meta.xml
+++ b/src/classes/ADDR_Validator_Batch.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Validator_Batch_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Validator_Batch_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ADDR_Validator_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Validator_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ADDR_Validator_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Validator_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/AFFL_Affiliations_UTIL.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_UTIL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/AFFL_BulkTests_TEST.cls-meta.xml
+++ b/src/classes/AFFL_BulkTests_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/BDE_BatchDataEntry.cls-meta.xml
+++ b/src/classes/BDE_BatchDataEntry.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDE_BatchDataEntry_TEST.cls-meta.xml
+++ b/src/classes/BDE_BatchDataEntry_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDE_BatchEntry_CTRL.cls-meta.xml
+++ b/src/classes/BDE_BatchEntry_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDE_BatchEntry_TEST.cls-meta.xml
+++ b/src/classes/BDE_BatchEntry_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDE_DescribeHelper_TEST.cls-meta.xml
+++ b/src/classes/BDE_DescribeHelper_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDE_DescribeHelper_UTIL.cls-meta.xml
+++ b/src/classes/BDE_DescribeHelper_UTIL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CAO_Constants.cls-meta.xml
+++ b/src/classes/CAO_Constants.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/CONV_Account_Conversion_BATCH.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/CONV_Account_Conversion_BATCH_TEST.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_BATCH_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/CONV_Account_Conversion_CTRL.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/CONV_Account_Conversion_CTRL_TEST.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_CTRL_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/CON_ContactMerge.cls-meta.xml
+++ b/src/classes/CON_ContactMerge.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/CON_ContactMerge_TEST.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ERR_AddError_TEST.cls-meta.xml
+++ b/src/classes/ERR_AddError_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_Handler.cls-meta.xml
+++ b/src/classes/ERR_Handler.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_Handler_CTRL_TEST.cls-meta.xml
+++ b/src/classes/ERR_Handler_CTRL_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ERR_Handler_TEST.cls-meta.xml
+++ b/src/classes/ERR_Handler_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ERR_Notifier.cls-meta.xml
+++ b/src/classes/ERR_Notifier.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/ERR_ParentAccountUpdater2_TEST.cls-meta.xml
+++ b/src/classes/ERR_ParentAccountUpdater2_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/ERR_ParentAccountUpdater_TEST.cls-meta.xml
+++ b/src/classes/ERR_ParentAccountUpdater_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_CampaignDedupeBTN_CTRL.cls-meta.xml
+++ b/src/classes/HH_CampaignDedupeBTN_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_CampaignDedupeBTN_TEST.cls-meta.xml
+++ b/src/classes/HH_CampaignDedupeBTN_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_CampaignDedupe_BATCH.cls-meta.xml
+++ b/src/classes/HH_CampaignDedupe_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_HHObject_TDTM.cls-meta.xml
+++ b/src/classes/HH_HHObject_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_HouseholdNaming.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_HouseholdNaming_BATCH.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_Households.cls-meta.xml
+++ b/src/classes/HH_Households.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_Households_TDTM.cls-meta.xml
+++ b/src/classes/HH_Households_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_Households_TEST.cls-meta.xml
+++ b/src/classes/HH_Households_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_INaming.cls-meta.xml
+++ b/src/classes/HH_INaming.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/HH_ManageHHAccount_TEST.cls-meta.xml
+++ b/src/classes/HH_ManageHHAccount_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_ManageHousehold_EXT.cls-meta.xml
+++ b/src/classes/HH_ManageHousehold_EXT.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_ManageHousehold_TEST.cls-meta.xml
+++ b/src/classes/HH_ManageHousehold_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_NameSpec.cls-meta.xml
+++ b/src/classes/HH_NameSpec.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_NameSpec_TEST.cls-meta.xml
+++ b/src/classes/HH_NameSpec_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/HH_ProcessControl.cls-meta.xml
+++ b/src/classes/HH_ProcessControl.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
+++ b/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/OPP_MatchingDonationsBTN_TEST.cls-meta.xml
+++ b/src/classes/OPP_MatchingDonationsBTN_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/PMT_PaymentCreator.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/PMT_PaymentCreator_TEST.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/PMT_Payment_TDTM.cls-meta.xml
+++ b/src/classes/PMT_Payment_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RD_AddDonationsBTN_CTRL.cls-meta.xml
+++ b/src/classes/RD_AddDonationsBTN_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RD_BulkTests_TEST.cls-meta.xml
+++ b/src/classes/RD_BulkTests_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RD_ProcessControl.cls-meta.xml
+++ b/src/classes/RD_ProcessControl.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RD_RecurringDonations.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RD_RecurringDonations_BATCH.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RD_RecurringDonations_Opp_TDTM.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_Opp_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RD_RecurringDonations_TDTM.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RD_RecurringDonations_TEST.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/REL_ProcessControl.cls-meta.xml
+++ b/src/classes/REL_ProcessControl.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/REL_RelationshipsViewer_CTRL.cls-meta.xml
+++ b/src/classes/REL_RelationshipsViewer_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_Cm_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/REL_Relationships_Con_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_Con_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/REL_Relationships_TDTM.cls-meta.xml
+++ b/src/classes/REL_Relationships_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/REL_Relationships_TEST.cls-meta.xml
+++ b/src/classes/REL_Relationships_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/REL_Utils.cls-meta.xml
+++ b/src/classes/REL_Utils.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RLLP_OppAccRollup_BATCH.cls-meta.xml
+++ b/src/classes/RLLP_OppAccRollup_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppContactRollup_BATCH.cls-meta.xml
+++ b/src/classes/RLLP_OppContactRollup_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppHouseholdRollup_BATCH.cls-meta.xml
+++ b/src/classes/RLLP_OppHouseholdRollup_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RLLP_OppRollup.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RLLP_OppRollup_TDTM.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_TDTM.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RLLP_OppRollup_TEST2.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_TEST2.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/RLLP_OppSoftCreditRollup_BATCH.cls-meta.xml
+++ b/src/classes/RLLP_OppSoftCreditRollup_BATCH.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_DataBoundMultiSelect_CTRL.cls-meta.xml
+++ b/src/classes/STG_DataBoundMultiSelect_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_InstallScript.cls-meta.xml
+++ b/src/classes/STG_InstallScript.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_InstallScript_TEST.cls-meta.xml
+++ b/src/classes/STG_InstallScript_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_InstallScript_TEST2.cls-meta.xml
+++ b/src/classes/STG_InstallScript_TEST2.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_Panel.cls-meta.xml
+++ b/src/classes/STG_Panel.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelADDRVerification_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelADDRVerification_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelAffiliations_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelAffiliations_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelBDE_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelBDE_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelContactRoles_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelContactRoles_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelContacts_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelContacts_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelERR_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelERR_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelErrorLog_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelErrorLog_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelLeads_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelLeads_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelMembership_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelMembership_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelOppBatch_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelOppBatch_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelOppRollups_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelOppRollups_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelOpps_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelOpps_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelRDBatch_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRDBatch_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelRDCustomFieldMapping_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRDCustomFieldMapping_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelRDCustomInstallment_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRDCustomInstallment_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelRD_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRD_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelRelAuto_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRelAuto_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelRelReciprocal_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRelReciprocal_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelRel_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRel_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_PanelTDTM_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelTDTM_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelUserRollup_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelUserRollup_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_SettingsManager_CTRL.cls-meta.xml
+++ b/src/classes/STG_SettingsManager_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_SettingsManager_TEST.cls-meta.xml
+++ b/src/classes/STG_SettingsManager_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_SettingsService.cls-meta.xml
+++ b/src/classes/STG_SettingsService.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/STG_UninstallScript.cls-meta.xml
+++ b/src/classes/STG_UninstallScript.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_UninstallScript_TEST.cls-meta.xml
+++ b/src/classes/STG_UninstallScript_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls-meta.xml
+++ b/src/classes/TDTM_DefaultConfig.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_ObjectDataGateway.cls-meta.xml
+++ b/src/classes/TDTM_ObjectDataGateway.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_Runnable.cls-meta.xml
+++ b/src/classes/TDTM_Runnable.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/TDTM_Runnable_TEST.cls-meta.xml
+++ b/src/classes/TDTM_Runnable_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/TDTM_TriggerActionHelper.cls-meta.xml
+++ b/src/classes/TDTM_TriggerActionHelper.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_TriggerHandler.cls-meta.xml
+++ b/src/classes/TDTM_TriggerHandler.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_TriggerScaffolds_TEST.cls-meta.xml
+++ b/src/classes/TDTM_TriggerScaffolds_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_iTableDataGateway.cls-meta.xml
+++ b/src/classes/TDTM_iTableDataGateway.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/UTIL_Describe.cls-meta.xml
+++ b/src/classes/UTIL_Describe.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Describe_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Describe_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_GlobalSchedulable.cls-meta.xml
+++ b/src/classes/UTIL_GlobalSchedulable.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_GlobalSchedulable_TEST.cls-meta.xml
+++ b/src/classes/UTIL_GlobalSchedulable_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_IScheduled.cls-meta.xml
+++ b/src/classes/UTIL_IScheduled.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_JobProgress_CTRL.cls-meta.xml
+++ b/src/classes/UTIL_JobProgress_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_JobProgress_CTRL_TEST.cls-meta.xml
+++ b/src/classes/UTIL_JobProgress_CTRL_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>30.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_JobScheduler.cls-meta.xml
+++ b/src/classes/UTIL_JobScheduler.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_JobScheduler_TEST.cls-meta.xml
+++ b/src/classes/UTIL_JobScheduler_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_MasterSchedulable.cls-meta.xml
+++ b/src/classes/UTIL_MasterSchedulable.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_MasterSchedulableHelper.cls-meta.xml
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_MasterSchedulable_TEST.cls-meta.xml
+++ b/src/classes/UTIL_MasterSchedulable_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Namespace.cls-meta.xml
+++ b/src/classes/UTIL_Namespace.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Namespace_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Namespace_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_RecordTypes.cls-meta.xml
+++ b/src/classes/UTIL_RecordTypes.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_RecordTypes_TEST.cls-meta.xml
+++ b/src/classes/UTIL_RecordTypes_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_SoqlListView_CTRL.cls-meta.xml
+++ b/src/classes/UTIL_SoqlListView_CTRL.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Typeahead.cls-meta.xml
+++ b/src/classes/UTIL_Typeahead.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Typeahead_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Typeahead_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
+++ b/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/classes/UTIL_iSoqlListViewConsumer.cls-meta.xml
+++ b/src/classes/UTIL_iSoqlListViewConsumer.cls-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/components/STG_DataBoundMultiSelect.component-meta.xml
+++ b/src/components/STG_DataBoundMultiSelect.component-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>STG_DataBoundMultiSelect</label>

--- a/src/components/STG_PageHeader.component-meta.xml
+++ b/src/components/STG_PageHeader.component-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>STG_PageHeader</label>

--- a/src/components/UTIL_JobProgress.component-meta.xml
+++ b/src/components/UTIL_JobProgress.component-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_JobProgress</label>

--- a/src/components/UTIL_SoqlListView.component-meta.xml
+++ b/src/components/UTIL_SoqlListView.component-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_SoqlListView</label>

--- a/src/components/UTIL_Typeahead.component-meta.xml
+++ b/src/components/UTIL_Typeahead.component-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <description>This is a generic template for Visualforce Component.  With this template, you may adjust the default elements and values and add new elements and values.</description>
     <label>UTIL_Typeahead</label>

--- a/src/pages/ACCT_ViewOverride.page-meta.xml
+++ b/src/pages/ACCT_ViewOverride.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/ADDR_CopyAddrHHObjBTN.page-meta.xml
+++ b/src/pages/ADDR_CopyAddrHHObjBTN.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/BDE_BatchEntry.page-meta.xml
+++ b/src/pages/BDE_BatchEntry.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/CONV_Account_Conversion.page-meta.xml
+++ b/src/pages/CONV_Account_Conversion.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/CON_ContactMerge.page-meta.xml
+++ b/src/pages/CON_ContactMerge.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/HH_CampaignDedupeBTN.page-meta.xml
+++ b/src/pages/HH_CampaignDedupeBTN.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/HH_ManageHHAccount.page-meta.xml
+++ b/src/pages/HH_ManageHHAccount.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/HH_ManageHousehold.page-meta.xml
+++ b/src/pages/HH_ManageHousehold.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/LD_LeadConvertOverride.page-meta.xml
+++ b/src/pages/LD_LeadConvertOverride.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/NPSP_Resources.page-meta.xml
+++ b/src/pages/NPSP_Resources.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>true</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
+++ b/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/PMT_PaymentWizard.page-meta.xml
+++ b/src/pages/PMT_PaymentWizard.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/RD_AddDonationsBTN.page-meta.xml
+++ b/src/pages/RD_AddDonationsBTN.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/REL_RelationshipsViewer.page-meta.xml
+++ b/src/pages/REL_RelationshipsViewer.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelAddrVerification.page-meta.xml
+++ b/src/pages/STG_PanelAddrVerification.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelAffiliations.page-meta.xml
+++ b/src/pages/STG_PanelAffiliations.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelBDE.page-meta.xml
+++ b/src/pages/STG_PanelBDE.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelContactRoles.page-meta.xml
+++ b/src/pages/STG_PanelContactRoles.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelContacts.page-meta.xml
+++ b/src/pages/STG_PanelContacts.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelERR.page-meta.xml
+++ b/src/pages/STG_PanelERR.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelErrorLog.page-meta.xml
+++ b/src/pages/STG_PanelErrorLog.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelHealthCheck.page-meta.xml
+++ b/src/pages/STG_PanelHealthCheck.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelHome.page-meta.xml
+++ b/src/pages/STG_PanelHome.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelHouseholds.page-meta.xml
+++ b/src/pages/STG_PanelHouseholds.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelLeads.page-meta.xml
+++ b/src/pages/STG_PanelLeads.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelMembership.page-meta.xml
+++ b/src/pages/STG_PanelMembership.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelOppBatch.page-meta.xml
+++ b/src/pages/STG_PanelOppBatch.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelOppRollups.page-meta.xml
+++ b/src/pages/STG_PanelOppRollups.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelOpps.page-meta.xml
+++ b/src/pages/STG_PanelOpps.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelPaymentMapping.page-meta.xml
+++ b/src/pages/STG_PanelPaymentMapping.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelRD.page-meta.xml
+++ b/src/pages/STG_PanelRD.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelRDBatch.page-meta.xml
+++ b/src/pages/STG_PanelRDBatch.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelRel.page-meta.xml
+++ b/src/pages/STG_PanelRel.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelRelAuto.page-meta.xml
+++ b/src/pages/STG_PanelRelAuto.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelRelReciprocal.page-meta.xml
+++ b/src/pages/STG_PanelRelReciprocal.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelTDTM.page-meta.xml
+++ b/src/pages/STG_PanelTDTM.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_PanelUserRollup.page-meta.xml
+++ b/src/pages/STG_PanelUserRollup.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/pages/STG_SettingsManager.page-meta.xml
+++ b/src/pages/STG_SettingsManager.page-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>

--- a/src/staticresources/CumulusStaticResources.resource-meta.xml
+++ b/src/staticresources/CumulusStaticResources.resource-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
     <cacheControl>Public</cacheControl>
     <contentType>application/zip</contentType>
     <description>all of the static resources needed by Cumulus</description>

--- a/src/triggers/TDTM_Account.trigger-meta.xml
+++ b/src/triggers/TDTM_Account.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Address.trigger-meta.xml
+++ b/src/triggers/TDTM_Address.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Affiliation.trigger-meta.xml
+++ b/src/triggers/TDTM_Affiliation.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/triggers/TDTM_Campaign.trigger-meta.xml
+++ b/src/triggers/TDTM_Campaign.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_CampaignMember.trigger-meta.xml
+++ b/src/triggers/TDTM_CampaignMember.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Contact.trigger-meta.xml
+++ b/src/triggers/TDTM_Contact.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_HouseholdObject.trigger-meta.xml
+++ b/src/triggers/TDTM_HouseholdObject.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/triggers/TDTM_Lead.trigger-meta.xml
+++ b/src/triggers/TDTM_Lead.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_Opportunity.trigger-meta.xml
+++ b/src/triggers/TDTM_Opportunity.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/TDTM_RecurringDonation.trigger-meta.xml
+++ b/src/triggers/TDTM_RecurringDonation.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>28.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>

--- a/src/triggers/TDTM_Relationship.trigger-meta.xml
+++ b/src/triggers/TDTM_Relationship.trigger-meta.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>29.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>


### PR DESCRIPTION
The upgrade to RD 3.1 seems to have incorrectly removed a line break between the first and second lines of all meta xml files.  This pull request puts the line breaks back.  All I did was run `ant updateMetaXml`

I will kill the Cumulus_dev_flow after merging and manually kick off Cumulus_dev_to_feature to resolve some of the merge conflicts created without building a new beta release for this change.
