### PR TITLE
Renaming the opportunity field sets that were mistakenly pulled from the...

### DIFF
--- a/src/classes/BDE_BatchDataEntry.cls
+++ b/src/classes/BDE_BatchDataEntry.cls
@@ -86,8 +86,13 @@ public class BDE_BatchDataEntry {
                     this.statusMessage = this.FAIL + this.objectName + ' does not have a lookup field to the ' + String.valueOf(Batch__c.sObjectType) + ' object. If this is a standard object, you can go to Setup->Customize-><objectname>->Fields to create a lookup field to the Batch. For custom object, please go to Setup->Create->Objects-><objectname> and click \'New\' under the Fields section.';
                 } else {
                     this.entryFieldList = BDE_DescribeHelper_UTIL.listStrFromFieldSet(pObjectName, UTIL_Namespace.StrTokenNSPrefix('BDE_Entry_FS'));
+                    if(this.entryFieldList == null) //The original fieldsets for opportunity got deleted by mistake. New name required.
+                        this.entryFieldList = BDE_DescribeHelper_UTIL.listStrFromFieldSet(pObjectName, UTIL_Namespace.StrTokenNSPrefix('BDE_Entry_FS_v2'));
+                    
                     this.listFieldList = BDE_DescribeHelper_UTIL.listStrFromFieldSet(pObjectName, UTIL_Namespace.StrTokenNSPrefix('BDE_List_FS'));                  
-                                            
+                    if(this.listFieldList == null) //The original fieldsets for opportunity got deleted by mistake. New name required.
+                        this.listFieldList = BDE_DescribeHelper_UTIL.listStrFromFieldSet(pObjectName, UTIL_Namespace.StrTokenNSPrefix('BDE_List_FS_v2')); 
+                    
                     buildFieldSet();
                     buildQueryString();
 					this.statusMessage = this.SUCCESS;

--- a/src/classes/BDE_BatchDataEntry_TEST.cls
+++ b/src/classes/BDE_BatchDataEntry_TEST.cls
@@ -55,6 +55,18 @@ private class BDE_BatchDataEntry_TEST {
         System.assertNotEquals(null, bde.getQueryString());
         System.assertNotEquals(null, bde.getFailureMessage());
         System.assertNotEquals(null, bde.getBatchLookupFieldName());
-        System.assertNotEquals(0, BDE_BatchDataEntry.mapDevNameToLabelBDEObjects().size());       
+        System.assertNotEquals(0, BDE_BatchDataEntry.mapDevNameToLabelBDEObjects().size());
+        
+        //Adding hard references to fieldset to make sure they don't get deleted from the package
+        System.assertNotEquals(null, Schema.SObjectType.Account.fieldSets.BDE_Entry_FS.getFields());
+        System.assertNotEquals(null, Schema.SObjectType.Account.fieldSets.BDE_List_FS.getFields());
+        System.assertNotEquals(null, Schema.SObjectType.Account.fieldSets.Manage_Household_Custom.getFields());
+        System.assertNotEquals(null, Schema.SObjectType.Batch__c.fieldSets.BatchDetailView.getFields());
+        System.assertNotEquals(null, Schema.SObjectType.Contact.fieldSets.BDE_Entry_FS.getFields());       
+	    System.assertNotEquals(null, Schema.SObjectType.Contact.fieldSets.BDE_List_FS.getFields());
+	    System.assertNotEquals(null, Schema.SObjectType.Lead.fieldSets.BDE_Entry_FS.getFields());
+	    System.assertNotEquals(null, Schema.SObjectType.Lead.fieldSets.BDE_List_FS.getFields());
+	    System.assertNotEquals(null, Schema.SObjectType.Opportunity.fieldSets.BDE_Entry_FS_v2.getFields());
+	    System.assertNotEquals(null, Schema.SObjectType.Opportunity.fieldSets.BDE_List_FS_v2.getFields());
     }
 }

