### PR TITLE
Feature/905 notification emails

### DIFF
--- a/src/classes/ERR_Handler_TEST.cls
+++ b/src/classes/ERR_Handler_TEST.cls
@@ -333,7 +333,7 @@ public with sharing class ERR_Handler_TEST {
         system.assertEquals(1, [select count() from Error__c]);    
     }
 
-    /** Test that an inactive user won't receive email **/
+    /** Test that an inactive user won't receive email as the primary error user **/
     static testMethod void testInactiveUserEmailBehavior(){
 
         if (strTestOnly != '*' && strTestOnly != 'testInactiveUserEmailBehavior') return;

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -76,7 +76,7 @@ public with sharing class ERR_Notifier {
             sendErrorQueueEmailNotification(context, sendList);
         }
     }
-    
+
     @future
     private static void sendErrorQueueEmailNotificationFuture(List<String> sendList) { 
         sendErrorQueueEmailNotification(null, sendList); 


### PR DESCRIPTION
# Warning
# Info

This change prevents Salesforce from sending error email messages to an inactive user, even if that user is specified as the only recipient of the error messages.
# Issues

Fixes #905 
