### PR TITLE
#1241. support for New custom setting Household Account Addresses Disabl...

### DIFF
--- a/src/classes/ADDR_Account_TDTM.cls
+++ b/src/classes/ADDR_Account_TDTM.cls
@@ -81,8 +81,10 @@ public with sharing class ADDR_Account_TDTM extends TDTM_Runnable {
                 if (ADDR_Addresses_TDTM.hasRunAddrTrigger)
                     continue;
                 // we only support address management with HH Accounts and Organizational Accounts (if enabled)
-                if (acc.npe01__SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_TYPE ||
-                    (!acc.npe01__SYSTEMIsIndividual__c && UTIL_CustomSettingsFacade.getContactsSettings().Organizational_Account_Addresses_Enabled__c)) {
+                if ((acc.npe01__SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_TYPE && 
+                		!UTIL_CustomSettingsFacade.getContactsSettings().Household_Account_Addresses_Disabled__c) ||
+                    (!acc.npe01__SYSTEMIsIndividual__c && 
+                    	UTIL_CustomSettingsFacade.getContactsSettings().Organizational_Account_Addresses_Enabled__c)) {
 	                // if the address changed, remember the account we want to add a new address for    
 	                if (isAccountAddressChanged(acc, accOld)) 
 	                    listAccCreateAddr.add(acc);

--- a/src/classes/ADDR_Addresses_TEST.cls
+++ b/src/classes/ADDR_Addresses_TEST.cls
@@ -2124,4 +2124,44 @@ private with sharing class ADDR_Addresses_TEST {
             system.assertEquals(null, con.MailingCity);
         }
     }
+
+    /*********************************************************************************************************
+    operation:
+        create N contacts with Household Accounts when the setting for Address Mgmt is off. 
+    verify:
+        no Address objects created
+        HH Account addresses set
+        Contact addresses set
+    **********************************************************************************************************/            
+    static testMethod void testDisabledHHAccountAddr() {
+        if (strTestOnly != '*' && strTestOnly != 'testDisabledHHAccountAddr') return;
+        
+        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_and_Orgs_Settings__c (
+                npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR,
+                Household_Account_Addresses_Disabled__c = true
+        ));
+ 
+        listConT = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(cCon);
+        for (Contact con : listConT) {
+            con.MailingStreet = 'new street';
+            con.MailingCity = 'new city';
+        }
+        insert listConT;        
+
+        // verify that the HH and Contacts share the same address
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry from Account]);
+        list<Contact> listCon = [select Id, Name, AccountId, is_Address_Override__c, Current_Address__c, MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry from Contact];
+        
+        for (Contact con : listCon) {
+            Account acc = mapAccIdAcc.get(con.AccountId);
+            system.assertEquals(true, isMatchAddressAccCon(acc, con));
+            system.assertEquals(false, con.is_Address_Override__c);
+            system.assertEquals(null, con.Current_Address__c);
+        }
+        
+        // verify no address objects created
+        list<Address__c> listAddr = [select Id from Address__c];
+        system.assertEquals(0, listAddr.size());
+    }
 }

--- a/src/classes/ADDR_Contact_TDTM.cls
+++ b/src/classes/ADDR_Contact_TDTM.cls
@@ -55,6 +55,10 @@ public with sharing class ADDR_Contact_TDTM extends TDTM_Runnable {
         map<Id, boolean> mapAddrIdIsOverride = new map<Id, boolean>();
         list<Contact> listConAddrReset = new list<Contact>();
         Map<Id,Account> mapAccountIdAccount = null;
+        
+		// bail out if address mgmt turned off.
+        if (UTIL_CustomSettingsFacade.getContactsSettings().Household_Account_Addresses_Disabled__c)
+        	return dmlWrapper;
                 
         // Rules:
         // inserting new contact - make their address a new default address, unless they say it is an override

--- a/src/classes/STG_PanelHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls
@@ -44,12 +44,18 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
     public boolean isRunningBatch { get; set; }
 
     public PageReference activateHouseholdNaming() {
-        isRunningBatch = true; 
         boolean isActivation = (UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c == false);
                 
         STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = true;
+
+        // make sure any custom name formats are valid.
+		if (!isValidNameFormats()) {
+			return null;        			
+		}
+
         saveSettings();
         
+        isRunningBatch = true; 
         HH_HouseholdNaming.refreshAllHouseholdNaming(isActivation);        
         return null;
     }
@@ -59,6 +65,27 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
         return super.editSettings();
     }
     
