### PR TITLE
Removing controller check for inactive accounts/cons/opps/tasks

### DIFF
--- a/src/classes/CONV_Account_Conversion_CTRL.cls
+++ b/src/classes/CONV_Account_Conversion_CTRL.cls
@@ -231,29 +231,28 @@ public with sharing class CONV_Account_Conversion_CTRL {
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, errorString));
         }
 
-        /* Spring 15 removed the requirement that users must be active
+
         List<User> inactiveUsers = new List<User>();
         inactiveUsers = [select id from User where isActive = false order by LastModifiedDate desc limit 9999];
-        Integer accountCount = [select count() from Account where OwnerId IN :inactiveUsers limit 200];
+  //      Integer accountCount = [select count() from Account where OwnerId IN :inactiveUsers limit 200];
         Integer contactCount = [select count() from Contact where OwnerId IN :inactiveUsers limit 200];
-        Integer opptyCount = [select count() from Opportunity where OwnerId IN :inactiveUsers limit 200];
+  //      Integer opptyCount = [select count() from Opportunity where OwnerId IN :inactiveUsers limit 200];
         Integer taskCount = [select count() from Task where OwnerId IN :inactiveUsers limit 200];
 
         String inactiveUserWarning = 'You have records owned by inactive Users.  You will need to transfer these records to an active user prior to running the conversion process.  The conversion process will not be available until these records have been reassigned.';
-        if (accountCount > 0)
-            inactiveUserWarning += '\n ' + accountCount + ' Accounts are currently owned by an inactive user. ';
+//        if (accountCount > 0)
+  //          inactiveUserWarning += '\n ' + accountCount + ' Accounts are currently owned by an inactive user. ';
         if (contactCount > 0)
             inactiveUserWarning += '\n ' + contactCount + ' Contacts are currently owned by an inactive user. ';
-        if (opptyCount > 0)
-            inactiveUserWarning += '\n ' + opptyCount + ' Opportunities are currently owned by an inactive user. ';
+      //  if (opptyCount > 0)
+    //        inactiveUserWarning += '\n ' + opptyCount + ' Opportunities are currently owned by an inactive user. ';
         if (taskCount > 0)
             inactiveUserWarning += '\n ' + taskCount + ' Tasks are currently owned by an inactive user. ';
 
-        if ((accountCount + contactCount + opptyCount + taskCount) > 0){
+        if ((contactCount + taskCount /* accountCount + opptyCount */) > 0){
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, inactiveUserWarning));
             runCheckErrorState = true;
         }
-        */
 
         //set the recordtype if its not already set
         Recordtypeinfo householdAccount = Schema.SObjectType.Account.getRecordTypeInfosByName().get('Household Account');

--- a/src/classes/CONV_Account_Conversion_CTRL.cls
+++ b/src/classes/CONV_Account_Conversion_CTRL.cls
@@ -231,6 +231,7 @@ public with sharing class CONV_Account_Conversion_CTRL {
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, errorString));
         }
 
+        /* Spring 15 removed the requirement that users must be active
         List<User> inactiveUsers = new List<User>();
         inactiveUsers = [select id from User where isActive = false order by LastModifiedDate desc limit 9999];
         Integer accountCount = [select count() from Account where OwnerId IN :inactiveUsers limit 200];
@@ -252,6 +253,7 @@ public with sharing class CONV_Account_Conversion_CTRL {
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, inactiveUserWarning));
             runCheckErrorState = true;
         }
+        */
 
         //set the recordtype if its not already set
         Recordtypeinfo householdAccount = Schema.SObjectType.Account.getRecordTypeInfosByName().get('Household Account');

--- a/src/classes/CONV_Account_Conversion_CTRL_TEST.cls
+++ b/src/classes/CONV_Account_Conversion_CTRL_TEST.cls
@@ -139,9 +139,7 @@ public with sharing class CONV_Account_Conversion_CTRL_TEST {
             Test.stopTest();
 
             //assert the warning exists
-        //    system.assertEquals(true, controller.runCheckErrorState);
-            //assert inactive users no longer cause an error state for the controller
-            system.assertEquals(false, controller.runCheckErrorState);
+            system.assertEquals(true, controller.runCheckErrorState);        
         }
     }
 }

--- a/src/classes/CONV_Account_Conversion_CTRL_TEST.cls
+++ b/src/classes/CONV_Account_Conversion_CTRL_TEST.cls
@@ -139,7 +139,9 @@ public with sharing class CONV_Account_Conversion_CTRL_TEST {
             Test.stopTest();
 
             //assert the warning exists
-            system.assertEquals(true, controller.runCheckErrorState);
+        //    system.assertEquals(true, controller.runCheckErrorState);
+            //assert inactive users no longer cause an error state for the controller
+            system.assertEquals(false, controller.runCheckErrorState);
         }
     }
 }


### PR DESCRIPTION
# Warning
# Info
- Removes the requirement that Accounts/Opptys be owned by active users.  Requirement remains for Tasks/Contacts.  This accommodates changes made in Salesforce Spring 15 release

# Issues
Fixes #1438 