### PR TITLE
misc BDI fixes

### DIFF
--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -49,7 +49,10 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             strComma = ', ';
         }
         strSoql += ' FROM ' + UTIL_Namespace.StrTokenNSPrefix('DataImport__c');
-        strSoql += ' WHERE Status__c <> \'' + label.bdiImported + '\' ';        
+        strSoql += ' WHERE Status__c <> \'' + label.bdiImported + '\' ';   
+        // this ensures consistency for our test code, but also should
+        // help users figure out import problems by importing in a consistent order.
+        strSoql += ' ORDER BY Name ';                   
     }
     
     public Database.QueryLocator start(Database.BatchableContext bc) {

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -777,8 +777,9 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
         list<string> listDiKey = new list<string>();
 
         // we need the Contact CustomId key to always be checked first when matching
-        if (isCustomIDInContactMatchRules && con.get(diSettings.Contact_Custom_Unique_ID__c) != null) {
-            listDiKey.add(string.valueOf(con.get(diSettings.Contact_Custom_Unique_ID__c)));
+        string strUniqueId = '';
+        if (isCustomIDInContactMatchRules && (strUniqueId = strNull(con.get(diSettings.Contact_Custom_Unique_ID__c))) != '') {
+            listDiKey.add(strUniqueId);
         }
 
         list<string> listFName = new list<string>();    
@@ -807,22 +808,22 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             listEmail.add('');
             
         set<string> setDiKey = new set<string>();
-        addDiKeyPermutations(setDiKey, listFName, listLName, ListEmail);
+        addDiKeyPermutations(setDiKey, listFName, listLName, ListEmail, strUniqueId);
         listDiKey.addAll(setDiKey);
 
         return listDiKey;
     }
 
     // utility to create all the diKey permutations given firstname, lastname, and emails.
-    private void addDiKeyPermutations(set<string> setDiKey, list<string> listFname, list<string> listLName, list<string> listEmail) {
+    private void addDiKeyPermutations(set<string> setDiKey, list<string> listFname, list<string> listLName, list<string> listEmail, string strUniqueId) {
         for (string strFName : listFName) {
             for (string strLName : listLName) {
                 for (string strEmail : listEmail) {
-                    setDiKey.add(strFName + '|' + strLName + '|' + strEmail);
+                    setDiKey.add(strFName + '|' + strLName + '|' + strEmail + '|' + strUniqueId);
                 }
             }
         }
-        setDiKey.remove('||');
+        setDiKey.remove('|||');
     }
 
     // utility to return the dikeys for contact1 in the given di.
@@ -840,9 +841,9 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
         list<string> listDiKey = new list<string>();
 
         // we need the Contact CustomId key to always be checked first when matching
-        string strUnique; 
-        if (isCustomIDInContactMatchRules && (strUnique = string.valueOf(di.get(strDIContactCustomIDField(strCx)))) != null) {
-            listDiKey.add(strUnique);
+        string strUniqueId = ''; 
+        if (isCustomIDInContactMatchRules && (strUniqueId = strNull(di.get(strDIContactCustomIDField(strCx)))) != '') {
+            listDiKey.add(strUniqueId);
         }
                 
         list<string> listFName = new list<string>();    
@@ -869,7 +870,7 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             listEmail.add('');
             
         set<string> setDiKey = new set<string>();
-        addDiKeyPermutations(setDiKey, listFName, listLName, ListEmail);
+        addDiKeyPermutations(setDiKey, listFName, listLName, ListEmail, strUniqueId);
         listDiKey.addAll(setDiKey);
         
         // if we didn't create any dikey's for this di due to it not matching all constraints,
@@ -882,8 +883,9 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
 	            diKey += string.valueOf(di.get(strCx + '_Work_Email__c'));
 	        else if (di.get(strCx + '_Alternate_Email__c') != null)
 	            diKey += string.valueOf(di.get(strCx + '_Alternate_Email__c'));
+	        diKey += '|' + strUniqueId;
 	        
-	        if (diKey != '||')
+	        if (diKey != '|||')
 	           listDiKey.add(diKey);
         }
         
@@ -1068,12 +1070,13 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             return null;
 
         list<string> listDiKey = new list<string>();
-        if (isCustomIDInAccountMatchRules && acc.get(diSettings.Account_Custom_Unique_ID__c) != null) {
-            listDiKey.add(string.valueOf(acc.get(diSettings.Account_Custom_Unique_ID__c)));
+        string strUniqueId = '';
+        if (isCustomIDInAccountMatchRules && (strUniqueId = strNull(acc.get(diSettings.Account_Custom_Unique_ID__c))) != '') {
+            listDiKey.add(strUniqueId);
         }
 
         if (acc.Name != null)
-            listDiKey.add(acc.Name);        
+            listDiKey.add(acc.Name + '|' + strUniqueId);        
         return listDiKey;
     }
 
@@ -1088,15 +1091,15 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
         list<string> listDiKey = new list<string>();
 
         // we nee the Account CustomId key to always be checked first when matching
-        string strUnique; 
-        if (isCustomIDInAccountMatchRules && (strUnique = string.valueOf(di.get(strDIAccountCustomIDField(strAx)))) != null) {
-            listDiKey.add(strUnique);
+        string strUniqueId = '';
+        if (isCustomIDInAccountMatchRules && (strUniqueId = strNull(di.get(strDIAccountCustomIDField(strAx)))) != '') {
+            listDiKey.add(strUniqueId);
         }
 
         // now create any other dikeys
         string strName;
         if ((strName = string.valueOf(di.get(strAx + '_Name__c'))) != null)
-            listDiKey.add(strName); 
+            listDiKey.add(strName + '|' + strUniqueId); 
         return listDiKey;        
     }
     

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -212,9 +212,13 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
                 // household since it later shows up in C2, location, we can't be assured that the
                 // contact's original household account is the same (and valid). Thus we must fixup
                 // all Household Account Id lookups in our di records.
-                Contact c1 = ContactFromDi(di, 1);
-                if (c1 != null)
-                    di.HouseholdAccountImported__c = c1.AccountId;
+                if (di.Status__c == label.bdiImported) {
+                    Contact c1 = ContactFromDi(di, 1);
+                    if (c1 != null)
+                        di.HouseholdAccountImported__c = c1.AccountId;
+                } else {
+                    di.HouseholdAccountImported__c = null;                    
+                }
             }
             
             //UTIL_Debug.debug('****DJH final update to listDI: ' + listDI);

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -191,6 +191,8 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
 
             importContactsAndHouseholds();
             
+            importHouseholdAccountFields();
+            
             importAccounts();
             
             importAddresses();
@@ -481,6 +483,57 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
         }
     }
 
