### PR TITLE
Issue #1105: Sort Primary Contact first for automated household naming

### DIFF
--- a/src/classes/ACCT_HHAccounts_TEST.cls
+++ b/src/classes/ACCT_HHAccounts_TEST.cls
@@ -116,8 +116,18 @@ private with sharing class ACCT_HHAccounts_TEST {
         
         Test.startTest();      
         insert listCon;
+
+        // Force the primary contact on each to ensure proper naming order
+        // Update separately so that Name field doesn't accidentally get overwritten
+        // Don't want to re-query first because the list may come back in a different order
+        list<Account> updtAccts = new list<Account>{
+            new Account(Id=listAcc[0].Id, npe01__One2OneContact__c = listCon[0].Id),
+            new Account(Id=listAcc[1].Id, npe01__One2OneContact__c = listCon[2].Id),
+            new Account(Id=listAcc[2].Id, npe01__One2OneContact__c = listCon[4].Id)
+        };
+        update updtAccts;        
         test.stopTest();    // to flush any future calls.
-        
+
         listAcc = [select Name, npe01__SYSTEM_AccountType__c, npo02__SYSTEM_CUSTOM_NAMING__c, npe01__SYSTEMIsIndividual__c, 
             npe01__One2OneContact__c, npo02__Formal_Greeting__c, npo02__Informal_Greeting__c, Number_of_Household_Members__c from Account];
         system.assertEquals(3, listAcc.size());
@@ -328,7 +338,13 @@ private with sharing class ACCT_HHAccounts_TEST {
         system.assertEqualS(listCon[0].LastName, listCon[1].LastName);
         listCon[3].LastName = 'DifferentLastName';
         system.assertNotEquals(listCon[2].LastName, listCon[3].LastName);
-        
+
+        // Force the primary contact on each to ensure proper naming order
+        listAcc[0].npe01__One2OneContact__c = listCon[0].Id;
+        listAcc[1].npe01__One2OneContact__c = listCon[2].Id;
+        listAcc[2].npe01__One2OneContact__c = listCon[4].Id;
+        update listAcc;
+                
         Test.startTest();      
         update listCon;
         test.stopTest();    // to flush any future calls.
@@ -416,6 +432,16 @@ private with sharing class ACCT_HHAccounts_TEST {
         // now split the HH's
         listCon[1].AccountId = listAcc[2].Id;
         listCon[4].AccountId = listAcc[2].Id;
+        
+        // Force the primary contact on each to ensure proper naming order
+        // Update separately so that Name field doesn't accidentally get overwritten
+        // Don't want to re-query first because the list may come back in a different order
+        list<Account> updtAccts = new list<Account>{
+            new Account(Id=listCon[0].AccountId, npe01__One2OneContact__c = listCon[0].Id),
+            new Account(Id=listCon[1].AccountId, npe01__One2OneContact__c = listCon[1].Id),
+            new Account(Id=listCon[2].AccountId, npe01__One2OneContact__c = listCon[2].Id)
+        };
+        update updtAccts;        
         
         Test.startTest();      
         update listCon;
@@ -595,6 +621,10 @@ private with sharing class ACCT_HHAccounts_TEST {
             npe01__One2OneContact__c, npo02__Formal_Greeting__c, npo02__Informal_Greeting__c, Number_of_Household_Members__c from Account];
         system.assertEquals(1, listAcc.size());
         
+        // Determine which contact is the primary contact
+        Integer contact1 = (listAcc[0].npe01__One2OneContact__c == listCon[0].Id ? 0 : 1);
+        Integer contact2 = (contact1 == 1 ? 0 : 1);
+
         for (Account acc : listAcc) {
             system.assertNotEquals(null, acc.npe01__One2OneContact__c);
             system.assertNotEquals(null, acc.npo02__Formal_Greeting__c);
@@ -604,9 +634,9 @@ private with sharing class ACCT_HHAccounts_TEST {
             system.assertEquals(true, acc.npe01__SYSTEMIsIndividual__c);
             // 2 contacts, same lastname
             if (acc.Id == listCon[0].AccountId) {
-                system.assertEquals(listCon[0].LastName + ' Household', acc.Name);
-                system.assertEquals(listCon[0].FirstName + ' and ' + listCon[1].FirstName, acc.npo02__Informal_Greeting__c);
-                system.assertEquals(listCon[0].FirstName + ' and ' + listCon[1].FirstName + ' ' + listCon[0].LastName, acc.npo02__Formal_Greeting__c);
+                system.assertEquals(listCon[contact1].LastName + ' Household', acc.Name);
+                system.assertEquals(listCon[contact1].FirstName + ' and ' + listCon[contact2].FirstName, acc.npo02__Informal_Greeting__c);
+                system.assertEquals(listCon[contact1].FirstName + ' and ' + listCon[contact2].FirstName + ' ' + listCon[contact1].LastName, acc.npo02__Formal_Greeting__c);
                 system.assertEquals(2, acc.Number_of_Household_Members__c);
             }
         }
@@ -726,7 +756,15 @@ private with sharing class ACCT_HHAccounts_TEST {
         listCon[6].AccountId = listAcc[5].Id;   // Org
         
         insert listCon;
-                
+
+        // Force the primary contact on each to ensure proper naming order
+        // Update separately so that Name field doesn't accidentally get overwritten
+        // Don't want to re-query first because the list may come back in a different order
+        list<Account> updtAccts = new list<Account>{
+            new Account(Id=listAcc[1].Id, npe01__One2OneContact__c = listCon[1].Id)
+        };
+        update updtAccts;        
+
         listCon[0].ownerId = u2.Id;   // single HH
         listCon[1].ownerId = u2.Id;   // multi HH
         //listCon[2].ownerId = u2.Id;   // multi HH

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -64,7 +64,7 @@ public without sharing class HH_HouseholdNaming {
         string strSoql = strContactSelectStmtAllNamingFields;
         string strHHId = UTIL_Namespace.StrTokenNSPrefix('HHId__c');
         strSoql += ' WHERE AccountId IN :hhids OR npo02__Household__c in :hhids ' +
-            ' ORDER BY ' + strHHId + ', npo02__Household_Naming_Order__c ASC NULLS LAST, CreatedDate ';     
+            ' ORDER BY ' + strHHId + ', Primary_Contact__c DESC, npo02__Household_Naming_Order__c ASC NULLS LAST, CreatedDate ';     
         list<Contact> contactlist = Database.Query(strSoql); 
         
         list<SObject> listHHObj = [select Id, Name, npo02__SYSTEM_CUSTOM_NAMING__c from npo02__Household__c where id IN : hhids];
@@ -503,6 +503,8 @@ public without sharing class HH_HouseholdNaming {
                         else if (h.get('npo02__Formal_Greeting__c') == system.Label.npo02.NameReplacementText)
                             hhlist.add(h.id);       
                         else if (h.get('npo02__SYSTEM_CUSTOM_NAMING__c') != mapIdHHOld.get(h.id).get('npo02__SYSTEM_CUSTOM_NAMING__c'))
+                            hhlist.add(h.id);                        
+                        else if (h.get('npe01__One2OneContact__c') != mapIdHHOld.get(h.id).get('npe01__One2OneContact__c'))
                             hhlist.add(h.id);                        
                     }
                 }


### PR DESCRIPTION
When building the Household Name, always sort the assigned Primary_Contact first regardless of the HouseholdNamingOrder value on the Contact.
# Warning
# Info
- In Household Naming, the Household's Primary Contact now always appears first.  Thanks to Michael Smith (@force2b) for contributing this fix!
# Issues

Fixes #1105 
