### PR TITLE
Feature/1698 relationship query after delete

### DIFF
--- a/src/classes/REL_Relationships_Con_TDTM.cls
+++ b/src/classes/REL_Relationships_Con_TDTM.cls
@@ -95,8 +95,9 @@ public class REL_Relationships_Con_TDTM extends TDTM_Runnable {
             }
         }
         
-        if(triggerAction == TDTM_Runnable.Action.afterDelete) {
-            DmlWrapper w = deleteEmptyRelationships();
+        if(triggerAction == TDTM_Runnable.Action.AfterDelete) {
+            System.debug('*** after delete oldMap: ' + oldMap);
+            DmlWrapper w = deleteEmptyRelationships(oldMap);
             dmlWrapper.objectsToDelete.addAll(w.objectsToDelete);
         }
         
@@ -135,13 +136,18 @@ public class REL_Relationships_Con_TDTM extends TDTM_Runnable {
     
     /*******************************************************************************************************
     * @description Deletes Relationships when a Contact is deleted
+    * @param contacts the Map of Contacts from trigger oldMap. 
     * @return dmlWrapper Relationships to delete.
     ********************************************************************************************************/
-    public static DmlWrapper deleteEmptyRelationships() {
+    public static DmlWrapper deleteEmptyRelationships(Map<Id, Contact> contacts) {
         DmlWrapper dmlWrapper = new DmlWrapper();
         List<SObject> relationshipsToDelete = new List<SObject>();
-        for (npe4__Relationship__c r : [Select Id from npe4__Relationship__c where npe4__RelatedContact__c = null]) {
-            relationshipsToDelete.add(new npe4__Relationship__c(Id = r.Id));
+
+        // The Contacts primary Relationships have already been cascade deleted in Contact After Delete context
+        // Using ALL ROWS returns them in the query used to gather the mirror Relationships to be deleted 
+        for (npe4__Relationship__c r : [Select Id, npe4__ReciprocalRelationship__c from npe4__Relationship__c 
+            where npe4__Contact__c in :contacts.keySet() ALL ROWS]){
+            relationshipsToDelete.add(new npe4__Relationship__c(Id = r.npe4__ReciprocalRelationship__c));
         }
         if ( relationshipsToDelete.size() > 0 ) {
             dmlWrapper.objectsToDelete.addAll(relationshipsToDelete);

--- a/src/classes/REL_Relationships_Con_TDTM.cls
+++ b/src/classes/REL_Relationships_Con_TDTM.cls
@@ -96,7 +96,6 @@ public class REL_Relationships_Con_TDTM extends TDTM_Runnable {
         }
         
         if(triggerAction == TDTM_Runnable.Action.AfterDelete) {
-            System.debug('*** after delete oldMap: ' + oldMap);
             DmlWrapper w = deleteEmptyRelationships(oldMap);
             dmlWrapper.objectsToDelete.addAll(w.objectsToDelete);
         }


### PR DESCRIPTION
Hi @davidhabib and @njjc,

@njjc - this update uses a slightly different solution. Instead of gathering the Contact Ids of the deleted Contacts and querying for Relationships that have that Contact value in the Related Contact field, I realized we can use the npe4__ReciprocalRelationship__c field to identify the mirror Relationships that need to be deleted.  It is still using 'ALL ROWS' in the query, which does allow us to query the Relationships after they have already been cascade deleted in the Contact delete process.  We could switch this to be a Before Delete action, but this solution does not require modification to the standard trigger configuration for the REL_Relationships_Con_TDTM class.  If you would still prefer to change this to happen Before Delete, let me know and I can try that. 

@davidhabib I'm re-submitting in a feature branch.  Sorry for originally submitting the pull directly to dev.  Still getting the hang of Git/Github!  I'm happy to write further tests to cover/assert this, but it is fully covered by the tests in the [REL_Relationships_TEST](https://github.com/SalesforceFoundation/Cumulus/blob/dev/src/classes/REL_Relationships_TEST.cls) class, specifically [this one](https://github.com/SalesforceFoundation/Cumulus/blob/dev/src/classes/REL_Relationships_TEST.cls).  Let me know if you'd like me to add any more.