### PR TITLE
#1595 Update Recurring Donation Paid Amount when related Closed/Won O…

### DIFF
--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -386,8 +386,9 @@ public with sharing class RD_RecurringDonations {
                 if (r.npe03__Total_Paid_Installments__c != null) {
                 	paidInstallments = integer.valueOf(r.npe03__Total_Paid_Installments__c);
                     j = paidInstallments;
-                    if (r.npe03__Schedule_Type__c != Label.npe03.RecurringDonationMultiplyValue) {                    
-                        installmentAmount = (r.npe03__Amount__c - paidAmount) / (installments - paidInstallments);
+                    if (r.npe03__Schedule_Type__c != Label.npe03.RecurringDonationMultiplyValue) {
+                        if (installments - paidInstallments > 0)                    
+                            installmentAmount = (r.npe03__Amount__c - paidAmount) / (installments - paidInstallments);
                     }
                 }
                     

--- a/src/classes/RD_RecurringDonations_Opp_TDTM.cls
+++ b/src/classes/RD_RecurringDonations_Opp_TDTM.cls
@@ -63,6 +63,19 @@ public with sharing class RD_RecurringDonations_Opp_TDTM extends TDTM_Runnable {
                 }
                 i++;
             }                  
+        }
+
+        if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
+            integer i = 0;
+            for (SObject sobj : newlist) {
+                Opportunity o = (Opportunity)sobj;
+                //does it have a recurring donation reference?
+                //is it in closed state?
+                if (o.npe03__Recurring_Donation__c != null && o.isClosed && o.Amount != null && o.Amount > 0){
+                    rdIds.add(o.npe03__Recurring_Donation__c);
+                }
+                i++;
+            }                  
         }           
         
         //Get the open label for opps

--- a/src/classes/RD_RecurringDonations_TEST.cls
+++ b/src/classes/RD_RecurringDonations_TEST.cls
@@ -841,8 +841,7 @@ public class RD_RecurringDonations_TEST {
         system.assertEquals(system.today(), rd.npe03__Last_Payment_Date__c);
     }
     
-    
-       //test closing an opportunity for an open recurring donation
+    //test closing an opportunity for an open recurring donation
     static testMethod void closeOppForOpenEndedRecurringDonationCustomDays(){
         if (strTestOnly != '*' && strTestOnly != 'closeOppForOpenEndedRecurringDonationCustomDays') return;
 
@@ -903,8 +902,7 @@ public class RD_RecurringDonations_TEST {
         system.assertEquals(system.today(), rd.npe03__Last_Payment_Date__c);
     }
     
-    
-       //test closing an opportunity for an open recurring donation
+    //test closing an opportunity for an open recurring donation
     static testMethod void closeOppForOpenEndedRecurringDonationCustomMonths(){
         if (strTestOnly != '*' && strTestOnly != 'closeOppForOpenEndedRecurringDonationCustomMonths') return;
 
@@ -966,7 +964,8 @@ public class RD_RecurringDonations_TEST {
         system.assertEquals(5, [select count() from Opportunity where npe03__Recurring_Donation__c = :r1.id and isClosed = false]);
         system.assertEquals(system.today(), rd.npe03__Last_Payment_Date__c);
     }
-       //test closing an opportunity for an open recurring donation
+
+    //test closing an opportunity for an open recurring donation
     static testMethod void closeOppForOpenEndedRecurringDonationCustomYears(){
         if (strTestOnly != '*' && strTestOnly != 'closeOppForOpenEndedRecurringDonationCustomYears') return;
 
@@ -1183,6 +1182,56 @@ public class RD_RecurringDonations_TEST {
         
         system.assertEquals(1, [select count() from Opportunity where npe03__Recurring_Donation__c = :r1.id and isClosed = false]);
         system.assertEquals(system.today(), rd.npe03__Last_Payment_Date__c);
+    }
+
+    //test inserting a closed/won opportunity for an open recurring donation
+    static testMethod void insertClosedOppForOpenEndedRecurringDonation(){
+        if (strTestOnly != '*' && strTestOnly != 'closeOppForOpenEndedRecurringDonationQuarterly') return;
+
+        UTIL_CustomSettingsFacade.getRecurringDonationsSettingsForTest(
+        new npe03__Recurring_Donations_Settings__c(
+        npe03__Opportunity_Forecast_Months__c = 12,
+        npe03__Maximum_Donations__c = 50,
+        npe03__Open_Opportunity_Behavior__c = RD_RecurringDonations.RecurringDonationCloseOptions.Mark_Opportunities_Closed_Lost.name()        
+        ));           
+        
+        Account a = new Account();
+        a.Name = 'test Individual';
+        insert a;
+        
+        Contact c = new Contact();
+        c.FirstName = 'test';
+        c.LastName = 'contact';
+        c.AccountId = a.Id;
+        insert c;       
+
+        npe03__Recurring_Donation__c r1 = new npe03__Recurring_Donation__c();
+        r1.Name = 'test';
+        r1.npe03__Installments__c = 0;
+        r1.npe03__Contact__c = c.Id;
+        r1.npe03__Amount__c = 100;
+        r1.npe03__Date_Established__c = date.newinstance(1970,6,12);
+        r1.npe03__Open_Ended_Status__c = system.label.npe03.RecurringDonationOpenStatus;
+        r1.npe03__Next_Payment_Date__c = system.today().toStartOfMonth();
+        r1.OwnerId = system.Userinfo.getUserId();
+        insert r1;        
+        
+        Opportunity o = new Opportunity();
+        string closedstage = [select masterlabel from opportunitystage where isActive = true and iswon = true and isClosed = true limit 1].masterlabel;
+        o.StageName = closedstage;
+        o.CloseDate = system.today();
+        o.Amount = 50;
+        o.AccountId = a.Id;
+        o.Name = 'test';
+        o.npe03__Recurring_Donation__c = r1.Id;
+        RD_ProcessControl.hasRun = false;
+        Test.startTest();        
+        insert o;
+        Test.stopTest();
+
+        npe03__Recurring_Donation__c rd = [select npe03__Paid_Amount__c from npe03__Recurring_Donation__c where id = :r1.id];    
+
+        system.assertEquals(50, rd.npe03__Paid_Amount__c);
     }
     
     //test closing an opportunity for an open recurring donation

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -111,7 +111,7 @@ public without sharing class TDTM_DefaultConfig {
         // RecurringDonations on Opportunity
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
               Class__c = 'RD_RecurringDonations_Opp_TDTM', Load_Order__c = 1, Object__c = 'Opportunity', 
-              Trigger_Action__c = 'AfterUpdate'));
+              Trigger_Action__c = 'AfterUpdate;AfterInsert'));
 
         // RecurringDonations on RecurringDonations
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 


### PR DESCRIPTION
…pp is inserted and prevents Divide by 0 error if Refresh Opps button is clicked when number of installments is equal to number of paid installments.

# Warning
# Info
Users/Admins will have to update the Trigger_Handler__c record for the RD_RecurringDonations_Opp_TDTM class to include the 'AfterInsert' trigger action.
# Issues 
Does not change how the npe03__Recurring_Donation__c. npe03__Installment_Amount__c field is calculated. So open ended recurring donations with Installments equal to Total Paid Installments will show an Installment Amount equal to the Amount, even if Paid Amount is greater than 0. 

Fixed #1595 