### PR TITLE
Feature/1360 hh naming customfield

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -86,6 +86,9 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             map<Id, Contact> mapContactIdContactOwnerChange = new map<Id, Contact>();
             map<Id, Id> mapContactIdAccountIdOldMoveOpps = new map<Id, Id>();
             map<Id, Id> mapContactIdAccountIdNewMoveOpps = new map<Id, Id>();
+            HH_INaming iNaming = new HH_NameSpec();
+            Set<String> hhNamingFields = iNaming.setHouseholdNameFieldsOnContact();
+
             
             if (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) {                    
                 // need to query account fields we need to look at
@@ -102,6 +105,14 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                     'OtherStreet, OtherCity, OtherState, OtherPostalCode, OtherCountry, OtherLatitude, OtherLongitude, '; 
                 if (ADDR_Addresses_TDTM.isStateCountryPicklistsEnabled)
                     strSoql += 'MailingCountryCode, MailingStateCode, OtherCountryCode, OtherStateCode, ';
+                
+                if (hhNamingFields.size() > 0) {
+                  for (String hhNameField : hhNamingFields) {
+                    if (!strSoql.containsIgnoreCase(hhNameField))
+                      strSoql += hhNameField + ',';
+                  }
+                }
+
                 strSoql += 'Phone, Fax from Contact where Id IN :contacts';
                 contacts = database.query(strSoql);
             }        
@@ -257,7 +268,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                             }
                                                                                  
                            // HH Account didn't change, but it still might need renaming
-                        } else if (c.npe01__Organization_Type__c == CAO_Constants.HH_ACCOUNT_TYPE && needsHHAccountRename(c, oldContacts[i])) {
+                        } else if (c.npe01__Organization_Type__c == CAO_Constants.HH_ACCOUNT_TYPE && needsHHAccountRename(hhNamingFields, c, oldContacts[i])) {
                            listAccountIdHHToRename.add(c.AccountId);    
                         }  
                         
@@ -761,25 +772,33 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
     }
  
     /*******************************************************************************************************
-    * @description returns whether changes in the contact require a rename of a HH Account 
+    * @description returns whether changes in the contact require a rename of a HH Account
+    * @param hhNamingFields the set of fields used in the namespec
     * @param conNew the new version of the Contact
     * @param conOld the old version of the Contact
     * @return boolean
-    */ 
-    private boolean needsHHAccountRename(Contact conNew, Contact conOld) {          
+    */
+    private boolean needsHHAccountRename(Set<String> hhNamingFields,Contact conNew, Contact conOld) {
         if(conNew == null && conOld != null)
             return true;
         if(conNew != null && conOld == null)
             return true;
         if(conNew.FirstName == null) conNew.FirstName = '';
         if(conNew.LastName == null) conNew.LastName = '';
-        
-        return (!conNew.Firstname.equals(conOld.Firstname) ||
-                !conNew.Lastname.equals(conOld.Lastname) ||
-                conNew.Salutation != conOld.Salutation ||
-                conNew.npo02__Household_Naming_Order__c != conOld.npo02__Household_Naming_Order__c ||
-                conNew.npo02__Naming_Exclusions__c != conOld.npo02__Naming_Exclusions__c);
-    }   
+        // Get any fields being used in household naming so we can check if they've changed
+        Boolean needsRename = false;
+        for(String fieldName : hhNamingFields) {
+            if (String.valueOf(conNew.get(fieldName)) != String.valueOf(conOld.get(fieldName))) {
+                system.debug(fieldName + 'is different');
+                needsRename = true;
+            }
+        }
+        if (conNew.npo02__Household_Naming_Order__c != conOld.npo02__Household_Naming_Order__c ||
+                conNew.npo02__Naming_Exclusions__c != conOld.npo02__Naming_Exclusions__c) {
+                needsRename = true ;
+        }
+        return needsRename;
+    }
     
     /*******************************************************************************************************
     * @description returns whether changes in the contact require an address change in the HH Account 

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -130,6 +130,52 @@ private class ACCT_IndividualAccounts_TEST {
     	System.assertEquals(2, numOfAccs);
     }
     
+    private static testMethod void insertHHAccountContactTitleForRename() {
+        if (strTestOnly != '*' && strTestOnly != 'insertHHAccountContactTitleForRename') return;
+        insertContactTitleForRename(CAO_Constants.HH_ACCOUNT_PROCESSOR);
+    }
+    private static void insertContactTitleForRename(string strProcessor) {
+        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_and_Orgs_Settings__c (npe01__Account_Processor__c = strProcessor));
+
+        Household_Naming_Settings__c hhNamingSettingsForTests = UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+        	new Household_Naming_Settings__c(
+                Household_Name_Format__c = '{!LastName} Household',
+        		Formal_Greeting_Format__c = '{!{!Title} {!FirstName}} {!LastName}',
+                Informal_Greeting_Format__c = '{!{!FirstName}}',
+        		Name_Connector__c = label.npo02.HouseholdNameConnector,
+       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+        		Contact_Overrun_Count__c = 9,
+        		Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
+
+        CAO_Constants.setIndividualAccountForTests(CAO_Constants.INDIVIDUAL_ACCOUNT_NAME_FOR_TESTS);
+
+        Contact con = new Contact(
+            FirstName='Jack',
+            LastName='Ruby',
+            Title = 'Doctor',
+            npe01__WorkEmail__c = CAO_Constants.CONTACT_EMAIL_FOR_TESTS,
+            npe01__Preferred_Email__c = CAO_Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            npe01__WorkPhone__c = CAO_Constants.CONTACT_PHONE_FOR_TESTS,
+            npe01__PreferredPhone__c = CAO_Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );
+        Test.startTest();
+        insert con;
+        Test.stopTest();
+
+        Contact[] insertedContacts = [Select Account.npo02__Formal_Greeting__c, FirstName, LastName, AccountId  from Contact where id=:con.id];
+        system.assertEquals('Doctor Jack Ruby', insertedContacts[0].Account.npo02__Formal_Greeting__c);
+
+        con.Title = 'Hard Worker';
+        update con;
+
+        Contact[] updatedContacts = [Select Account.npo02__Formal_Greeting__c, FirstName, LastName, AccountId  from Contact where id=:con.id];
+        system.assertEquals('Hard Worker Jack Ruby', updatedContacts[0].Account.npo02__Formal_Greeting__c);
+    }
+
+    
     /*********************************************************************************************************
     * @description Create a contact, and change it to private, against all three account models.  
     */