+    /*******************************************************************************************************
+    * @description Imports any custom fields specified for Household Accounts
+    * @return void
+    */
+    private void importHouseholdAccountFields() {
+        
+        // get our mapping of household custom fields
+        map<string, string> mapDIFieldToHHField = mapFieldsForDIObject('Household', 'Account', listStrDataImportFields);
+        
+        // bail out if no custom fields
+        if (mapDIFieldToHHField.size() == 0)
+            return;
+        
+        // holds the Households that need updating
+        list<Account> listAccHHUpdate = new list<Account>();
+        set<Id> setHHIdUpdate = new set<Id>();
+        list<DataImport__c> listDIUpdate = new list<DataImport__c>();
+        
+        for (DataImport__c di : listDI) {
+            // skip di's that already have an error
+            if (di.Status__c == label.bdiFailed)
+               continue;
+            if (di.HouseholdAccountImported__c == null)
+                continue;
+            
+            boolean isModified = false;
+            Account accHH = new Account(Id=di.HouseholdAccountImported__c);                
+            for (string strDIField : mapDIFieldToHHField.keySet()) {
+                if (di.get(strDIField) != null) {
+                    accHH.put(mapDIFieldToHHField.get(strDIField), di.get(strDIField));
+                    isModified = true;
+                }
+            }
+                        
+            if (isModified && setHHIdUpdate.add(accHH.Id)) {
+                listAccHHUpdate.add(accHH);
+                listDIUpdate.add(di);
+            }
+            
+        }
+        
+        //UTIL_Debug.debug('****DJH about to upsert household Accounts: ' + listAccHHUpdate);
+        list<Database.UpsertResult> listUR = database.upsert(listAccHHUpdate, false);
+        for (integer i = 0; i < listUR.size(); i++) {
+            Database.UpsertResult ur = listUR[i];
+            if (!ur.isSuccess()) {
+                LogBDIError(listDIUpdate[i], ur.getErrors()[0].getMessage(), null);
+            }
+        }        
+    }
+    
     // for every di with C1 or C2 data, make sure they have a lastname
     private void verifyContactData() {    
         for (DataImport__c di: listDI) {

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -1219,13 +1219,13 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             MailingPostalCode__c from Address__c where Household_Account__c in :setHHId];
         map<String, Id> mapHHAddrKeyToId = new map<String, Id>();
         for (Address__c addr : listAddrExisting) {
-            mapHHAddrKeyToId.put(addr.Household_Account__c + addr.MailingStreet__c + addr.MailingCity__c + 
-                addr.MailingState__c + addr.MailingPostalCode__c, addr.Id);
+            mapHHAddrKeyToId.put(strKeyOfAddr(addr), addr.Id);
         }        
         
         map<string, string> mapDIFieldToAddrField = mapFieldsForDIObject('Address', UTIL_Namespace.StrTokenNSPrefix('Address__c'), listStrDataImportFields);
         list<Address__c> listAddrInsert = new list<Address__c>();
         list<DataImport__c> listDIInsert = new list<DataImport__c>();
+        map<String, Address__c> mapHHAddrKeyToAddrNew = new map<String, Address__c>();
         for (DataImport__c di : listDI) {
             // skip di's that already have an error
             if (di.Status__c == label.bdiFailed)
@@ -1251,14 +1251,21 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
 	            }
             	
             	// check to see if we already have this address in this hh.
-            	ID idAddr = mapHHAddrKeyToId.get(addr.Household_Account__c + addr.MailingStreet__c + addr.MailingCity__c + addr.MailingState__c + addr.MailingPostalCode__c);
+            	ID idAddr = mapHHAddrKeyToId.get(strKeyOfAddr(addr));
             	if (idAddr != null) {
             	   di.HomeAddressImported__c = idAddr;
             	   di.HomeAddressImportStatus__c = label.bdiMatched;
             	} else {
+            	    // see if we are already creating this new address
+            	    Address__c addrNew = mapHHAddrKeyToAddrNew.get(strKeyOfAddr(addr));
+            	    if (addrNew != null) {
+            	        addr = addrNew;
+            	    } else {
+                        mapHHAddrKeyToAddrNew.put(strKeyOfAddr(addr), addr);            	        
+                        listAddrInsert.add(addr);
+                        listDIInsert.add(di);
+            	    }
                     mapDIIdToAddr.put(di.Id, addr);
-                    listAddrInsert.add(addr);
-                    listDIInsert.add(di);
             	}
             }
             if (Test.isRunningTest() && addr.MailingCity__c != null && addr.MailingCity__c.startsWith('FailTest')) {
@@ -1301,6 +1308,11 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
                 }
             }
         }
