### PR TITLE
Job Progress Lightning component update for multiple instance

### DIFF
--- a/src/components/UTIL_JobProgressLightning.component
+++ b/src/components/UTIL_JobProgressLightning.component
@@ -37,17 +37,17 @@
             dominant-baseline: middle;
             fill: #00396B;
         }
-        #jobsListTemplate {
+        ul[data-job-progress="template"] {
             display: none;
         }
     </style>
 
-    <div class="slds">
+    <apex:outputPanel layout="block" id="jobProgressContainer" styleClass="slds">
         <div class="slds-card">
             <div class="slds-card__header">
                 <h3 class="slds-text-heading--small">{!batchComponentLabel}</h3>
             </div>
-            <div id="jobsListContainer" class="slds-card__body">
+            <div data-job-progress="list-container" class="slds-card__body">
                 <div class="slds-spinner--large slds-container--center slds-m-vertical--xx-large">
                     <img src="{!URLFOR($Resource.SLDS, '/assets/images/spinners/slds_spinner_brand.gif')}" alt="Loading..." />
                 </div>
@@ -55,7 +55,7 @@
         </div>
 
 
-        <ul id="jobsListTemplate" class="slds-list--vertical">
+        <ul data-job-progress="template" class="slds-list--vertical">
             <li class="slds-list__item slds-m-bottom--large">
                 <div class="slds-media slds-tile slds-wrap">
                     <div class="slds-media__figure slds-size--2-of-12">
@@ -110,18 +110,19 @@
                 </div>
             </li>
         </ul>
-    </div>
+    </apex:outputPanel>
 
 
     <script>
     (function () {
 
+        var jobProgressContainer = document.getElementById('{!$Component.jobProgressContainer}');
         var pollingDelay = {!pollingDelay};
         var refreshInterval;
         var eventTarget;
 
-        var jobsListTemplate = document.getElementById('jobsListTemplate').cloneNode(true);
-        jobsListTemplate.removeAttribute("id");
+        var jobsListTemplate = jobProgressContainer.querySelector('[data-job-progress="template"]').cloneNode(true);
+        jobsListTemplate.removeAttribute("data-job-progress");
 
         var directives = {
             "completionBadge": {
@@ -190,7 +191,7 @@
                 {!numberOfJobs},
                 function (result, event) {
                     sendProgressEvents(result);
-                    var jobsListContainer = document.getElementById('jobsListContainer');
+                    var jobsListContainer = jobProgressContainer.querySelector('[data-job-progress="list-container"]');
                     var jobsListContent = Transparency.render(jobsListTemplate.cloneNode(true), result, directives);
                     jobsListContainer.replaceChild(jobsListContent, jobsListContainer.firstElementChild);
                 }


### PR DESCRIPTION
Previously, the job progress lightning component used ids to identify
the html elements that it needed to target.  However, having multiple
instances of the job progress component on a single page would cause
confusion, because the different components would access just the first
element with that id they found in the page.  This update modifies the
markup of the component to be wrapped in an apex:outputPanel tag, which
allows for a unique id to be generated for that element.  The elements
needing to be targeted are identified by querying by a data attribute as
children of the wrapper element.