### PR TITLE
Supporting two-word country in Google Geocoding verification.

### DIFF
--- a/src/classes/ADDR_GoogleGeoAPI_Validator.cls
+++ b/src/classes/ADDR_GoogleGeoAPI_Validator.cls
@@ -78,7 +78,7 @@ public with sharing class ADDR_GoogleGeoAPI_Validator implements ADDR_IValidator
         if (a.MailingPostalCode__c != null)
             address_request_string += a.MailingPostalCode__c + '+';
         if (a.MailingCountry__c != null)
-            address_request_string += a.MailingCountry__c;
+            address_request_string += a.MailingCountry__c.replace(' ', '+');
 
         HttpResponse response = new HttpResponse();
 


### PR DESCRIPTION
This pull request can be merged now, @kbromer.

# Warning

# Info
* Google Geocoding Address Verification now supports State and Country picklists.

# Issues
Fixes #1259. 