### PR TITLE
Fix for job progress component

### DIFF
--- a/src/components/UTIL_JobProgressLightning.component
+++ b/src/components/UTIL_JobProgressLightning.component
@@ -244,7 +244,7 @@
             }
         }
 
-        document.addEventListener('DOMContentLoaded', function () {
+        function init() {
             eventTarget = document.getElementById('{!eventTargetId}');
 
             if (eventTarget) {
@@ -266,7 +266,13 @@
             if ({!IF(startPolling, 'true', 'false')}) {
                 startPolling(pollingDelay);
             }
-        });
+        }
+
+        if ('loading' !== document.readyState) {
+            init();
+        } else {
+            document.addEventListener('DOMContentLoaded', init);
+        }
     })();
     </script>
 </apex:component>


### PR DESCRIPTION
When job progress component was loaded via a rerender target, and not
when the page first loaded, it was failing to initialize because it was
missing the 'DOMContentLoaded' event.  Now the component checks to see
if the page has been loaded, and if so will initialize.  Otherwise, it
will initialize when the document loaded event is fired.