+    private boolean isValidNameFormats() {
+        // make sure any custom name formats are valid.
+        if (STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c) {
+	        string strSetting;        
+			try {
+				strSetting = UTIL_Describe.getFieldLabel('Household_Naming_Settings__c', 'Household_Name_Format__c');     
+	            strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2); 
+				strSetting = UTIL_Describe.getFieldLabel('Household_Naming_Settings__c', 'Formal_Greeting_Format__c');     
+	            strNameSpecExample(STG_Panel.stgService.stgHN, 'Formal_Greeting_Format__c', 2); 
+				strSetting = UTIL_Describe.getFieldLabel('Household_Naming_Settings__c', 'Informal_Greeting_Format__c');     
+	            strNameSpecExample(STG_Panel.stgService.stgHN, 'Informal_Greeting_Format__c', 2);
+	            return true; 
+			} catch (Exception ex) {
+	            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, 
+	            	string.format(label.stgErrorInvalidNameFormat, new string[]{strSetting, ex.getMessage()})));
+	            return false;			
+			}        
+        } 
+        return true;   	
+    }
+
     public override PageReference saveSettings() {
     	
     	// add some extra error detection
@@ -67,7 +94,11 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, system.Label.stgValidationHHAccountHHRules));
             return null;
         }
-        
+
+        // make sure any custom name formats are valid.
+		if (!isValidNameFormats())
+			return null;        
+                
         return super.saveSettings();
     }
 

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -427,6 +427,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         contactsSettings.npe01__Payments_Enabled__c = mySettings.npe01__Payments_Enabled__c;
         contactsSettings.Organizational_Account_Addresses_Enabled__c = mySettings.Organizational_Account_Addresses_Enabled__c;
         contactsSettings.Simple_Address_Change_Treated_as_Update__c = mySettings.Simple_Address_Change_Treated_as_Update__c;
+        contactsSettings.Household_Account_Addresses_Disabled__c = mySettings.Household_Account_Addresses_Disabled__c;
         upsert contactsSettings;
         return contactsSettings;
     }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2070,6 +2070,14 @@
         <value>Invalid Implementing Class.</value>
     </labels>
     <labels>
+        <fullName>stgErrorInvalidNameFormat</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>stgErrorInvalidNameFormat</shortDescription>
+        <value>Error in {0}: {1}</value>
+    </labels>
+    <labels>
         <fullName>stgHHNameRefreshTitle</fullName>
         <categories>Settings</categories>
         <language>en_US</language>
@@ -2227,6 +2235,14 @@ Once the renaming process is 100% complete, you can safely leave or refresh this
         <protected>false</protected>
         <shortDescription>stgHelpDefaultGAU</shortDescription>
         <value>Default General Accounting Unit for default allocation of unallocated Opportunities, and remainders of partially allocated Opportunities.</value>
+    </labels>
+    <labels>
+        <fullName>stgHelpDisableHHAccountAddr</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>stgHelpDisableHHAccountAddr</shortDescription>
+        <value>Disables Address management for Household Accounts when selected.</value>
     </labels>
     <labels>
         <fullName>stgHelpEnableSoftCreditRollups</fullName>

