### PR TITLE
Updated inline help labels

### DIFF
--- a/src/objects/Address__c.object
+++ b/src/objects/Address__c.object
@@ -217,7 +217,7 @@ MailingCity__c &amp; IF(LEN(MailingCity__c) &gt; 0, &quot;, &quot;, &quot;&quot;
     <fields>
         <fullName>Latest_End_Date__c</fullName>
         <externalId>false</externalId>
-        <inlineHelpText>The most recent ending date that this Address was used for this Household.</inlineHelpText>
+        <inlineHelpText>The most recent ending date that this address was used. Generally used with Latest Start Date to track a date range for an address that's no longer in use.</inlineHelpText>
         <label>Latest End Date</label>
         <required>false</required>
         <trackFeedHistory>false</trackFeedHistory>
@@ -227,7 +227,7 @@ MailingCity__c &amp; IF(LEN(MailingCity__c) &gt; 0, &quot;, &quot;, &quot;&quot;
     <fields>
         <fullName>Latest_Start_Date__c</fullName>
         <externalId>false</externalId>
-        <inlineHelpText>The most recent starting date that this Address was used for this Household.</inlineHelpText>
+        <inlineHelpText>The most recent starting date that this address was used. Generally used with Latest End Date to track a date range for an address that's no longer in use.</inlineHelpText>
         <label>Latest Start Date</label>
         <required>false</required>
         <trackFeedHistory>false</trackFeedHistory>


### PR DESCRIPTION
Changed Latest Start/End Date descriptions to distinguish these fields from the Seasonal Address fields, which also appear at the bottom of this same interface.