### PR TITLE
Feature/332 del contac

### DIFF
--- a/ApexDocContent/Contacts.htm
+++ b/ApexDocContent/Contacts.htm
@@ -1,0 +1,22 @@
+<html>
+	<body>
+		<h2>Contacts Classes</h2>
+		<p>NPSP Contacts functionality is made up of these components:</p>
+		<ul>
+			<li>Contact Delete Override</li>
+			<li>Do Not Contact</li>
+		</ul>
+	
+		<p>The classes involved with Contact Delete Override include:</p>
+		<ul>
+			<li>CON_DeleteContactOverride_CTRL</li>
+			<li>CON_DeleteContactOverride_TEST</li>
+		</ul>
+	
+		<p>The classes involved with Do Not Contact include:</p>
+		<ul>
+			<li>CON_DoNotContact_TDTM</li>
+			<li>CON_DoNotContact_TEST</li>
+		</ul>	
+	</body>
+</html>

--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -80,7 +80,8 @@ public with sharing class ALLO_ManageAllocations_CTRL {
             parentId = String.escapeSingleQuotes(params.get('opp'));
             opp = [SELECT Id, Name, Amount FROM Opportunity WHERE Id = :parentId];
             //only Opportunities have parent amounts and enforce being below this amount
-            parentAmount = opp.Amount;
+            if (opp.Amount!=null) 
+                parentAmount = opp.Amount;
         } else if (params.containsKey('cam')) {
             parentId = String.escapeSingleQuotes(params.get('cam'));
             cam = [SELECT Id, Name FROM Campaign WHERE Id = :parentId];

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -55,7 +55,9 @@ public with sharing class CON_DeleteContactOverride_CTRL {
     }
 
     /*******************************************************************************************************
-    * @description Standard controller constructor.
+    * @description Action method in Contact Delete Button override, handles deleting a contact and
+    * potentially its account if it is a system account (1:1, individual, or household) and is the last 
+    * contact in the account.
     * @return pageReference Redirects to the Contacts tab.
     */ 
     public pageReference processDelete() {

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -1,0 +1,84 @@
+/*
+    Copyright (c) 2014, Salesforce.com Foundation
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.com Foundation
+* @date 2015
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Overrides the contact Delete button, to avoid removing the contact from the recycle bin 
+*               if the deleted contact is the only member of their household.
+*/
+public with sharing class CON_DeleteContactOverride_CTRL {
+
+    /** @description The contact id of the record to delete. */
+	private final string conId;
+    private string retURL;
+
+    /*******************************************************************************************************
+    * @description Standard controller constructor.
+    */ 
+    public CON_DeleteContactOverride_CTRL(ApexPages.StandardController stdController) {
+        conId = stdController.getId();
+        retURL = ApexPages.currentPage().getParameters().get('returl');
+        
+        //if we don't have a return URL, go back to Contacts home.
+        if (string.isBlank(retURL)) {
+            retURL = '/003/o';
+        }
+    }
+
+    /*******************************************************************************************************
+    * @description Standard controller constructor.
+    * @return pageReference Redirects to the Contacts tab.
+    */ 
+    public pageReference processDelete() {
+        Contact queryContact = [SELECT Id, AccountId, Account.npe01__SYSTEMIsIndividual__c FROM Contact WHERE Id = :conId];
+        string accId = queryContact.AccountId;
+        integer contactsInHousehold = [SELECT Count(id) FROM Contact WHERE AccountId = :accId].size();
+
+        //This contact is alone in a system account, delete the system account and allow the cascading
+        //delete to remove the contact
+        if (contactsInHousehold==1 && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
+            Account accForDelete = new Account(id=accId);
+            delete accForDelete;
+
+            //if we were returning to the account we just deleted, go back to contacts home
+            if (retURL.contains(accId.substring(0,15))) {
+                retURL = '/003/o';
+            }
+        } else {
+            delete queryContact;
+        }
+
+        PageReference redirect = new PageReference(retURL);
+        redirect.setRedirect(true);
+        return redirect;
+    }
+}

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls-meta.xml
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
         <minorNumber>0</minorNumber>

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls-meta.xml
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>31.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_DeleteContactOverride_TEST.cls
+++ b/src/classes/CON_DeleteContactOverride_TEST.cls
@@ -1,0 +1,150 @@
+/*
+    Copyright (c) 2014, Salesforce.com Foundation
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.com Foundation
+* @date 2015
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Test class for Contact delete override.
+*/
+@isTest
+private class CON_DeleteContactOverride_TEST {
+    /*********************************************************************************************************
+    * @description if you only want to run one test in this class, fill in its name here.
+    * if you want to run all tests, then use '*'
+    */
+    private static string strTestOnly = '*';
+
+    /*******************************************************************************************************
+    * @description Deletes contact in the 1:1 account model. Verifies that contact is marked is in the 
+    * recycle bin and not hard deleted.
+    */
+    @isTest static void deleteOneToOne() {
+        if (strTestOnly != '*' && strTestOnly != 'deleteOneToOne') return;
+        
+        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_and_Orgs_Settings__c (
+                npe01__Account_Processor__c = CAO_Constants.ONE_TO_ONE_PROCESSOR
+            )
+        );
+        Contact con = new Contact(LastName='foo');
+        insert con;
+        
+        list<Contact> queryCon = [SELECT Id, AccountId, Account.npe01__SYSTEMIsIndividual__c FROM Contact WHERE Id = :con.id];
+        system.assertNotEquals(null, queryCon[0].AccountId, 'The contact should have an auto-created household.');
+        system.assert(queryCon[0].Account.npe01__SYSTEMIsIndividual__c, 'The household should have the system flag set.');
+
+        test.startTest();
+        CON_DeleteContactOverride_CTRL ctrl = new CON_DeleteContactOverride_CTRL(new ApexPages.StandardController(con));
+        ctrl.processDelete();
+        test.stopTest();
+
+        list<account> queryAcc = [SELECT Id, isDeleted FROM Account WHERE id = :querycon[0].AccountId ALL ROWS];
+        
+        system.assertEquals(1,queryAcc.size(),'There should be one deleted account.');
+        system.assert(queryacc[0].isDeleted,'Deleted flag should be set.');
+
+        queryCon = [SELECT Id, isDeleted FROM Contact WHERE id = :con.id ALL ROWS];
+
+        system.assertEquals(1,queryCon.size(),'There should be one deleted contact.');
+        system.assert(queryCon[0].isDeleted,'Deleted flag should be set.');
+    }
+    
+    /*******************************************************************************************************
+    * @description Deletes contact in the household account model that is alone in their household
+    * account. Verifies that contact is in the recycle bin and not hard deleted.
+    */
+    @isTest static void deleteAloneInHousehold() {
+        if (strTestOnly != '*' && strTestOnly != 'deleteAloneInHousehold') return;
+
+        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettings();
+
+        Contact con = new Contact(LastName='foo');
+        insert con;
+        
+        list<Contact> queryCon = [SELECT Id, AccountId, Account.npe01__SYSTEMIsIndividual__c FROM Contact WHERE Id = :con.id];
+        system.assertNotEquals(null, queryCon[0].AccountId, 'The contact should have an auto-created household.');
+        system.assert(queryCon[0].Account.npe01__SYSTEMIsIndividual__c, 'The household should have the system flag set.');
+
+        test.startTest();
+        CON_DeleteContactOverride_CTRL ctrl = new CON_DeleteContactOverride_CTRL(new ApexPages.StandardController(con));
+        ctrl.processDelete();
+        test.stopTest();
+
+        list<account> queryAcc = [SELECT Id, isDeleted FROM Account WHERE id = :querycon[0].AccountId ALL ROWS];
+        
+        system.assertEquals(1,queryAcc.size(),'There should be one deleted account.');
+        system.assert(queryacc[0].isDeleted,'Deleted flag should be set.');
+
+        queryCon = [SELECT Id, isDeleted FROM Contact WHERE id = :con.id ALL ROWS];
+
+        system.assertEquals(1,queryCon.size(),'There should be one deleted contact.');
+        system.assert(queryCon[0].isDeleted,'Deleted flag should be set.');
+
+    }
+
+    /*******************************************************************************************************
+    * @description Deletes contact in the household account model that is alone in their household \
+    * account. Verifies that contact is in the recycle bin and not hard deleted.
+    */
+    @isTest static void deleteSeveralInHousehold() {
+        if (strTestOnly != '*' && strTestOnly != 'deleteSeveralInHousehold') return;
+
+        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettings();
+
+        Contact con = new Contact(LastName='foo');
+        insert con;
+        
+        list<Contact> queryCon = [SELECT Id, AccountId, Account.npe01__SYSTEMIsIndividual__c FROM Contact WHERE Id = :con.id];
+        system.assertNotEquals(null, queryCon[0].AccountId, 'The contact should have an auto-created household.');
+        system.assert(queryCon[0].Account.npe01__SYSTEMIsIndividual__c, 'The household should have the system flag set.');
+
+        id householdId = queryCon[0].AccountId;
+
+        //add a second contact to the household
+        Contact con2 = new Contact(Lastname='foo2', AccountId=householdId);
+        insert con2;
+
+        test.startTest();
+        CON_DeleteContactOverride_CTRL ctrl = new CON_DeleteContactOverride_CTRL(new ApexPages.StandardController(con));
+        ctrl.processDelete();
+        test.stopTest();
+
+        list<account> queryAcc = [SELECT Id, isDeleted FROM Account WHERE id = :householdId ALL ROWS];
+        
+        system.assertEquals(1,queryAcc.size(),'There should be one account.');
+        system.assert(queryacc[0].isDeleted,'Deleted flag should not be set.');
+
+        queryCon = [SELECT Id, isDeleted FROM Contact WHERE id = :con.id ALL ROWS];
+
+        system.assertEquals(1,queryCon.size(),'There should be one deleted contact.');
+        system.assert(queryCon[0].isDeleted,'Deleted flag should be set.');
+    }
+}

--- a/src/classes/CON_DeleteContactOverride_TEST.cls-meta.xml
+++ b/src/classes/CON_DeleteContactOverride_TEST.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
         <minorNumber>0</minorNumber>

--- a/src/classes/CON_DeleteContactOverride_TEST.cls-meta.xml
+++ b/src/classes/CON_DeleteContactOverride_TEST.cls-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>31.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CON_DoNotContact_TDTM.cls
+++ b/src/classes/CON_DoNotContact_TDTM.cls
@@ -30,6 +30,8 @@
 /**
 * @author Salesforce.com Foundation
 * @date 2015
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
 * @description Handles changes to the deceased and do not contact fields on Contact.
 */
 public class CON_DoNotContact_TDTM extends TDTM_Runnable {

--- a/src/classes/CON_DoNotContact_TEST.cls
+++ b/src/classes/CON_DoNotContact_TEST.cls
@@ -1,6 +1,47 @@
+/*
+    Copyright (c) 2015, Salesforce.com Foundation
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.com Foundation
+* @date 2015
+* @group Contacts
+* @group-content ../../ApexDocContent/Contacts.htm
+* @description Handles changes to the deceased and do not contact fields on Contact.
+*/
 @isTest
 private class CON_DoNotContact_TEST {
 
+    /*******************************************************************************************************
+    * @description Marks a contact as Deceased, verifies DoNotCall, HasOptedOutOfEmail, and naming 
+    * exclusions are set. Removes deceased flag, verifies DoNotCall, HasOptedOutOfEmail, and naming 
+    * exclusion have been removed.
+    */
     static testMethod void testDeceased() {
         UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c (npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR));    
         
@@ -32,6 +73,10 @@ private class CON_DoNotContact_TEST {
         system.assert(!queryCon[0].HasOptedOutOfEmail, 'Contact should not be opted out of email.');
     }
 
+    /*******************************************************************************************************
+    * @description Marks a contact as Do Not Contact, verifies DoNotCall and HasOptedOutOfEmail are set.
+    * Removes Do Not Contact flag, verifies DoNotCall and HasOptedOutOfEmail are no longer set.
+    */
     static testMethod void testDoNotContact() {
         UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c (npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR));
         

--- a/src/classes/OPP_PrimaryContact_BATCH.cls-meta.xml
+++ b/src/classes/OPP_PrimaryContact_BATCH.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RD_InstallScript_BATCH.cls-meta.xml
+++ b/src/classes/RD_InstallScript_BATCH.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
         <minorNumber>1</minorNumber>

--- a/src/package.xml
+++ b/src/package.xml
@@ -64,6 +64,8 @@
         <members>CON_ContactMerge_CTRL</members>
         <members>CON_ContactMerge_TDTM</members>
         <members>CON_ContactMerge_TEST</members>
+        <members>CON_DeleteContactOverride_CTRL</members>
+        <members>CON_DeleteContactOverride_TEST</members>
         <members>CON_DoNotContact_TDTM</members>
         <members>CON_DoNotContact_TEST</members>
         <members>ERR_AddError_TEST</members>
@@ -231,6 +233,7 @@
         <members>BDI_DataImport</members>
         <members>CONV_Account_Conversion</members>
         <members>CON_ContactMerge</members>
+        <members>CON_DeleteContactOverride</members>
         <members>HH_CampaignDedupeBTN</members>
         <members>HH_ManageHHAccount</members>
         <members>HH_ManageHousehold</members>

--- a/src/pages/CON_DeleteContactOverride.page
+++ b/src/pages/CON_DeleteContactOverride.page
@@ -1,0 +1,2 @@
+<apex:page standardController="Contact" extensions="CON_DeleteContactOverride_CTRL" action="{!processDelete}">
+</apex:page>

--- a/src/pages/CON_DeleteContactOverride.page-meta.xml
+++ b/src/pages/CON_DeleteContactOverride.page-meta.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>31.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>CON_DeleteContactOverride</label>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npe03</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
+        <namespace>npe4</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
+        <namespace>npe5</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npo02</namespace>
+    </packageVersions>
+</ApexPage>

--- a/src/pages/CON_DeleteContactOverride.page-meta.xml
+++ b/src/pages/CON_DeleteContactOverride.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>CON_DeleteContactOverride</label>

--- a/src/pages/OPP_SendAcknowledgmentBTN.page-meta.xml
+++ b/src/pages/OPP_SendAcknowledgmentBTN.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>OPP_SendAcknowledgmentBTN</label>


### PR DESCRIPTION
# Warning
# Info
- The Contact delete button override should be updated to use the CON_DeleteContactOverride visualforce page: Setup > Build > Customize > Contacts > Buttons, Links, and Actions > Click 'Edit' next to Delete > Select 'Visualforce Page' and choose CON_DeleteContactOverride.

# Issues
Fixes #332 
Fixes #1678