--- a/src/classes/HH_Households_TDTM.cls
+++ b/src/classes/HH_Households_TDTM.cls
@@ -98,6 +98,8 @@ public without sharing class HH_Households_TDTM extends TDTM_Runnable {
             
                 	   
             npo02__Households_Settings__c currentHouseholdsSettings = UTIL_CustomSettingsFacade.getHouseholdsSettings();
+            HH_INaming iNaming = new HH_NameSpec();
+            Set<String> hhNamingFields = iNaming.setHouseholdNameFieldsOnContact();
             List<Contact> householdInserts = new List<Contact>();
             List<Contact> contactEvaluations = new List<Contact>();
             List<Contact> householdDeletes = new List<Contact>();
@@ -170,17 +172,16 @@ public without sharing class HH_Households_TDTM extends TDTM_Runnable {
                     else if (c.npo02__household__c == null && currentHouseholdsSettings.npo02__Household_Rules__c == HH_Households.ALL_INDIVIDUALS_PROCESSOR)
                         contactEvaluations.add(c);
                     
-                    if (newcmap.get(c.id).Salutation != oldcmap.get(c.id).Salutation)
-                        householdnameupdates.add(c.npo02__household__c);
-                    else if (newcmap.get(c.id).FirstName != oldcmap.get(c.id).Firstname )
-                        householdnameupdates.add(c.npo02__household__c);
-                    else if (newcmap.get(c.id).LastName != oldcmap.get(c.id).LastName)
-                        householdnameupdates.add(c.npo02__household__c);    
+                    for(String fieldName : hhNamingFields) {
+                        if (String.valueOf(newcmap.get(c.id).get(fieldName)) != String.valueOf(oldcmap.get(c.id).get(fieldName))) {
+                            householdnameupdates.add(c.npo02__household__c);
+                        }
+                    }
                     
                     //if they've changed households, we need to query the old
                     //household to see if anybody is left, if so, send it for renaming
                     //if not, delete it.
-                    else if (newcmap.get(c.id).npo02__household__c != oldcmap.get(c.id).npo02__household__c){
+                    if (newcmap.get(c.id).npo02__household__c != oldcmap.get(c.id).npo02__household__c){
                         householdnameupdates.add(c.npo02__household__c);
                         setHHIdToRollup.add(c.npo02__household__c);
                         if (oldHouseholdSize.get(oldcmap.get(c.id).npo02__household__c) > 0){

--- a/src/classes/HH_Households_TEST.cls
+++ b/src/classes/HH_Households_TEST.cls
@@ -107,6 +107,51 @@ public with sharing class HH_Households_TEST {
         system.assertEquals(1, createdContacts[0].npo02__household__r.Number_of_Household_Members__c);
     }
     
+
+    /*********************************************************************************************************
+    * @description Test insert and update a contact and see household object naming change
+    */
+    static testMethod void testNewAndUpdateContactWithHHNaming() {
+
+        npo02__Households_Settings__c householdSettingsForTests = UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(new npo02__Households_Settings__c (npo02__Household_Rules__c = HH_Households.ALL_PROCESSOR, npo02__Advanced_Household_Naming__c = true));
+
+        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c (npe01__Account_Processor__c = CAO_Constants.ONE_TO_ONE_PROCESSOR));
+
+        Household_Naming_Settings__c hhNamingSettingsForTests = UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+        	new Household_Naming_Settings__c(
+                Household_Name_Format__c = '{!LastName} Household',
+                Formal_Greeting_Format__c = '{!{!Title}} {!LastName}',
+                Informal_Greeting_Format__c = '{!{!FirstName}}',
+        		Name_Connector__c = label.npo02.HouseholdNameConnector,
+       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+        		Contact_Overrun_Count__c = 9,
+        		Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
+
+        Contact con = new Contact(
+            FirstName=CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName=CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,
+            Title= 'Doctor',
+            npe01__WorkEmail__c = CAO_Constants.CONTACT_EMAIL_FOR_TESTS,
+            npe01__Preferred_Email__c = CAO_Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
+            npe01__WorkPhone__c = CAO_Constants.CONTACT_PHONE_FOR_TESTS,
+            npe01__PreferredPhone__c = CAO_Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS
+        );
+        Test.startTest();
+        insert con;
+        Test.stopTest();
+
+        Contact[] createdContacts = [select npo02__household__r.npo02__Formal_Greeting__c  from Contact where id=:con.id];
+        system.assertEquals('Doctor '+CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,createdContacts[0].npo02__household__r.npo02__Formal_Greeting__c  );
+
+        con.Title = 'Handy Man';
+        update con;
+
+        Contact[] updatedContacts = [select npo02__household__r.npo02__Formal_Greeting__c  from Contact where id=:con.id];
+        system.assertEquals('Handy Man '+CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,updatedContacts[0].npo02__household__r.npo02__Formal_Greeting__c  );
+    }    
+    
     /*********************************************************************************************************
     * @description Tests insert private individual with all contacts processor
     */

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -755,4 +755,27 @@ public without sharing class UTIL_CustomSettingsFacade {
         orgRecurringDonationsSettings = recurringDonationsSettings;
         return recurringDonationsSettings;
     }
+    
+    /*******************************************************************************************************
+    * @description Creates instance of settings to use in tests. It does not insert it, but all other methods will see these settings
+    * as the configured settings.
+    * @parameter mySettings Settings instance with the values to set.
+    * @return Household_Naming_Settings__c The configured settings.
+    **/
+    public static Household_Naming_Settings__c getHouseholdNamingSettingsForTests(Household_Naming_Settings__c mySettings) {
+      if(householdNamingSettings == null)
+        householdNamingSettings = new Household_Naming_Settings__c();
+
+      householdNamingSettings.Household_Name_Format__c = mySettings.Household_Name_Format__c;
+      householdNamingSettings.Formal_Greeting_Format__c = mySettings.Formal_Greeting_Format__c;
+      householdNamingSettings.Informal_Greeting_Format__c = mySettings.Informal_Greeting_Format__c;
+      householdNamingSettings.Name_Connector__c = mySettings.Name_Connector__c;
+      householdNamingSettings.Name_Overrun__c = mySettings.Name_Overrun__c;
+      householdNamingSettings.Contact_Overrun_Count__c = mySettings.Contact_Overrun_Count__c;
+      householdNamingSettings.Implementing_Class__c = mySettings.Implementing_Class__c;
+
+      orgHouseholdNamingSettings = householdNamingSettings;
+      return householdNamingSettings;
+    }
+
 }


### PR DESCRIPTION
Chris and I jammed out yesterday to get HH renaming to support custom fields in the Namespec. This has been tested with both standard and custom fields, and we have test cases supporting this for both the HH Object and the HH Account.

# Contribution Info

This external contribution was submitted by @cdcarter and Christopher McCullough at Percolator and Fixes #1360.

# Changes

* Adds a UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests() method.
* The HH Naming Namespec is now parsed on contact update, and the HH Object or Account names are updated if any fields in the Namespec change