### PR TITLE
Updates to allow address update code to work with State & Country picklists enabled

### DIFF
--- a/src/classes/ADDR_Addresses_TDTM.cls
+++ b/src/classes/ADDR_Addresses_TDTM.cls
@@ -37,6 +37,9 @@ public with sharing class ADDR_Addresses_TDTM extends TDTM_Runnable {
     // static flags to prevent recursive call 
     public static boolean hasRunAddrTrigger = false;
 
+    public static Boolean isStateCountryPicklistsEnabled = false;
+    public static Map<Id, String> addressErrors = new Map<Id, String>();
+
     // the main entry point for TDTM to invoke our trigger handlers.
     public override DmlWrapper run(List<SObject> listNew, List<SObject> listOld, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
@@ -57,7 +60,11 @@ public with sharing class ADDR_Addresses_TDTM extends TDTM_Runnable {
         	//system.debug('DJH**** stop Addr Trigger recursion');
             return null;
         }
-        
+
+        // If State & Country Picklists are enabled in the org, build sets of the
+        // valid Labels and Codes for each field to use for validation
+        isStateCountryPicklistsEnabled = UTIL_Describe.initValidStateCountryCodes();
+
         // first go through all new/modified Addresses, and collect the list of HH Accounts to consider.
         map<Id, Address__c> mapAccIdAddr = new map<Id, Address__c>(); // map of HH Accounts, and their default Address 
         map<Id, Address__c> mapAddrIdAddr = new map<Id, Address__c>(); // map of changed Addresses who need to only update any contact overrides.     
@@ -234,9 +241,38 @@ public with sharing class ADDR_Addresses_TDTM extends TDTM_Runnable {
             Account acc = new Account(Id = accId);
             acc.BillingStreet = getMultilineStreet(addr);
             acc.BillingCity = addr.MailingCity__c;
-            acc.BillingState = addr.MailingState__c;
             acc.BillingPostalCode = addr.MailingPostalCode__c;
-            acc.BillingCountry = addr.MailingCountry__c;
+
+            if (!isStateCountryPicklistsEnabled) {
+                acc.BillingState = addr.MailingState__c;
+                acc.BillingCountry = addr.MailingCountry__c;
+            } else {
+                if (addr.MailingCountry__c != null) {
+                    if (UTIL_Describe.validCountriesByLabel.containsKey(addr.MailingCountry__c)) {
+                        acc.BillingCountry = addr.MailingCountry__c;
+                        acc.put('BillingCountryCode', UTIL_Describe.validCountriesByLabel.get(addr.MailingCountry__c));
+                    } else if (UTIL_Describe.validCountriesByCode.containsKey(addr.MailingCountry__c)) {
+                        acc.put('BillingCountryCode', addr.MailingCountry__c);
+                        acc.BillingCountry = UTIL_Describe.validCountriesByCode.get(addr.MailingCountry__c);
+                    } else {
+                        addressErrors.put(addr.Id, 
+                            Label.Address_StateCountry_Invalid_Error.replace('{0}', addr.MailingCountry__c));
+                    }
+                }
+                if (addr.MailingState__c != null) {
+                    if (UTIL_Describe.validStatesByLabel.containsKey(addr.MailingState__c)) {
+                        acc.BillingState = addr.MailingState__c;
+                        acc.put('BillingStateCode', UTIL_Describe.validStatesByLabel.get(addr.MailingState__c));
+                    } else if (UTIL_Describe.validStatesByCode.containsKey(addr.MailingState__c)) {
+                        acc.put('BillingStateCode', addr.MailingState__c);
+                        acc.BillingState = UTIL_Describe.validStatesByCode.get(addr.MailingState__c);
+                    } else {
+                        addressErrors.put(addr.Id, 
+                            Label.Address_StateCountry_Invalid_Error.replace('{0}', addr.MailingState__c));
+                    }
+                }
+            }
+
             listAccUpdate.add(acc);
 
             
@@ -259,11 +295,39 @@ public with sharing class ADDR_Addresses_TDTM extends TDTM_Runnable {
 	                if (con.is_Address_Override__c == false || con.Current_Address__c == addr.Id) {
 	                    con.MailingStreet = getMultilineStreet(addr);
 	                    con.MailingCity = addr.MailingCity__c;
-	                    con.MailingState = addr.MailingState__c;
 	                    con.MailingPostalCode = addr.MailingPostalCode__c;
-	                    con.MailingCountry = addr.MailingCountry__c;
 	                    con.npe01__Primary_Address_Type__c = addr.Address_Type__c;
 	                    con.Current_Address__c = addr.Id;
+
+                        if (!isStateCountryPicklistsEnabled) {
+                            con.MailingState = addr.MailingState__c;
+                            con.MailingCountry = addr.MailingCountry__c;
+                        } else {
+                            if (addr.MailingCountry__c != null) {
+                                if (UTIL_Describe.validCountriesByLabel.containsKey(addr.MailingCountry__c)) {
+                                    con.MailingCountry = addr.MailingCountry__c;
+                                    con.put('MailingCountryCode', UTIL_Describe.validCountriesByLabel.get(addr.MailingCountry__c));
+                                } else if (UTIL_Describe.validCountriesByCode.containsKey(addr.MailingCountry__c)) {
+                                    con.put('MailingCountryCode', addr.MailingCountry__c);
+                                    con.MailingCountry = UTIL_Describe.validCountriesByCode.get(addr.MailingCountry__c);
+                                } else {
+                                    addressErrors.put(addr.Id, 
+                                        Label.Address_StateCountry_Invalid_Error.replace('{0}', addr.MailingCountry__c));
+                                }
+                            }
+                            if (addr.MailingState__c != null) {
+                                if (UTIL_Describe.validStatesByLabel.containsKey(addr.MailingState__c)) {
+                                    con.MailingState = addr.MailingState__c;
+                                    con.put('MailingStateCode', UTIL_Describe.validStatesByLabel.get(addr.MailingState__c));
+                                } else if (UTIL_Describe.validStatesByCode.containsKey(addr.MailingState__c)) {
+                                    con.put('MailingStateCode', addr.MailingState__c);
+                                    con.MailingState = UTIL_Describe.validStatesByCode.get(addr.MailingState__c);
+                                } else {
+                                    addressErrors.put(addr.Id, 
+                                        Label.Address_StateCountry_Invalid_Error.replace('{0}', addr.MailingState__c));
+                                }
+                            }
+                        }
 	                    listConUpdate.add(con);
 	                }   
 	            }
@@ -283,6 +347,15 @@ public with sharing class ADDR_Addresses_TDTM extends TDTM_Runnable {
             dmlWrapper.objectsToUpdate.addAll((List<SObject>)listConUpdate);
         }
         
+        if (addressErrors.size() > 0) {
+            ERR_Handler errHandler = new ERR_Handler();
+            for (Id addrId : addressErrors.keySet()) {
+                errHandler.queueError('Address__c', addrId, addressErrors.get(addrId), 
+                    'Address Update Error', 'ADDR_Address_TDTM');
+            }
+            errHandler.storeErrors();
+        }
+
         return mapAccIdHHInfo;
     }
     
@@ -335,9 +408,38 @@ public with sharing class ADDR_Addresses_TDTM extends TDTM_Runnable {
     		Address__c addr = mapAddrIdAddr.get(con.Current_Address__c);
             con.MailingStreet = getMultilineStreet(addr);
             con.MailingCity = addr.MailingCity__c;
-            con.MailingState = addr.MailingState__c;
             con.MailingPostalCode = addr.MailingPostalCode__c;
-            con.MailingCountry = addr.MailingCountry__c;
+
+            if (!isStateCountryPicklistsEnabled) {
+                con.MailingState = addr.MailingState__c;
+                con.MailingCountry = addr.MailingCountry__c;
+            } else {
+                if (addr.MailingCountry__c != null) {
+                    if (UTIL_Describe.validCountriesByLabel.containsKey(addr.MailingCountry__c)) {
+                        con.MailingCountry = addr.MailingCountry__c;
+                        con.put('MailingCountryCode', UTIL_Describe.validCountriesByLabel.get(addr.MailingCountry__c));
+                    } else if (UTIL_Describe.validCountriesByCode.containsKey(addr.MailingCountry__c)) {
+                        con.put('MailingCountryCode', addr.MailingCountry__c);
+                        con.MailingCountry = UTIL_Describe.validCountriesByCode.get(addr.MailingCountry__c);
+                    } else {
+                        addressErrors.put(addr.Id, 
+                            Label.Address_StateCountry_Invalid_Error.replace('{0}', addr.MailingCountry__c));
+                    }
+                }
+                if (addr.MailingState__c != null) {
+                    if (UTIL_Describe.validStatesByLabel.containsKey(addr.MailingState__c)) {
+                        con.MailingState = addr.MailingState__c;
+                        con.put('MailingStateCode', UTIL_Describe.validStatesByLabel.get(addr.MailingState__c));
+                    } else if (UTIL_Describe.validStatesByCode.containsKey(addr.MailingState__c)) {
+                        con.put('MailingStateCode', addr.MailingState__c);
+                        con.MailingState = UTIL_Describe.validStatesByCode.get(addr.MailingState__c);
+                    } else {
+                        addressErrors.put(addr.Id, 
+                            Label.Address_StateCountry_Invalid_Error.replace('{0}', addr.MailingState__c));
+                    }
+                }
+            }
+
             con.npe01__Primary_Address_Type__c = addr.Address_Type__c;
             dmlWrapper.objectsToUpdate.add(con);    		
     	}

--- a/src/classes/ADDR_Contact_TDTM.cls
+++ b/src/classes/ADDR_Contact_TDTM.cls
@@ -34,6 +34,9 @@
 */
 public with sharing class ADDR_Contact_TDTM extends TDTM_Runnable {
 
+    public static Boolean isStateCountryPicklistsEnabled = false;
+    public static Map<Id, String> addressErrors = new Map<Id, String>();
+
     // the main entry point for TDTM to invoke our trigger handlers.
     public override DmlWrapper run(List<SObject> listNew, List<SObject> listOld, 
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
@@ -45,6 +48,10 @@ public with sharing class ADDR_Contact_TDTM extends TDTM_Runnable {
         list<Contact> listConAddrReset = new list<Contact>();
         Map<Id,Account> mapAccountIdAccount = null;
                 
+        // If State & Country Picklists are enabled in the org, build sets of the
+        // valid Labels and Codes for each field to use for validation
+        isStateCountryPicklistsEnabled = UTIL_Describe.initValidStateCountryCodes();
+
         // Rules:
         // inserting new contact - make their address a new default address, unless they say it is an override
         // updating an existing contact - make their address a new default address, unless they say it is an override
@@ -160,6 +167,15 @@ public with sharing class ADDR_Contact_TDTM extends TDTM_Runnable {
         if (listConCreateAddr.size() > 0)
             createAddrFromCon(listConCreateAddr, dmlWrapper, triggerAction);
             
+        if (addressErrors.size() > 0) {
+            ERR_Handler errHandler = new ERR_Handler();
+            for (Id addrId : addressErrors.keySet()) {
+                errHandler.queueError('Address__c', addrId, addressErrors.get(addrId), 
+                    'Address Update Error', 'ADDR_Contact_TDTM');
+            }
+            errHandler.storeErrors();
+        }
+
         return dmlWrapper;    
     }
 
@@ -180,9 +196,31 @@ public with sharing class ADDR_Contact_TDTM extends TDTM_Runnable {
             	con.npe01__Primary_Address_Type__c = addr.Address_Type__c;
             	con.MailingStreet = ADDR_Addresses_TDTM.getMultilineStreet(addr);
             	con.MailingCity = addr.MailingCity__c;
-            	con.MailingState = addr.MailingState__c;
             	con.MailingPostalCode = addr.MailingPostalCode__c;
-            	con.MailingCountry = addr.MailingCountry__c;
+
+                if (!isStateCountryPicklistsEnabled) {
+                    con.MailingState = addr.MailingState__c;
+                    con.MailingCountry = addr.MailingCountry__c;
+                } else {
+                    if (addr.MailingCountry__c != null) {
+                        if (UTIL_Describe.validCountriesByCode.containsKey(addr.MailingCountry__c)) {
+                            con.put('MailingCountryCode', addr.MailingCountry__c);
+                            con.MailingCountry = UTIL_Describe.validCountriesByCode.get(addr.MailingCountry__c);
+                        } else {
+                            con.MailingCountry = addr.MailingCountry__c;
+                            con.put('MailingCountryCode', UTIL_Describe.validCountriesByLabel.get(addr.MailingCountry__c));
+                        }
+                    }
+                    if (addr.MailingState__c != null) {
+                        if (UTIL_Describe.validStatesByCode.containsKey(addr.MailingState__c)) {
+                            con.put('MailingStateCode', addr.MailingState__c);
+                            con.MailingState = UTIL_Describe.validStatesByCode.get(addr.MailingState__c);
+                        } else {
+                            con.MailingState = addr.MailingState__c;
+                            con.put('MailingStateCode', UTIL_Describe.validStatesByLabel.get(addr.MailingState__c));
+                        }
+                    }
+                }
             }
         }     	
     }
@@ -365,11 +403,33 @@ public with sharing class ADDR_Contact_TDTM extends TDTM_Runnable {
                 if (addr != null) {
                 	con.MailingStreet = ADDR_Addresses_TDTM.getMultilineStreet(addr);
                 	con.MailingCity = addr.MailingCity__c;
-                	con.MailingState = addr.MailingState__c;
                 	con.MailingPostalCode = addr.MailingPostalCode__c;
-                	con.MailingCountry = addr.MailingCountry__c;
                 	con.npe01__Primary_Address_Type__c = addr.Address_Type__c;
                 	con.Current_Address__c = addr.Id;
+
+                    if (!isStateCountryPicklistsEnabled) {
+                        con.MailingState = addr.MailingState__c;
+                        con.MailingCountry = addr.MailingCountry__c;
+                    } else {
+                        if (addr.MailingState__c != null) {
+                            if (UTIL_Describe.validStatesByCode.containsKey(addr.MailingState__c)) {
+                                con.put('MailingStateCode', addr.MailingState__c);
+                                con.MailingState = UTIL_Describe.validStatesByCode.get(addr.MailingState__c);
+                            } else {
+                                con.MailingState = addr.MailingState__c;
+                                con.put('MailingStateCode', UTIL_Describe.validStatesByLabel.get(addr.MailingState__c));
+                            }
+                        }
+                        if (addr.MailingCountry__c != null) {
+                            if (UTIL_Describe.validCountriesByCode.containsKey(addr.MailingCountry__c)) {
+                                con.put('MailingCountryCode', addr.MailingCountry__c);
+                                con.MailingCountry = UTIL_Describe.validCountriesByCode.get(addr.MailingCountry__c);
+                            } else {
+                                con.MailingCountry = addr.MailingCountry__c;
+                                con.put('MailingCountryCode', UTIL_Describe.validCountriesByLabel.get(addr.MailingCountry__c));
+                            }
+                        }
+                    }
                 }        	   
         	}
         }         

--- a/src/classes/ERR_Handler.cls
+++ b/src/classes/ERR_Handler.cls
@@ -204,6 +204,17 @@ public with sharing class ERR_Handler {
 		return error;
 	}
 
+    public void queueError(string objectType, Id objId, String errMessage, String errType, String stkTrace) {
+        Error__c error = new Error__c();
+        error.Datetime__c = System.now();
+        error.Object_Type__c = objectType;
+        error.Record_URL__c = getRecordURL(null, objId);
+        error.Error_Type__c = errType;
+        error.Full_Message__c = errMessage;
+        error.Stack_Trace__c = stkTrace;
+        errors.add(error);
+    }
+
     private static Error__c createError(Object result, string objectType, id objId) {
     	Error__c error = new Error__c();
         error.Datetime__c = System.now();

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -47,7 +47,16 @@ public with sharing class UTIL_Describe {
     private static Map<String, Schema.DescribeSObjectResult> objectDescribes = new Map<String, Schema.DescribeSObjectResult>();
     private static Map<String, Map<String, Schema.SObjectField>> fieldTokens = new Map<String,Map<String, Schema.SObjectField>>();
     private static Map<String, Map<String, Schema.DescribeFieldResult>> fieldDescribes = new Map<String,Map<String, Schema.DescribeFieldResult>>();
-        
+
+    // hold valid state & country picklist values, if enabled in the Org
+    public static Boolean isStateCountryPicklistsEnabled = false;
+    // The maps by convert the Code to a Label and Vice-Versa
+    // Required because Salesforce expects either two Codes or two Labels, but not a mix
+    public static Map<String, String> validCountriesByLabel = new Map<String, String>();
+    public static Map<String, String> validStatesByLabel = new Map<String, String>();
+    public static Map<String, String> validCountriesByCode = new Map<String, String>();
+    public static Map<String, String> validStatesByCode = new Map<String, String>();
+
     /*******************************************
     * Gets describe maps for a new object
     ********************************************/
@@ -325,6 +334,38 @@ public with sharing class UTIL_Describe {
             return true;
         
         return false;
+    }
+
+    /*******************************************************************************************************
+    * @description utility to determine if the "State and Country Picklist" field feature is enabled in Salesforce
+    * @return true if enabled; Fills 4 sets<> with a list of value codes and labels for each field
+    */ 
+    public static Boolean initValidStateCountryCodes() {
+        if (isStateCountryPicklistsEnabled == true) {
+            return true;
+        }
+
+        // If State & Country Picklists are enabled in the org, build sets of the
+        // valid Labels and Codes for each field to use for validation
+        map<String, Schema.SObjectField> acctFields = Account.getSobjectType().getDescribe().fields.getMap();
+        isStateCountryPicklistsEnabled = acctFields.containsKey('BillingCountryCode');
+        if (isStateCountryPicklistsEnabled) {
+            list<Schema.Picklistentry> countryPLValues = acctFields.get('BillingCountryCode').getDescribe().getPicklistValues();
+            for (Schema.Picklistentry p : countryPLValues) {
+                if (p.isActive()) { 
+                    validCountriesByLabel.put(p.getLabel(), p.getValue()); 
+                    validCountriesByCode.put(p.getValue(), p.getLabel());
+                }
+            }
+            list<Schema.Picklistentry> statePLValues = acctFields.get('BillingStateCode').getDescribe().getPicklistValues();
+            for (Schema.Picklistentry p : statePLValues) {
+                if (p.isActive()) { 
+                    validStatesByLabel.put(p.getLabel(), p.getValue()); 
+                    validStatesByCode.put(p.getValue(), p.getLabel());
+                }
+            }
+        }
+        return isStateCountryPicklistsEnabled;
     }
 
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -212,6 +212,14 @@
         <value>Address not found.</value>
     </labels>
     <labels>
+        <fullName>Address_StateCountry_Invalid_Error</fullName>
+        <categories>address, error</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>{value} is not configured as a valid Country in your Organization.</shortDescription>
+        <value>&apos;{0}&apos; is not configured as a valid Country in your Organization.</value>
+    </labels>
+    <labels>
         <fullName>Address_Verification_Limit</fullName>
         <categories>address, verification</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -471,6 +471,7 @@
     <members>Addr_Verify_Settings</members>
     <members>Addr_Verifying</members>
     <members>Address_Not_Found</members>
+    <members>Address_StateCountry_Invalid_Error</members>
     <members>Address_Verification_Limit</members>
     <members>HiddenForSecurity</members>
     <members>RecurringDonationAccountAndContactError</members>


### PR DESCRIPTION
Modify triggers related to the updating the Account and Contact objects for address changes to first validate the value against the set of valid State and Country picklist codes/values, if that feature is enabled in the Org. Potential errors due to a state or country value that cannot be matched against the configured codes/labels is logged as to the Error__c object; and the change is not made to the record.

Warning

Info

Household Account address management now works with State and Country picklists. Thanks to Michael Smith (@force2b) for this contribution
Issues

Fixes #994