--- a/src/objects/npe01__Contacts_And_Orgs_Settings__c.object
+++ b/src/objects/npe01__Contacts_And_Orgs_Settings__c.object
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <fields>
+        <fullName>Household_Account_Addresses_Disabled__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Disables Address management for Household Accounts when selected.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Disables Address management for Household Accounts when selected.</inlineHelpText>
+        <label>Household Account Addresses Disabled</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Max_Payments__c</fullName>
         <defaultValue>12</defaultValue>
         <description>Determines the maximum number of payments available in the Payment Creation Wizard.</description>

--- a/src/package.xml
+++ b/src/package.xml
@@ -762,6 +762,7 @@
     <members>stgBtnSave</members>
     <members>stgErrorINaming</members>
     <members>stgErrorInvalidClass</members>
+    <members>stgErrorInvalidNameFormat</members>
     <members>stgHHNameRefreshTitle</members>
     <members>stgHelpAccountModel</members>
     <members>stgHelpAlloFiscalYearRollups</members>
@@ -781,6 +782,7 @@
     <members>stgHelpContactRTExcluded</members>
     <members>stgHelpDefaultAllocationsEnabled</members>
     <members>stgHelpDefaultGAU</members>
+    <members>stgHelpDisableHHAccountAddr</members>
     <members>stgHelpEnableSoftCreditRollups</members>
     <members>stgHelpErrorNotifyOn</members>
     <members>stgHelpErrorNotifyTo</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -495,6 +495,7 @@
     <members>Trigger_Handler__c.Object__c</members>
     <members>Trigger_Handler__c.Trigger_Action__c</members>
     <members>Trigger_Handler__c.User_Managed__c</members>
+    <members>npe01__Contacts_And_Orgs_Settings__c.Household_Account_Addresses_Disabled__c</members>
     <members>npe01__Contacts_And_Orgs_Settings__c.Max_Payments__c</members>
     <members>npe01__Contacts_And_Orgs_Settings__c.Organizational_Account_Addresses_Enabled__c</members>
     <members>npe01__Contacts_And_Orgs_Settings__c.Simple_Address_Change_Treated_as_Update__c</members>

--- a/src/pages/STG_PanelAddrVerification.page
+++ b/src/pages/STG_PanelAddrVerification.page
@@ -59,6 +59,15 @@
         <section>
             <h3 class="section-header" >{!$Label.addrGeneralSettings}</h3>
             <div class="form-group">
+                <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Household_Account_Addresses_Disabled__c.Label}" for="cbxDHAA" styleClass="col-md-4 control-label" />
+                <div class="col-md-8 form-control-column">
+                    <apex:inputCheckbox value="{!stgService.stgCon.Household_Account_Addresses_Disabled__c}" disabled="{!isReadOnlyMode}" id="cbxDHAA" />
+                </div>
+                <div class="col-md-offset-4 col-md-8 help-block">
+                    <apex:outputText value="{!$Label.stgHelpDisableHHAccountAddr}" />
+                </div>
+            </div>
+            <div class="form-group">
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Organizational_Account_Addresses_Enabled__c.Label}" for="cbxOAAE" styleClass="col-md-4 control-label" />
                 <div class="col-md-8 form-control-column">
                     <apex:inputCheckbox value="{!stgService.stgCon.Organizational_Account_Addresses_Enabled__c}" disabled="{!isReadOnlyMode}" id="cbxOAAE" />

--- a/src/pages/STG_PanelHouseholds.page
+++ b/src/pages/STG_PanelHouseholds.page
@@ -328,5 +328,6 @@
             </apex:outputPanel>
 
         </apex:pageBlock>
+        <apex:pageMessages />
     </apex:form>
 </apex:page>


### PR DESCRIPTION
# Warning

# Info
* There is a new custom setting on the Address Settings page, Household Account Addresses Disabled.  This allows organizations who have data storage concerns to still use the Household Account model, but not use the new Address management features in NPSP 3.

# Issues
Fixes #1241 
Fixes #1218 