+    }
+
+    // returns the unique address key for the given address    
+    private static string strKeyOfAddr(Address__c addr) {
+        return addr.Household_Account__c + addr.MailingStreet__c + addr.MailingCity__c + addr.MailingState__c + addr.MailingPostalCode__c;
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -203,15 +203,26 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
 
             // update final status for each DI
             for (DataImport__c di: listDI) {
-            	if (di.Status__c == null)
+                if (di.Status__c == null)
                     di.Status__c = label.bdiImported;
                 di.ImportedDate__c = system.now();
                 di.ApexJobId__c = bc.getJobId();
+                
+                // because a contact might be first imported in C1 location, but then moved to another 
+                // household since it later shows up in C2, location, we can't be assured that the
+                // contact's original household account is the same (and valid). Thus we must fixup
+                // all Household Account Id lookups in our di records.
+                Contact c1 = ContactFromDi(di, 1);
+                if (c1 != null)
+                    di.HouseholdAccountImported__c = c1.AccountId;
             }
             
+            //UTIL_Debug.debug('****DJH final update to listDI: ' + listDI);
             update listDI;
 	
 	    } catch (Exception e) {
+	        //UTIL_Debug.debug('****DJH Exception ' + e);
+	        
             // we should only hit this exception if a truly unexpected runtime
             // error occurs.  not even database updates/inserts should get here,
             // since we now handle all database updates/inserts using the flavor
@@ -367,7 +378,7 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             if (Test.isRunningTest() && con.LastName != null && con.LastName.startsWith('FailTest'))
                 con.LastName = null;
         }
-        //upsert listConUpsert;
+        //UTIL_Debug.debug('****DJH about to upsert c1s: ' + listConUpsert);
         list<Database.UpsertResult> listUR = database.upsert(listConUpsert, false);
         for (integer i = 0; i < listUR.size(); i++) {
             Database.UpsertResult ur = listUR[i];
@@ -443,7 +454,7 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             if (Test.isRunningTest() && con.LastName != null && con.LastName.startsWith('FailTest'))
                 con.LastName = null;
         }
