### PR TITLE
Feature/1837 opp naming action

### DIFF
--- a/src/classes/BDI_DataImport_TEST2.cls-meta.xml
+++ b/src/classes/BDI_DataImport_TEST2.cls-meta.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>33.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_ContactMergeTDTM_TEST.cls-meta.xml
+++ b/src/classes/CON_ContactMergeTDTM_TEST.cls-meta.xml
@@ -4,11 +4,6 @@
     <packageVersions>
         <majorNumber>3</majorNumber>
         <minorNumber>0</minorNumber>
-        <namespace>npe4</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>3</majorNumber>
-        <minorNumber>0</minorNumber>
         <namespace>npe5</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/CON_ContactMergeTDTM_TEST2.cls-meta.xml
+++ b/src/classes/CON_ContactMergeTDTM_TEST2.cls-meta.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>33.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>0</minorNumber>
+        <namespace>npe4</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npo02</namespace>
+    </packageVersions>
+    <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_ContactMerge_TEST.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TEST.cls-meta.xml
@@ -6,10 +6,5 @@
         <minorNumber>1</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
-    <packageVersions>
-        <majorNumber>3</majorNumber>
-        <minorNumber>1</minorNumber>
-        <namespace>npo02</namespace>
-    </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CON_ContactMerge_TEST2.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TEST2.cls-meta.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>33.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npo02</namespace>
+    </packageVersions>
+    <status>Active</status>
 </ApexClass>

--- a/src/classes/OPP_OpportunityNaming_Action.cls
+++ b/src/classes/OPP_OpportunityNaming_Action.cls
@@ -3,7 +3,7 @@
 * @date 2015 (12.25)
 * @group Opportunity
 * @group-content ../../ApexDocContent/Opportunity.htm