--- a/src/classes/BDE_DescribeHelper_UTIL.cls
+++ b/src/classes/BDE_DescribeHelper_UTIL.cls
@@ -213,17 +213,17 @@ public class  BDE_DescribeHelper_UTIL {
         Schema.DescribeSObjectResult d = targetType.getDescribe(); 
         Schema.FieldSet fs = d.fieldSets.getMap().get(strFS); 
         if (fs == null) {
-        	throw (new MyException('Field set \'' + strFS + '\' does not exist.'));
-        }      
-
-        for(Schema.FieldSetMember f : fs.getFields()) {
-            if (f.getFieldPath().contains('.')) {
-                throw (new MyException('Related field \'' + f.getFieldPath() + '\' not supported ' +
-                    'in field set \'' + strFS + '\'.  You can only include fields directly on object \'' + strObject + '\'.'));
-            }
-            listStrFields.add(f.getFieldPath());
+        	return null;
+        } else {
+	        for(Schema.FieldSetMember f : fs.getFields()) {
+	            if (f.getFieldPath().contains('.')) {
+	                throw (new MyException('Related field \'' + f.getFieldPath() + '\' not supported ' +
+	                    'in field set \'' + strFS + '\'.  You can only include fields directly on object \'' + strObject + '\'.'));
+	            }
+	            listStrFields.add(f.getFieldPath());
+	        }
+	        return listStrFields;
         }
-        return listStrFields;
     }
     
     // utility to return a comma separated string of field names from a field set

--- a/src/objects/Account.object
+++ b/src/objects/Account.object
@@ -765,16 +765,4 @@
         <type>Number</type>
         <unique>false</unique>
     </fields>
-    <listViews>
-        <fullName>AllAccounts</fullName>
-        <columns>ACCOUNT.NAME</columns>
-        <columns>ACCOUNT.ADDRESS1_STATE</columns>
-        <columns>ACCOUNT.PHONE1</columns>
-        <columns>ACCOUNT.TYPE</columns>
-        <columns>npo02__TotalOppAmount__c</columns>
-        <columns>npo02__OppAmountLastNDays__c</columns>
-        <columns>npo02__AverageAmount__c</columns>
-        <filterScope>Everything</filterScope>
-        <label>All Accounts</label>
-    </listViews>
 </CustomObject>

--- a/src/objects/Opportunity.object
+++ b/src/objects/Opportunity.object
@@ -27,7 +27,7 @@
         <label>NPSP Donation Compact Layout</label>
     </compactLayouts>
     <fieldSets>
-        <fullName>BDE_Entry_FS</fullName>
+        <fullName>BDE_Entry_FS_v2</fullName>
         <availableFields>
             <field>CampaignId</field>
             <isFieldManaged>false</isFieldManaged>
@@ -204,10 +204,10 @@
             <isFieldManaged>false</isFieldManaged>
             <isRequired>false</isRequired>
         </displayedFields>
-        <label>BDE Entry FS</label>
+        <label>BDE Entry FS v2</label>
     </fieldSets>
     <fieldSets>
-        <fullName>BDE_List_FS</fullName>
+        <fullName>BDE_List_FS_v2</fullName>
         <availableFields>
             <field>npe01__Amount_Outstanding__c</field>
             <isFieldManaged>false</isFieldManaged>
@@ -444,7 +444,7 @@
             <isFieldManaged>false</isFieldManaged>
             <isRequired>false</isRequired>
         </displayedFields>
-        <label>BDE List FS</label>
+        <label>New BDE List v2</label>
     </fieldSets>
     <fields>
         <fullName>Batch__c</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1003,8 +1003,8 @@
     <members>Contact.BDE_List_FS</members>
     <members>Lead.BDE_Entry_FS</members>
     <members>Lead.BDE_List_FS</members>
-    <members>Opportunity.BDE_Entry_FS</members>
-    <members>Opportunity.BDE_List_FS</members>
+    <members>Opportunity.BDE_Entry_FS_v2</members>
+    <members>Opportunity.BDE_List_FS_v2</members>
     <name>FieldSet</name>
   </types>
   <types>
@@ -1026,7 +1026,6 @@
     <name>Layout</name>
   </types>
   <types>
-    <members>Account.AllAccounts</members>
     <members>Batch__c.All</members>
     <members>Batch__c.Completed_Batches</members>
     <members>Batch__c.Open_Batches</members>


### PR DESCRIPTION
... packaging org. Removing the account listview that was also pulled. Adding hard references to all field sets, so they cannot be removed without us noticing.

# Warning

# Info
* Due to a packaging issue, it was necessary to rename the BDE_Entry_FS and BDE_List_FS fieldsets in Opportunity. The new names are BDE_Entry_FS_v2 and BDE_List_FS_v2. Once you install this version, you will have both sets of fieldsets. If you customized them, you'll probably want to reapply those customizations to the new ones. Once these are applied, the old fieldsets can be deleted.

# Issues
Fixes #1271.