### PR TITLE
Rename from Cumulus to Nonprofit Starter Pack

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -392,7 +392,7 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
       <delete dir="uninstall" />
 
       <!-- Fetch all metadata in the  package from target org -->
-      <retrievePackaged dir="uninstallsrc" package="${cumulusci.package.name}" />
+      <retrievePackaged dir="uninstallsrc" package="${cumulusci.package.name.managed}" />
 
       <!-- Build a destructiveChanges.xml pacckage to delete metadata in org but not in repo -->
       <buildDestroyStaleMetadata srcdir="uninstallsrc" commdir="src" dir="uninstall" />
@@ -458,7 +458,7 @@ npsp: ${InstalledPackage.npsp.versionNumber} (${version.npsp} required)
     </target>
 
     <target name="updatePackageXmlManaged">
-      <buildPackageXml package="${cumulusci.package.name}" version="${cumulusci.package.apiVersion}" installClass="${cumulusci.package.installClass}" uninstallClass="${cumulusci.package.uninstallClass}" />
+      <buildPackageXml package="${cumulusci.package.name.managed}" version="${cumulusci.package.apiVersion}" installClass="${cumulusci.package.installClass}" uninstallClass="${cumulusci.package.uninstallClass}" />
     </target>
 
     <target name="updateMetaXml">

--- a/cumulusci.properties
+++ b/cumulusci.properties
@@ -1,4 +1,5 @@
 cumulusci.package.name=Cumulus
+cumulusci.package.name.managed=Nonprofit Starter Pack
 cumulusci.package.namespace=npsp
 cumulusci.package.apiVersion=29.0
 cumulusci.package.installClass=STG_InstallScript


### PR DESCRIPTION
This branch modifies the build scripts to use the new cumulusci.package.name.managed property when deploying against the packaging org.  This allows us to keep the Cumulus package in all unmanaged deployments but rename the package to Nonprofit Starter Pack in the packaging org.
# Warning
# Info
- Changes the package name from Cumulus to Nonprofit Starter Pack in the Installed Packages list
# Issues

Fixes #884 
