### PR TITLE
Handle setting RecordType visibility and defaults in deployUpdatedAdminProfile

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -86,4 +86,35 @@ If you are on a unix based system, the following commands should work:
         </if>
     </target>
 
+    <!-- Update the Admin.profile to grant all FLS permissions -->
+    <target name="preDeployUpdatedAdminProfile">
+
+        <!-- Strip the existing recordTypeVisibilties -->
+        <xslt 
+            in="admin_profile/profiles/Admin.profile"
+            out="admin_profile/profiles/Admin.profile.no_rt"
+            style="${basedir}/lib/remove_recordtype_visibilities.xsl" />
+        <move file="admin_profile/profiles/Admin.profile.no_rt" tofile="admin_profile/profiles/Admin.profile" />
+
+        <!-- Add the record types -->
+
+        <!-- Account.HH_Account (default) -->
+        <replaceregexp 
+            file="admin_profile/profiles/Admin.profile" 
+            match="(${lt}tabVisibilities>)" 
+            replace="${lt}recordTypeVisibilities>${line.separator}      ${lt}default>true${lt}/default>${line.separator}      ${lt}personAccountDefault>true${lt}/personAccountDefault>${line.separator}      ${lt}recordType>Account.HH_Account${lt}/recordType>${line.separator}      ${lt}visible>true${lt}/visible>${line.separator}    ${lt}/recordTypeVisibilities>${line.separator}    \1" />
+
+        <!-- Account.Organization (default) -->
+        <replaceregexp 
+            file="admin_profile/profiles/Admin.profile" 
+            match="(${lt}tabVisibilities>)" 
+            replace="${lt}recordTypeVisibilities>${line.separator}      ${lt}default>false${lt}/default>${line.separator}      ${lt}personAccountDefault>false${lt}/personAccountDefault>${line.separator}      ${lt}recordType>Account.Organization${lt}/recordType>${line.separator}      ${lt}visible>true${lt}/visible>${line.separator}    ${lt}/recordTypeVisibilities>${line.separator}    \1" />
+
+        <!-- Opportunity.NPSP_Default (default) -->
+        <replaceregexp 
+            file="admin_profile/profiles/Admin.profile" 
+            match="(${lt}tabVisibilities>)" 
+            replace="${lt}recordTypeVisibilities>${line.separator}      ${lt}default>true${lt}/default>${line.separator}      ${lt}personAccountDefault>true${lt}/personAccountDefault>${line.separator}      ${lt}recordType>Opportunity.NPSP_Default${lt}/recordType>${line.separator}      ${lt}visible>true${lt}/visible>${line.separator}    ${lt}/recordTypeVisibilities>${line.separator}    \1" />
+        
+    </target>
 </project>

--- a/lib/remove_recordtype_visibilities.xsl
+++ b/lib/remove_recordtype_visibilities.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:sf="http://soap.sforce.com/2006/04/metadata" xmlns="http://soap.sforce.com/2006/04/metadata"  exclude-result-prefixes="sf">
+
+
+<xsl:template match="@* | node()">
+  <xsl:copy>
+    <xsl:apply-templates select="@* | node()"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="sf:recordTypeVisibilities">
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Added override for ant target preDeployUpdatedAdminProfile which also sets up the Account and Opportunity record types as visible and default (where appropriate) for the Admin.profile in addition to granting all FLS permissions

This change affects the build scripts only and has no implications on any of the package metadata.  It is used to help spin up LDV orgs.