-* @description Provides an action to generate Opportunitu names for lists of opps
+* @description Provides an action to generate Opportunity names for lists of opps
 */
 global class OPP_OpportunityNaming_Action {
     /*******************************************************************************************************
@@ -13,7 +13,7 @@ global class OPP_OpportunityNaming_Action {
     */
 
 	@InvocableMethod(label='Rename Opportunities' description='Runs automatic opportunity naming for the selected opportunity IDs.')
-  	global static void renameHouseholds(List<ID> oppIds) {
+  	global static void renameOpportunities(List<ID> oppIds) {
     	Savepoint sp = Database.setSavepoint();
         try {
             List<Opportunity> oppsToUpdate = [SELECT Id FROM Opportunity WHERE Id IN :oppIds];

--- a/src/classes/OPP_OpportunityNaming_Action.cls
+++ b/src/classes/OPP_OpportunityNaming_Action.cls
@@ -1,0 +1,27 @@
+/**
+* @author Christian Carter @cdcarter
+* @date 2015 (12.25)
+* @group Opportunity
+* @group-content ../../ApexDocContent/Opportunity.htm
+* @description Provides an action to generate Opportunitu names for lists of opps
+*/
+global class OPP_OpportunityNaming_Action {
+    /*******************************************************************************************************
+    * @description invocable method to update the opportunity names for the specified Opps
+    * @param oppIds the list of opportunity IDs 
+    * @return void
+    */
+
+	@InvocableMethod(label='Rename Opportunities' description='Runs automatic opportunity naming for the selected opportunity IDs.')
+  	global static void renameHouseholds(List<ID> oppIds) {
+    	Savepoint sp = Database.setSavepoint();
+        try {
+            List<Opportunity> oppsToUpdate = [SELECT Id FROM Opportunity WHERE Id IN :oppIds];
+            oppsToUpdate = OPP_OpportunityNaming.getOppNamesAfterInsert(oppsToUpdate); 
+            update oppsToUpdate;
+        } catch(Exception e) {
+        	Database.rollback(sp);
+        	ERR_Handler.processError(e, ERR_Handler_API.Context.OPP);
+        }      
+  	}
+}

--- a/src/classes/OPP_OpportunityNaming_Action.cls-meta.xml
+++ b/src/classes/OPP_OpportunityNaming_Action.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>35.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/OPP_OpportunityNaming_TEST.cls
+++ b/src/classes/OPP_OpportunityNaming_TEST.cls
@@ -117,6 +117,63 @@ private class OPP_OpportunityNaming_TEST
         system.assertEquals(oppName, queryOpp[0].Name, 'The name should be recalculated after clicking the button.');
 
     }
+    
+    /*******************************************************************************************************
+    * @description Creates an opportunity name setting and an opportunity, verifies name is calculated and
+    * dates with a blank naming scheme use a default international format.
+    * Modifies the value of a field and runs the invocable action, verifies rename happened correctly.
+    ********************************************************************************************************/
+    @isTest
+    static void testAction() {
+        if (strTestOnly != '*' && strTestOnly != 'testAction') return;
+
+        Opportunity_Naming_Settings__c ons = new Opportunity_Naming_Settings__c(
+            Name = 'foo',
+            Opportunity_Name_Format__c = '{!Account.Name} {!Contact.Name} {!CloseDate} {!RecordType.Name}',
+            Attribution__c = Label.oppNamingBoth
+        );
+        if (hasActiveRecType())
+            ons.Opportunity_Record_Types__c = UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
+        insert ons;
+
+        Account acc = new Account(Name='accname');
+        insert acc;
+
+        Contact con = new Contact(LastName='conname');
+        insert con;
+
+        Opportunity opp = new Opportunity(
+            AccountId = acc.id,
+            StageName = UTIL_UnitTestData_TEST.getClosedWonStage(),
+            Name='temp',
+            Amount=8,
+            CloseDate = Date.newInstance(2000, 1, 1),
+            Primary_Contact__c = con.id
+        );
+        if (hasActiveRecType())
+            opp.RecordTypeId = UTIL_RecordTypes.GetRecordTypeId('Opportunity', UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity'));
+        insert opp;
+
+        list<Opportunity> queryOpp = [SELECT Name FROM Opportunity WHERE Id = :opp.id];
+        string oppName = 'accname conname 2000.01.01';
+        if (hasActiveRecType())
+            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
+        system.assertEquals(oppName, queryOpp[0].Name, 'The name should be calculated based on the setting.');
+
+        acc.Name = 'newname';
+        update acc;
+
+		Test.startTest();
+        OPP_OpportunityNaming_Action.renameOpportunities(new List<Id>{opp.Id});
+        Test.stopTest();
+
+        queryOpp = [SELECT Name FROM Opportunity WHERE Id = :opp.id];
+        oppname = 'newname conname 2000.01.01';
+        if (hasActiveRecType())
+            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
+        system.assertEquals(oppName, queryOpp[0].Name, 'The name should be recalculated after running the Invocable Method`.');
+
+    }
 
     /*******************************************************************************************************
     * @description Creates an opportunity name setting and an opportunity with a missing field and related

--- a/src/classes/PMT_PaymentCreator_BATCH.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator_BATCH.cls-meta.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>34.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/RD_RecurringDonations_TEST2.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_TEST2.cls-meta.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>33.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>2</minorNumber>
+        <namespace>npe03</namespace>
+    </packageVersions>
+    <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_PanelHealthCheck_TEST.cls-meta.xml
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls-meta.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>33.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
     <status>Active</status>
 </ApexClass>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -3522,7 +3522,7 @@ Once the process is 100% complete, you can safely leave or refresh this page.</v
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpRDAddCampaign</shortDescription>
-        <value>If selected, adds the campaign that you’ve specified for the Recurring Donation to all related (i.e. “child”) opportunities. If this option is not selected, the campaign appears on the Recurring Donation’s first opportunity only.</value>
+        <value>If selected, adds the campaign that youâve specified for the Recurring Donation to all related (i.e. âchildâ) opportunities. If this option is not selected, the campaign appears on the Recurring Donationâs first opportunity only.</value>
     </labels>
     <labels>
         <fullName>stgHelpRDDisableScheduling</fullName>
@@ -3530,7 +3530,7 @@ Once the process is 100% complete, you can safely leave or refresh this page.</v
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpRDDisableScheduling</shortDescription>
-        <value>Prevents the scheduling of the nightly update to Recurring Donations. You’ll need to remove any existing scheduled jobs through Setup | Monitoring | Scheduled Jobs.</value>
+        <value>Prevents the scheduling of the nightly update to Recurring Donations. Youâll need to remove any existing scheduled jobs through Setup | Monitoring | Scheduled Jobs.</value>
     </labels>
     <labels>
         <fullName>stgHelpRDFailures</fullName>
@@ -3594,7 +3594,7 @@ Once the process is 100% complete, you can safely leave or refresh this page.</v
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpRDOppForecastMonths</shortDescription>
-        <value>Number of months’ worth of open opportunities created for Open-Ended Recurring Donations. The default is 12, so after every month, Salesforce creates another month’s worth of open opportunities (i.e., the total months’ worth of open opportunities is always 12).</value>
+        <value>Number of monthsâ worth of open opportunities created for Open-Ended Recurring Donations. The default is 12, so after every month, Salesforce creates another monthâs worth of open opportunities (i.e., the total monthsâ worth of open opportunities is always 12).</value>
     </labels>
     <labels>
         <fullName>stgHelpRDOppRT</fullName>
@@ -3602,7 +3602,7 @@ Once the process is 100% complete, you can safely leave or refresh this page.</v
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpRDOppRT</shortDescription>
-        <value>The opportunity record type assigned to the Recurring Donation’s child opportunities.</value>
+        <value>The opportunity record type assigned to the Recurring Donationâs child opportunities.</value>
     </labels>
     <labels>
         <fullName>stgHelpRDPeriodFrequency</fullName>

--- a/src/objects/Batch__c.object
+++ b/src/objects/Batch__c.object
@@ -190,8 +190,8 @@
     <pluralLabel>Batches</pluralLabel>
     <searchLayouts>
         <excludedStandardButtons>New</excludedStandardButtons>
-        <excludedStandardButtons>Accept</excludedStandardButtons>
         <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
+        <excludedStandardButtons>Accept</excludedStandardButtons>
     </searchLayouts>
     <sharingModel>ReadWrite</sharingModel>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1172,10 +1172,10 @@
         <name>CustomLabel</name>
     </types>
     <types>
-        <name>CustomLabel</name>
+        <members>CustomLabels</members>
+        <name>CustomLabels</name>
     </types>
     <types>
-        <members>Account</members>
         <members>Addr_Verification_Settings__c</members>
         <members>Address_Verification_Settings__c</members>
         <members>Address__c</members>
@@ -1183,7 +1183,6 @@
         <members>Allocations_Settings__c</members>
         <members>Batch_Data_Entry_Settings__c</members>
         <members>Batch__c</members>
-        <members>Contact</members>
         <members>DataImport__c</members>
         <members>Data_Import_Settings__c</members>
         <members>Error_Settings__c</members>
@@ -1192,8 +1191,6 @@
         <members>General_Accounting_Unit__c</members>
         <members>Grant_Deadline__c</members>
         <members>Household_Naming_Settings__c</members>
-        <members>Lead</members>
-        <members>Opportunity</members>
         <members>Opportunity_Naming_Settings__c</members>
         <members>Schedulable__c</members>
         <members>Trigger_Handler__c</members>
@@ -1279,9 +1276,6 @@
         <name>MatchingRule</name>
     </types>
     <types>
-        <name>MatchingRule</name>
-    </types>
-    <types>
         <members>Account.New_Address</members>
         <members>Account.New_Affiliation</members>
         <members>Account.Quick_Household_Update</members>
@@ -1344,10 +1338,6 @@
         <members>Opportunity.Email_Acknowledgments</members>
         <members>Opportunity.Refresh_Name</members>
         <name>WebLink</name>
-    </types>
-    <types>
-        <members>Opportunity</members>
-        <name>Workflow</name>
     </types>
     <types>
         <members>Opportunity.Opportunity_Email_Acknowledgment</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -111,6 +111,7 @@
         <members>OPP_OpportunityContactRoles_TEST</members>
         <members>OPP_OpportunityNaming</members>
         <members>OPP_OpportunityNamingBTN_CTRL</members>
+        <members>OPP_OpportunityNaming_Action</members>
         <members>OPP_OpportunityNaming_BATCH</members>
         <members>OPP_OpportunityNaming_TDTM</members>
         <members>OPP_OpportunityNaming_TEST</members>

--- a/src/reports/NPSP_Health_Check-meta.xml
+++ b/src/reports/NPSP_Health_Check-meta.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ReportFolder xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accessType>Hidden</accessType>
     <name>NPSP Health Check</name>
+    <publicFolderAccess>ReadWrite</publicFolderAccess>
 </ReportFolder>


### PR DESCRIPTION
My notes to reviewer here are very rinse-and-repeat-y from the last one.

Once again, used the Action naming convention.

Once again, labels got all weird via the contrib tool, so only my changes to OPP_OpportunityNaming_Action and OPP_OpportunityNaming_TEST should be merged.

The test class is getting repetitive, and if you don't want to merge the tests as is, I would understand that. The class is just a minor wrapper around the tested code, so the test method provided is purely for coverage reasons. As more global interfaces to NPSP functionality are created, I'd love some guidance on what replication in tests is a-ok/what should be split out a little bit/where real love is needed.

# Contribution Info

This external contribution was submitted by @cdcarter and Fixes #1837 

# Changes

Adds a global @InvocableMethod class OPP_OpportunityNaming_Action to provide a method to force opportunity renaming programmatically (via Apex, Flow, or PB).