-        //upsert listConUpsert;
+        //UTIL_Debug.debug('****DJH about to upsert c2s: ' + listConUpsert);
         listUR = database.upsert(listConUpsert, false);
         for (integer i = 0; i < listUR.size(); i++) {
             Database.UpsertResult ur = listUR[i];

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -316,7 +316,11 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
                     
                     // make sure they have permissions to modify the target field
                     // we can't do this in all tests, because many profiles won't have FLS set for all our new fields!
-                    if (!Test.isRunningTest() || failFieldLevelSecurity) {
+                    // also they may have enabled "Set Audit Fields upon Record Creation", which doesn't seem to change the
+                    // describe results!
+                    if (strField != 'CreatedDate' && 
+                        strField != 'LastModifiedDate' &&
+                        (!Test.isRunningTest() || failFieldLevelSecurity)) {
                         dfr = UTIL_Describe.getFieldDescribe(strBaseObj, strField);
                         if (failFieldLevelSecurity)
                             dfr = null;

--- a/src/classes/BDI_DataImport_TEST.cls
+++ b/src/classes/BDI_DataImport_TEST.cls
@@ -204,6 +204,51 @@ public with sharing class BDI_DataImport_TEST {
 
     /*********************************************************************************************************
     operation:
+        import matching contacts within multiple di records in the same batch 
+    verify:
+        only two contacts created
+        only 1 household account created
+    **********************************************************************************************************/            
+    static testMethod void TwoDIDuplicateNewContactsDifferentOrder() {
+        if (strTestOnly != '*' && strTestOnly != 'TwoDIDuplicateNewContactsDifferentOrder') return;
+            
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(newDI('c1', 'C1', 'c2', 'C2'));
+        listDI.add(newDI('c2', 'C2'));
+        insert listDI;
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results
+        list<Contact> listCon = [select Id, Name, AccountId from Contact order by Lastname];
+        system.assertEquals(2, listCon.size());
+        system.assertEquals('c1 C1', listCon[0].Name);
+        system.assertEquals('c2 C2', listCon[1].Name);
+        
+        // verify only one household account
+        list<Account> listAcc = [select Id, Name from Account];
+        system.assertEquals(1, listAcc.size());
+        system.assertEquals(listAcc[0].Id, listCon[0].AccountId);
+        system.assertEquals(listAcc[0].Id, listCon[1].AccountId);
+
+        listDI = [select Contact1Imported__c, Contact1ImportStatus__c, HouseholdAccountImported__c, 
+            Contact2Imported__c, Contact2ImportStatus__c from DataImport__c order by Name];
+        system.assertEquals(2, listDI.size());
+        system.assertEquals(listDI[0].Contact1Imported__c, listCon[0].Id);
+        system.assertEquals(listDI[1].Contact1Imported__c, listCon[1].Id);
+        system.assertNotEquals(null, listDI[0].HouseholdAccountImported__c);
+        system.assertNotEquals(null, listDI[1].HouseholdAccountImported__c);
+        system.assertEquals(label.bdiCreated, listDI[0].Contact1ImportStatus__c);
+        system.assertEquals(label.bdiCreated, listDI[1].Contact1ImportStatus__c);        
+        system.assertEquals(label.bdiMatched, listDI[0].Contact2ImportStatus__c);        
+    }
+
+    /*********************************************************************************************************
+    operation:
         import existing contacts within the same di record 
     verify:
         two contacts matched

--- a/src/classes/BDI_DataImport_TEST.cls
+++ b/src/classes/BDI_DataImport_TEST.cls
@@ -1151,4 +1151,42 @@ public with sharing class BDI_DataImport_TEST {
         system.assertEquals(label.bdiImported, listDI[0].Status__c);        
         system.assertEquals(label.bdiFailed, listDI[1].Status__c);        
     }
+
+    /*********************************************************************************************************
+    operation:
+        import different contacts within multiple di records in the same batch setting Household fields
+    verify:
+        two contacts created
+    **********************************************************************************************************/            
+    static testMethod void TwoDITwoNewContactsHouseholdFields() {
+        if (strTestOnly != '*' && strTestOnly != 'TwoDITwoNewContactsHouseholdFields') return;
+            
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(new DataImport__c(Contact1_Lastname__c = 'c1', Household_Phone__c = '425-111-2222'));
+        listDI.add(new DataImport__c(Contact1_Lastname__c = 'c2', Household_Phone__c = '425-111-2222'));
+        insert listDI;
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results
+        list<Contact> listCon = [select Id, Name, AccountId, Account.Phone from Contact order by Lastname];
+        system.assertEquals(2, listCon.size());
+        system.assertNotEquals(listCon[1].Name, listCon[0].Name);
+        system.assertEquals(listDI[0].Household_Phone__c, listCon[0].Account.Phone);
+        system.assertEquals(listDI[1].Household_Phone__c, listCon[1].Account.Phone);
+        
+        listDI = [select Contact1Imported__c, Contact1ImportStatus__c, HouseholdAccountImported__c, 
+            Contact2Imported__c, Contact2ImportStatus__c from DataImport__c order by Contact1Imported__c];
+        system.assertEquals(2, listDI.size());
+        system.assertEquals(listDI[0].Contact1Imported__c, listCon[0].Id);
+        system.assertEquals(listDI[1].Contact1Imported__c, listCon[1].Id);
+        system.assertNotEquals(null, listDI[0].HouseholdAccountImported__c);
+        system.assertNotEquals(null, listDI[1].HouseholdAccountImported__c);
+        system.assertEquals(label.bdiCreated, listDI[0].Contact1ImportStatus__c);
+        system.assertEquals(label.bdiCreated, listDI[1].Contact1ImportStatus__c);        
+    }
 }

--- a/src/classes/BDI_DataImport_TEST.cls
+++ b/src/classes/BDI_DataImport_TEST.cls
@@ -616,6 +616,87 @@ public with sharing class BDI_DataImport_TEST {
     
     /*********************************************************************************************************
     operation:
+        import duplicate contacts with duplicate home addresses 
+    verify:
+        no duplicate address objects created
+        contacts' mailing address set
+        hh accounts' billing address set
+    **********************************************************************************************************/            
+    static testMethod void ManyDISameHomeAddresses() {
+        if (strTestOnly != '*' && strTestOnly != 'ManyDIHomeAddresses') return;
+            
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(newDI('c1', 'C1', 'c2', 'C2'));
+        listDI.add(newDI('c1', 'C1'));
+        listDI.add(newDI('c1', 'C1'));
+        listDI.add(newDI('c2', 'C2'));
+        listDI.add(newDI('c2', 'C2'));
+
+        // add same address to all
+        for (DataImport__c di : listDI) {        
+            di.Home_Street__c = '123 45th St NE';
+            di.Home_City__c = 'Seattle';
+            di.Home_State_Province__c = 'Washington';
+            di.Home_Zip_Postal_Code__c = '98052';
+            di.Home_Country__c = 'United States';
+        }
+        insert listDI;
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results
+        list<Contact> listCon = [select Id, Name, AccountId, MailingStreet, MailingCity, MailingState, 
+            MailingPostalCode, MailingCountry from Contact order by Lastname];
+        system.assertEquals(2, listCon.size());
+        for (Contact con : listCon) {        
+            system.assertEquals(listDI[0].Home_Street__c, con.MailingStreet);
+            system.assertEquals(listDI[0].Home_City__c, con.MailingCity);
+            system.assertEquals(listDI[0].Home_State_Province__c, con.MailingState);
+            system.assertEquals(listDI[0].Home_Zip_Postal_Code__c, con.MailingPostalCode);
+            system.assertEquals(listDI[0].Home_Country__c, con.MailingCountry);
+        }
+        
+        list<Address__c> listAddr = [select Id, Household_Account__c, MailingStreet__c, MailingCity__c, MailingState__c, 
+            MailingPostalCode__c, MailingCountry__c from Address__c order by MailingCity__c]; 
+        system.assertEquals(1, listAddr.size());
+        system.assertEquals(listDI[0].Home_Street__c, listAddr[0].MailingStreet__c);
+        system.assertEquals(listDI[0].Home_City__c, listAddr[0].MailingCity__c);
+        system.assertEquals(listDI[0].Home_State_Province__c, listAddr[0].MailingState__c);
+        system.assertEquals(listDI[0].Home_Zip_Postal_Code__c, listAddr[0].MailingPostalCode__c);
+        system.assertEquals(listDI[0].Home_Country__c, listAddr[0].MailingCountry__c);
+        
+        list<Account> listAcc = [select Id, Name, BillingStreet, BillingCity, BillingState, 
+            BillingPostalCode, BillingCountry from Account order by Name];
+        system.assertEquals(1, listAcc.size());
+        system.assertEquals(listDI[0].Home_Street__c, listAcc[0].BillingStreet);
+        system.assertEquals(listDI[0].Home_City__c, listAcc[0].BillingCity);
+        system.assertEquals(listDI[0].Home_State_Province__c, listAcc[0].BillingState);
+        system.assertEquals(listDI[0].Home_Zip_Postal_Code__c, listAcc[0].BillingPostalCode);
+        system.assertEquals(listDI[0].Home_Country__c, listAcc[0].BillingCountry);                
+
+        listDI = [select HomeAddressImported__c, HomeAddressImportStatus__c from DataImport__c order by Name];
+        system.assertEquals(5, listDI.size());
+        integer cCreated = 0;
+        integer cMatched = 0;
+        for (DataImport__c di : listDI) {
+            system.assertEquals(di.HomeAddressImported__c, listAddr[0].Id);
+            if (di.HomeAddressImportStatus__c == label.bdiCreated)
+                cCreated++; 
+            else if (di.HomeAddressImportStatus__c == label.bdiMatched)
+                cMatched++; 
+        }
+        // we didn't have an easy way to track the specific DI record that caused the addr to be created vs matched
+        // in these duplicate (but new) scenarios, so we will live with marking them all as created.
+        system.assertEquals(5, cCreated);
+        system.assertEquals(0, cMatched);
+    }
+
+    /*********************************************************************************************************
+    operation:
         import contacts with home addresses, while address management is disabled
     verify:
         address objects NOT created

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -401,6 +401,48 @@ private with sharing class BDI_DataImport_TEST2 {
 
    /*********************************************************************************************************
     operation:
+        import existing contacts within multiple di records in the same batch, using Custom Unique Id matching
+    verify:
+        all contacts matched
+    **********************************************************************************************************/            
+    static testMethod void ManyDIUniqueIdNotMatchingExistingContacts() {
+        if (strTestOnly != '*' && strTestOnly != 'ManyDIUniqueIdNotMatchingExistingContacts') return;
+            
+         // existing contacts
+        list<Contact> listConExisting = new list<Contact>();
+        listConExisting.add(new Contact(Firstname='c1', Lastname='C1', Email='c1@c1.com', Title='ID1'));
+        listConExisting.add(new Contact(Firstname='c1', Lastname='C1', Email='c1@c1.com', Title='ID2'));
+        insert listConExisting;
+ 
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c1', Contact1_Lastname__c='C1', Contact1_Personal_Email__c='c1@c1.com', Contact1_Title__c='ID3'));
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c1', Contact1_Lastname__c='C1', Contact1_Personal_Email__c='c1@c1.com', Contact1_Title__c='ID4'));
+        insert listDI;
+        
+        Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
+        // for testing, we need to use an existing contact field that exists on both Contact and the DI.
+        diSettings.Contact_Custom_Unique_ID__c = 'Title';
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results
+        list<Contact> listCon = [select Id, Name, Email, Title from Contact order by Title];
+        system.assertEquals(4, listCon.size());
+        
+        listDI = [select Contact1Imported__c, Contact1ImportStatus__c, Contact2Imported__c, Contact2ImportStatus__c from DataImport__c order by Contact1_Title__c];
+        system.assertEquals(2, listDI.size());
+        system.assertEquals(listDI[0].Contact1Imported__c, listCon[2].Id);
+        system.assertEquals(listDI[1].Contact1Imported__c, listCon[3].Id);
+        system.assertEquals(label.bdiCreated, listDI[0].Contact1ImportStatus__c);
+        system.assertEquals(label.bdiCreated, listDI[1].Contact1ImportStatus__c);        
+    }
+
+   /*********************************************************************************************************
+    operation:
         import new contacts within multiple di records in the same batch, using Custom Unique Id matching
     verify:
         all contacts created, since unique Id's provided
@@ -467,14 +509,50 @@ private with sharing class BDI_DataImport_TEST2 {
     
         // verify expected results
         list<Account> listAcc = [select Id, Name, Website from Account];
+        system.assertEquals(3, listAcc.size());
+        
+        listDI = [select Account1Imported__c, Account1ImportStatus__c, Account1_Name__c, Account2Imported__c, Account2ImportStatus__c from DataImport__c order by Account1_Website__c];
+        system.assertEquals(2, listDI.size());
+        system.assertEquals(listDI[0].Account1Imported__c, listAccExisting[0].Id);
+        system.assertEquals(listDI[0].Account1_Name__c, listAcc[0].Name);
+        system.assertNotEquals(listDI[1].Account1Imported__c, listAccExisting[1].Id);
+        system.assertEquals(label.bdiMatched, listDI[0].Account1ImportStatus__c);
+        system.assertEquals(label.bdiCreated, listDI[1].Account1ImportStatus__c);        
+    }
+
+   /*********************************************************************************************************
+    operation:
+        import new accounts within multiple di records in the same batch, using Custom Unique Id matching
+    verify:
+        all accounts matched
+    **********************************************************************************************************/            
+    static testMethod void ManyDIUniqueIdNewAccounts() {
+        if (strTestOnly != '*' && strTestOnly != 'ManyDIUniqueIdNewAccounts') return;
+            
+ 
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(new DataImport__c(Account1_Name__c='a1', Account1_Website__c='a1.com'));
+        listDI.add(new DataImport__c(Account1_Name__c='a1', Account1_Website__c='z.com'));
+        insert listDI;
+        
+        Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
+        // for testing, we need to use an existing account field that exists on both Account and the DI.
+        diSettings.Account_Custom_Unique_ID__c = 'Website';
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results
+        list<Account> listAcc = [select Id, Name, Website from Account];
         system.assertEquals(2, listAcc.size());
         
         listDI = [select Account1Imported__c, Account1ImportStatus__c, Account2Imported__c, Account2ImportStatus__c from DataImport__c order by Account1_Website__c];
         system.assertEquals(2, listDI.size());
-        system.assertEquals(listDI[0].Account1Imported__c, listAccExisting[0].Id);
-        system.assertEquals(listDI[1].Account1Imported__c, listAccExisting[1].Id);
-        system.assertEquals(label.bdiMatched, listDI[0].Account1ImportStatus__c);
-        system.assertEquals(label.bdiMatched, listDI[1].Account1ImportStatus__c);        
+        system.assertEquals(label.bdiCreated, listDI[0].Account1ImportStatus__c);
+        system.assertEquals(label.bdiCreated, listDI[1].Account1ImportStatus__c);        
     }
 
     /*********************************************************************************************************

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -479,6 +479,63 @@ private with sharing class BDI_DataImport_TEST2 {
 
    /*********************************************************************************************************
     operation:
+        import existing & new contacts within multiple di records in the same batch, using Custom Unique Id matching
+    verify:
+        all contacts matched
+    **********************************************************************************************************/            
+    static testMethod void ManyDIUniqueIdMatchingNewAndExistingContacts() {
+        if (strTestOnly != '*' && strTestOnly != 'ManyDIUniqueIdMatchingNewAndExistingContacts') return;
+            
+         // existing contacts
+        list<Contact> listConExisting = new list<Contact>();
+        listConExisting.add(new Contact(Firstname='c1', Lastname='C1', Email='c1@foo.com', Title='id1'));
+        listConExisting.add(new Contact(Firstname='c1', Lastname='C1', Email='c1@foo.com', Title='id2'));
+        listConExisting.add(new Contact(Firstname='c1', Lastname='C1', Email='c1@foo.com', Title=null));
+        listConExisting.add(new Contact(Firstname='c2', Lastname='C2', Email='c2@foo.com', Title='id4'));
+        insert listConExisting;
+ 
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c1', Contact1_Lastname__c='C1', Contact1_Personal_Email__c='c1@foo.com', Contact1_Title__c='id1'));
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c1', Contact1_Lastname__c='C1', Contact1_Personal_Email__c='c1@foo.com', Contact1_Title__c='id3'));
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c1', Contact1_Lastname__c='C1', Contact1_Personal_Email__c='c1@foo.com', Contact1_Title__c=null));
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c2', Contact1_Lastname__c='C2', Contact1_Personal_Email__c='c2@foo.com', Contact1_Title__c=null));
+        insert listDI;
+        
+        Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
+        // for testing, we need to use an existing contact field that exists on both Contact and the DI.
+        diSettings.Contact_Custom_Unique_ID__c = 'Title';
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results
+        list<Contact> listCon = [select Id, Name, Email, Title from Contact order by Title NULLS LAST, Lastname NULLS LAST]; // id1, id2, id3, id4, null (c1), null (c2)
+        system.assertEquals(6, listCon.size());
+        system.debug('****DJH: listCon ' + listCon);
+        
+        listDI = [select Contact1Imported__c, Contact1ImportStatus__c, Contact2Imported__c, Contact2ImportStatus__c from DataImport__c 
+            order by Contact1_Title__c NULLS LAST, Contact1_Lastname__c NULLS LAST];
+        system.assertEquals(4, listDI.size());
+        system.debug('****DJH: listDI ' + listDI);
+
+        system.assertEquals(listDI[0].Contact1Imported__c, listCon[0].Id);
+        system.assertEquals(listDI[0].Contact1ImportStatus__c, label.bdiMatched);
+
+        system.assertEquals(listDI[1].Contact1Imported__c, listCon[2].Id);
+        system.assertEquals(listDI[1].Contact1ImportStatus__c, label.bdiCreated);
+
+        system.assertEquals(listDI[2].Contact1Imported__c, listCon[4].Id);
+        system.assertEquals(listDI[2].Contact1ImportStatus__c, label.bdiMatched);        
+
+        system.assertEquals(listDI[3].Contact1Imported__c, listCon[5].Id);
+        system.assertEquals(listDI[3].Contact1ImportStatus__c, label.bdiCreated);        
+    }
+
+   /*********************************************************************************************************
+    operation:
         import existing accounts within multiple di records in the same batch, using Custom Unique Id matching
     verify:
         all accounts matched
@@ -553,6 +610,62 @@ private with sharing class BDI_DataImport_TEST2 {
         system.assertEquals(2, listDI.size());
         system.assertEquals(label.bdiCreated, listDI[0].Account1ImportStatus__c);
         system.assertEquals(label.bdiCreated, listDI[1].Account1ImportStatus__c);        
+    }
+
+   /*********************************************************************************************************
+    operation:
+        import existing accounts within multiple di records in the same batch, using Custom Unique Id matching
+    verify:
+        all accounts matched
+    **********************************************************************************************************/            
+    static testMethod void ManyDIUniqueIdMatchingNewAndExistingAccounts() {
+        if (strTestOnly != '*' && strTestOnly != 'ManyDIUniqueIdMatchingNewAndExistingAccounts') return;
+            
+         // existing Accounts
+        list<Account> listAccExisting = new list<Account>();
+        listAccExisting.add(new Account(Name='a1', website='id1.com'));
+        listAccExisting.add(new Account(Name='a1', website='id2.com'));
+        listAccExisting.add(new Account(Name='a1', website=null));
+        listAccExisting.add(new Account(Name='a2', website='id4.com'));
+        insert listAccExisting;
+ 
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(new DataImport__c(Account1_Name__c='a1', Account1_Website__c='id1.com'));
+        listDI.add(new DataImport__c(Account1_Name__c='a1', Account1_Website__c='id3.com'));
+        listDI.add(new DataImport__c(Account1_Name__c='a1', Account1_Website__c=null));
+        listDI.add(new DataImport__c(Account1_Name__c='a2', Account1_Website__c=null));
+        insert listDI;
+        
+        Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
+        // for testing, we need to use an existing account field that exists on both Account and the DI.
+        diSettings.Account_Custom_Unique_ID__c = 'Website';
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results
+        list<Account> listAcc = [select Id, Name, Website from Account order by Website NULLS LAST, Name]; // id1, id2, id3, id4, null (a1), null (a2)
+        system.debug('****DJH: listAcc ' + listAcc);
+        system.assertEquals(6, listAcc.size());
+        
+        listDI = [select Account1Imported__c, Account1ImportStatus__c, Account1_Name__c from DataImport__c order by Account1_Website__c NULLS LAST, Account1_Name__c];
+        system.debug('****DJH: listDI ' + listDI);
+        system.assertEquals(4, listDI.size());
+        
+        system.assertEquals(listDI[0].Account1Imported__c, listAcc[0].Id);
+        system.assertEquals(listDI[0].Account1ImportStatus__c, label.bdiMatched);
+
+        system.assertEquals(listDI[1].Account1Imported__c, listAcc[2].Id);
+        system.assertEquals(listDI[1].Account1ImportStatus__c, label.bdiCreated);
+
+        system.assertEquals(listDI[2].Account1Imported__c, listAcc[4].Id);
+        system.assertEquals(listDI[2].Account1ImportStatus__c, label.bdiMatched);
+
+        system.assertEquals(listDI[3].Account1Imported__c, listAcc[5].Id);
+        system.assertEquals(listDI[3].Account1ImportStatus__c, label.bdiCreated);
     }
 
     /*********************************************************************************************************

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -380,8 +380,6 @@ private with sharing class BDI_DataImport_TEST2 {
         Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
         // for testing, we need to use an existing contact field that exists on both Contact and the DI.
         diSettings.Contact_Custom_Unique_ID__c = 'Title';
-        if(!Test.isRunningTest())
-            upsert diSettings;
           
         //run batch data import
         Test.StartTest();
@@ -399,6 +397,42 @@ private with sharing class BDI_DataImport_TEST2 {
         system.assertEquals(listDI[1].Contact1Imported__c, listConExisting[1].Id);
         system.assertEquals(label.bdiMatched, listDI[0].Contact1ImportStatus__c);
         system.assertEquals(label.bdiMatched, listDI[1].Contact1ImportStatus__c);        
+    }
+
+   /*********************************************************************************************************
+    operation:
+        import new contacts within multiple di records in the same batch, using Custom Unique Id matching
+    verify:
+        all contacts created, since unique Id's provided
+    **********************************************************************************************************/            
+    static testMethod void ManyDIUniqueIdNewContacts() {
+        if (strTestOnly != '*' && strTestOnly != 'ManyDIUniqueIdNewContacts') return;
+            
+        list<DataImport__c> listDI = new list<DataImport__c>();
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c1', Contact1_Lastname__c='C1', Contact1_Personal_Email__c='c1@c1.com', Contact1_Title__c='ID1'));
+        listDI.add(new DataImport__c(Contact1_Firstname__c='c1', Contact1_Lastname__c='C1', Contact1_Personal_Email__c='c1@c1.com', Contact1_Title__c='ID2'));
+        insert listDI;
+        
+        Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
+        // for testing, we need to use an existing contact field that exists on both Contact and the DI.
+        diSettings.Contact_Custom_Unique_ID__c = 'Title';
+          
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+    
+        // verify expected results.
+        list<Contact> listCon = [select Id, Name, Email, Title from Contact order by Title];
+        system.assertEquals(2, listCon.size());
+        
+        listDI = [select Contact1Imported__c, Contact1ImportStatus__c, Contact2Imported__c, Contact2ImportStatus__c from DataImport__c order by Contact1_Title__c];
+        system.assertEquals(2, listDI.size());
+        system.assertEquals(listDI[0].Contact1Imported__c, listCon[0].Id);
+        system.assertEquals(listDI[1].Contact1Imported__c, listCon[1].Id);
+        system.assertEquals(label.bdiCreated, listDI[0].Contact1ImportStatus__c);
+        system.assertEquals(label.bdiCreated, listDI[1].Contact1ImportStatus__c);        
     }
 
    /*********************************************************************************************************
@@ -424,8 +458,6 @@ private with sharing class BDI_DataImport_TEST2 {
         Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
         // for testing, we need to use an existing account field that exists on both Account and the DI.
         diSettings.Account_Custom_Unique_ID__c = 'Website';
-        if(!Test.isRunningTest())
-            upsert diSettings;
           
         //run batch data import
         Test.StartTest();
@@ -583,8 +615,6 @@ private with sharing class BDI_DataImport_TEST2 {
           
         Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
         diSettings.Contact_Matching_Rule__c = strRule;
-        if(!Test.isRunningTest())
-            upsert diSettings;
  
         //run batch data import
         Test.StartTest();

--- a/src/classes/BDI_DataImport_TEST2.cls-meta.xml
+++ b/src/classes/BDI_DataImport_TEST2.cls-meta.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>33.0</apiVersion>
+    <apiVersion>33.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>1</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <status>Active</status>
 </ApexClass>

--- a/src/layouts/DataImport__c-Data Import Layout.layout
+++ b/src/layouts/DataImport__c-Data Import Layout.layout
@@ -127,6 +127,21 @@
                 <behavior>Edit</behavior>
                 <field>Contact1ImportStatus__c</field>
             </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsLeftToRight</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Household Account Information</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Household_Phone__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>HouseholdAccountImported__c</field>
@@ -138,7 +153,7 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
-        <label>Account1 Information</label>
+        <label>Account1 Organization Information</label>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -264,7 +279,7 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
-        <label>Account2 Information</label>
+        <label>Account2 Organization Information</label>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -460,7 +475,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h61000001c8dY</masterLabel>
+        <masterLabel>00hG000000UVE7F</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -928,6 +928,15 @@
         <type>Lookup</type>
     </fields>
     <fields>
+        <fullName>Household_Phone__c</fullName>
+        <externalId>false</externalId>
+        <inlineHelpText>Household.Phone</inlineHelpText>
+        <label>Household Phone</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Phone</type>
+    </fields>
+    <fields>
         <fullName>ImportedDate__c</fullName>
         <description>When the Data Import record was successfully imported.</description>
         <externalId>false</externalId>

--- a/src/objects/Data_Import_Settings__c.object
+++ b/src/objects/Data_Import_Settings__c.object
@@ -5,9 +5,9 @@
     <enableFeeds>false</enableFeeds>
     <fields>
         <fullName>Account_Custom_Unique_ID__c</fullName>
-        <description>An optional Unique Id field to use for Account matching</description>
+        <description>An optional Unique Id field to use for Organization Account matching</description>
         <externalId>false</externalId>
-        <inlineHelpText>An optional Unique Id field to use for Account matching</inlineHelpText>
+        <inlineHelpText>An optional Unique Id field to use for Organization Account matching</inlineHelpText>
         <label>Account Custom Unique ID</label>
         <length>255</length>
         <required>false</required>

--- a/src/package.xml
+++ b/src/package.xml
@@ -520,6 +520,7 @@
         <members>DataImport__c.Home_Street__c</members>
         <members>DataImport__c.Home_Zip_Postal_Code__c</members>
         <members>DataImport__c.HouseholdAccountImported__c</members>
+        <members>DataImport__c.Household_Phone__c</members>
         <members>DataImport__c.ImportedDate__c</members>
         <members>DataImport__c.Payment_Check_Reference_Number__c</members>
         <members>DataImport__c.Payment_Method__c</members>


### PR DESCRIPTION
# Warning

# Info
* The NPSP Data Importer now supports updating Household Account fields, and includes the field Household Phone.  Make sure to add a new Household Account Information section to your NPSP Data Importer page layout, and put Household Phone and Household Account Imported fields in that section.  In addition, you must enables Field Level Security on the new Household Phone field on the NPSP Data Import object, in order to use it.

# Issues
Fixes #1907 
Fixes #1767 
Fixes #1802 
Fixes #1654 
