### PR TITLE
Adding english translations to support build process scripts

### DIFF
--- a/src/objectTranslations/Addr_Verification_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Addr_Verification_Settings__c-en_US.objectTranslation
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Address Verification Settings</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Address Verification Settings</value>
+    </caseValues>
+    <fields>
+        <help><!-- URL used for address verification. --></help>
+        <label><!-- Address Verification URL --></label>
+        <name>Address_Verification_Endpoint__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Authentication ID. --></help>
+        <label><!-- Auth ID --></label>
+        <name>Auth_ID__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Authentication Token. --></help>
+        <label><!-- Auth Token --></label>
+        <name>Auth_Token__c</name>
+    </fields>
+    <fields>
+        <help><!-- Salesforce class responsible for contacting the web service and verifying addresses. --></help>
+        <label><!-- Verification Service --></label>
+        <name>Class__c</name>
+    </fields>
+    <fields>
+        <help><!-- Enables automatic address verification for new addresses. --></help>
+        <label><!-- Enable Automatic Verification --></label>
+        <name>Enable_Automatic_Verification__c</name>
+    </fields>
+    <fields>
+        <help><!-- Marks ambiguous addresses as invalid, when the API returns more than one address. If left unselected, Salesforce will accept the first suggested address as the valid address. --></help>
+        <label><!-- Reject Ambiguous Addresses --></label>
+        <name>Reject_Ambiguous_Addresses__c</name>
+    </fields>
+    <fields>
+        <help><!-- Callout timeout in seconds. --></help>
+        <label><!-- Timeout --></label>
+        <name>Timeout__c</name>
+    </fields>
+    <fields>
+        <help><!-- Specifies whether or not you are using the SmartyStreets address verification service. --></help>
+        <label><!-- DEPRECATED - Using SmartyStreets --></label>
+        <name>Using_SmartyStreets__c</name>
+    </fields>
+    <fields>
+        <help><!-- URL used for zip code verification. --></help>
+        <label><!-- Zipcode Verification Endpoint --></label>
+        <name>Zipcode_Verification_Endpoint__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Address_Verification_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Address_Verification_Settings__c-en_US.objectTranslation
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Address Verification Settings-DEPRECATED</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Address Verification Settings-DEPRECATED</value>
+    </caseValues>
+    <fields>
+        <help><!-- URL used for address verification. --></help>
+        <label><!-- Address Verification Endpoint-DEPRECATED --></label>
+        <name>Address_Verification_Endpoint__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Auth ID from your Secret Pair Key. --></help>
+        <label><!-- Auth ID-DEPRECATED --></label>
+        <name>Auth_ID__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Auth Token from your Secret Pair Key. --></help>
+        <label><!-- Auth Token-DEPRECATED --></label>
+        <name>Auth_Token__c</name>
+    </fields>
+    <fields>
+        <help><!-- If checked, changed addresses get updated automatically with the response from the service (when there is one verified result). --></help>
+        <label><!-- Auto-Update Addresses-DEPRECATED --></label>
+        <name>Auto_Update_Addresses__c</name>
+    </fields>
+    <fields>
+        <help><!-- Salesforce class responsible for contacting the SmartyStreets API and verifying addresses. --></help>
+        <label><!-- Class-DEPRECATED --></label>
+        <name>Class__c</name>
+    </fields>
+    <fields>
+        <help><!-- If checked, any US account address that the service marks undeliverable will automatically get cleared out. (You can review the invalid entry in the Address record.) --></help>
+        <label><!-- Clear Invalid Addresses-DEPRECATED --></label>
+        <name>Clear_Invalid_Addresses__c</name>
+    </fields>
+    <fields>
+        <help><!-- Enables automatic address verification for new addresses. --></help>
+        <label><!-- Enable Automatic Verification-DEPRECATED --></label>
+        <name>Enable_Automatic_Verification__c</name>
+    </fields>
+    <fields>
+        <help><!-- Marks ambiguous addresses as invalid, when the API returns more than one address. If left unselected, Salesforce will accept the first suggested address as the valid address. --></help>
+        <label><!-- Reject Ambiguous Addresses-DEPRECATED --></label>
+        <name>Reject_Ambiguous_Addresses__c</name>
+    </fields>
+    <fields>
+        <help><!-- Callout timeout in seconds --></help>
+        <label><!-- Timeout-DEPRECATED --></label>
+        <name>Timeout__c</name>
+    </fields>
+    <fields>
+        <help><!-- Specifies whether or not you are using the SmartyStreets address verification service. --></help>
+        <label><!-- Using SmartyStreets-DEPRECATED --></label>
+        <name>Using_SmartyStreets__c</name>
+    </fields>
+    <fields>
+        <help><!-- URL used for zip code verification. --></help>
+        <label><!-- Zipcode Verification Endpoint-DEPRECATED --></label>
+        <name>Zipcode_Verification_Endpoint__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Address__c-en_US.objectTranslation
+++ b/src/objectTranslations/Address__c-en_US.objectTranslation
@@ -1,0 +1,523 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Address</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Addresses</value>
+    </caseValues>
+    <fields>
+        <help><!-- Contains the raw response or an error message. --></help>
+        <label><!-- API Response --></label>
+        <name>API_Response__c</name>
+    </fields>
+    <fields>
+        <label><!-- Address Type --></label>
+        <name>Address_Type__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation><!-- Home --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation><!-- Other --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Vacation Residence</masterLabel>
+            <translation><!-- Vacation Residence --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation><!-- Work --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Depending on the country and area, could be a city, township, municipality or other civic region associated with this address. --></help>
+        <label><!-- Administrative Area --></label>
+        <name>Administrative_Area__c</name>
+    </fields>
+    <fields>
+        <help><!-- Indicates whether more than on valid address was found when attempting to validate it through an external service. --></help>
+        <label><!-- Ambiguous --></label>
+        <name>Ambiguous__c</name>
+    </fields>
+    <fields>
+        <help><!-- The congressional district to which the address belongs pertains. --></help>
+        <label><!-- Congressional District --></label>
+        <name>Congressional_District__c</name>
+    </fields>
+    <fields>
+        <help><!-- Name of the county the address is located at. --></help>
+        <label><!-- County Name --></label>
+        <name>County_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- Is this the Default Address to use for the Household and its Contacts? --></help>
+        <label><!-- Default Address --></label>
+        <name>Default_Address__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing Address --></label>
+        <name>Formula_MailingAddress__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing Street Address --></label>
+        <name>Formula_MailingStreetAddress__c</name>
+    </fields>
+    <fields>
+        <help><!-- Location expressed as latitude and longitude. --></help>
+        <label><!-- Geolocation --></label>
+        <name>Geolocation__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Account this Address is for. --></help>
+        <label><!-- Account --></label>
+        <name>Household_Account__c</name>
+        <relationshipLabel><!-- Addresses --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The most recent ending date that this address was used. Generally used with Latest Start Date to track a date range for an address that&apos;s no longer in use. --></help>
+        <label><!-- Latest End Date --></label>
+        <name>Latest_End_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- The most recent starting date that this address was used. Generally used with Latest End Date to track a date range for an address that&apos;s no longer in use. --></help>
+        <label><!-- Latest Start Date --></label>
+        <name>Latest_Start_Date__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing City --></label>
+        <name>MailingCity__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing Country --></label>
+        <name>MailingCountry__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing Zip/Postal Code --></label>
+        <name>MailingPostalCode__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing State/Province --></label>
+        <name>MailingState__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing Street2 --></label>
+        <name>MailingStreet2__c</name>
+    </fields>
+    <fields>
+        <label><!-- Mailing Street --></label>
+        <name>MailingStreet__c</name>
+    </fields>
+    <fields>
+        <help><!-- Stores the address as entered before verification with a remote service, in case any information is lost in the verification process. --></help>
+        <label><!-- Pre-Verification Address --></label>
+        <name>Pre_Verification_Address__c</name>
+    </fields>
+    <fields>
+        <help><!-- The day of the month when this address no longer replaces the default address. --></help>
+        <label><!-- Seasonal End Day --></label>
+        <name>Seasonal_End_Day__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>13</masterLabel>
+            <translation><!-- 13 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>14</masterLabel>
+            <translation><!-- 14 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>15</masterLabel>
+            <translation><!-- 15 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>16</masterLabel>
+            <translation><!-- 16 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>17</masterLabel>
+            <translation><!-- 17 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>18</masterLabel>
+            <translation><!-- 18 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>19</masterLabel>
+            <translation><!-- 19 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>20</masterLabel>
+            <translation><!-- 20 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>21</masterLabel>
+            <translation><!-- 21 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>22</masterLabel>
+            <translation><!-- 22 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>23</masterLabel>
+            <translation><!-- 23 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>24</masterLabel>
+            <translation><!-- 24 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>25</masterLabel>
+            <translation><!-- 25 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>26</masterLabel>
+            <translation><!-- 26 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>27</masterLabel>
+            <translation><!-- 27 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>28</masterLabel>
+            <translation><!-- 28 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>29</masterLabel>
+            <translation><!-- 29 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>30</masterLabel>
+            <translation><!-- 30 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>31</masterLabel>
+            <translation><!-- 31 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- The month of the year when this address no longer replaces the default address. --></help>
+        <label><!-- Seasonal End Month --></label>
+        <name>Seasonal_End_Month__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- The day of the month when this address replaces the default address. --></help>
+        <label><!-- Seasonal Start Day --></label>
+        <name>Seasonal_Start_Day__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>13</masterLabel>
+            <translation><!-- 13 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>14</masterLabel>
+            <translation><!-- 14 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>15</masterLabel>
+            <translation><!-- 15 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>16</masterLabel>
+            <translation><!-- 16 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>17</masterLabel>
+            <translation><!-- 17 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>18</masterLabel>
+            <translation><!-- 18 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>19</masterLabel>
+            <translation><!-- 19 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>20</masterLabel>
+            <translation><!-- 20 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>21</masterLabel>
+            <translation><!-- 21 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>22</masterLabel>
+            <translation><!-- 22 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>23</masterLabel>
+            <translation><!-- 23 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>24</masterLabel>
+            <translation><!-- 24 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>25</masterLabel>
+            <translation><!-- 25 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>26</masterLabel>
+            <translation><!-- 26 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>27</masterLabel>
+            <translation><!-- 27 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>28</masterLabel>
+            <translation><!-- 28 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>29</masterLabel>
+            <translation><!-- 29 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>30</masterLabel>
+            <translation><!-- 30 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>31</masterLabel>
+            <translation><!-- 31 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- The month of the year when this address replaces the default address. --></help>
+        <label><!-- Seasonal Start Month --></label>
+        <name>Seasonal_Start_Month__c</name>
+        <picklistValues>
+            <masterLabel>1</masterLabel>
+            <translation><!-- 1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>10</masterLabel>
+            <translation><!-- 10 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>11</masterLabel>
+            <translation><!-- 11 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>12</masterLabel>
+            <translation><!-- 12 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>2</masterLabel>
+            <translation><!-- 2 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>3</masterLabel>
+            <translation><!-- 3 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>4</masterLabel>
+            <translation><!-- 4 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>5</masterLabel>
+            <translation><!-- 5 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>6</masterLabel>
+            <translation><!-- 6 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>7</masterLabel>
+            <translation><!-- 7 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>8</masterLabel>
+            <translation><!-- 8 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>9</masterLabel>
+            <translation><!-- 9 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- The state lower district (such as a state assembly district) this address belongs to. --></help>
+        <label><!-- State Lower District --></label>
+        <name>State_Lower_District__c</name>
+    </fields>
+    <fields>
+        <help><!-- The state upper district (such as state senate district) this address belongs to. --></help>
+        <label><!-- State Upper District --></label>
+        <name>State_Upper_District__c</name>
+    </fields>
+    <fields>
+        <help><!-- If this address requires verification, click the Verify Address button at the top of this page. Consult the Help documentation in the Power of Us Hub for more information. --></help>
+        <label><!-- Verification Status --></label>
+        <name>Verification_Status__c</name>
+    </fields>
+    <fields>
+        <help><!-- Indicates whether the address has been verified by an external address verification service. --></help>
+        <label><!-- Verified --></label>
+        <name>Verified__c</name>
+    </fields>
+    <layouts>
+        <layout>Address Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label><!-- Seasonal Information --></label>
+            <section>Seasonal Information</section>
+        </sections>
+    </layouts>
+    <quickActions>
+        <label><!-- Update Address --></label>
+        <name>Update_Address</name>
+    </quickActions>
+    <startsWith>Vowel</startsWith>
+    <webLinks>
+        <label><!-- Verify_Address --></label>
+        <name>Verify_Address</name>
+    </webLinks>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Allocation__c-en_US.objectTranslation
+++ b/src/objectTranslations/Allocation__c-en_US.objectTranslation
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>GAU Allocation</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>GAU Allocations</value>
+    </caseValues>
+    <fields>
+        <help><!-- Amount of the opportunity to allocate to this general accounting unit. Leave blank for percent based allocations. --></help>
+        <label><!-- Amount --></label>
+        <name>Amount__c</name>
+    </fields>
+    <fields>
+        <help><!-- Optionally attributes allocations to a campaign. All new opportunities created with this campaign as primary campaign source will automatically be allocated in the same way. --></help>
+        <label><!-- Campaign --></label>
+        <name>Campaign__c</name>
+        <relationshipLabel><!-- GAU Allocations --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The general accounting unit to attribute this allocation. Only general accounting units marked as active are available for new allocations. --></help>
+        <label><!-- General Accounting Unit --></label>
+        <lookupFilter>
+            <errorMessage><!-- Allocations can only be assigned to active general accounting units. Allocations assigned to inactive general accounting units cannot be modified. --></errorMessage>
+            <informationalMessage><!-- Only active general accounting units can be selected. --></informationalMessage>
+        </lookupFilter>
+        <name>General_Accounting_Unit__c</name>
+        <relationshipLabel><!-- GAU Allocations --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Attributes allocations to an opportunity. All opportunities in a closed and won stage will be rolled up to this allocation&apos;s general accounting unit. --></help>
+        <label><!-- Opportunity --></label>
+        <name>Opportunity__c</name>
+        <relationshipLabel><!-- GAU Allocations --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Percent of opportunity amount to allocate to this general accounting unit. Modifying an opportunity amount of a percent based allocation will modify the allocation amount. --></help>
+        <label><!-- Percent --></label>
+        <name>Percent__c</name>
+    </fields>
+    <fields>
+        <help><!-- Optionally attributes allocations to a recurring donation. All new opportunities created with this recurring donation schedule will automatically be allocated in the same way. --></help>
+        <label><!-- Recurring Donation --></label>
+        <name>Recurring_Donation__c</name>
+        <relationshipLabel><!-- GAU Allocations --></relationshipLabel>
+    </fields>
+    <layouts>
+        <layout>Allocation Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Vowel</startsWith>
+    <webLinks>
+        <label><!-- Manage_Allocations --></label>
+        <name>Manage_Allocations</name>
+    </webLinks>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Allocations_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Allocations_Settings__c-en_US.objectTranslation
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Allocations Settings</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Allocations Settings</value>
+    </caseValues>
+    <fields>
+        <help><!-- Enabling Default Allocations creates an Allocation object for each Opportunity. This enables reporting on allocations to a default General Accounting Unit, but uses more data storage. --></help>
+        <label><!-- Default Allocations Enabled --></label>
+        <name>Default_Allocations_Enabled__c</name>
+    </fields>
+    <fields>
+        <help><!-- Holds the ID of the default General Accounting Unit for creation of default allocations or for the allocation of non allocated amounts. --></help>
+        <label><!-- Default General Accounting Unit --></label>
+        <name>Default__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity Record Types to exclude from calculations of Allocations rollups. --></help>
+        <label><!-- Excluded Opp RecTypes --></label>
+        <name>Excluded_Opp_RecTypes__c</name>
+    </fields>
+    <fields>
+        <help><!-- Excluded Opportunity Types from Allocations rollups. --></help>
+        <label><!-- Excluded Opp Types --></label>
+        <name>Excluded_Opp_Types__c</name>
+    </fields>
+    <fields>
+        <help><!-- This value affects the number of days to count for N Days Allocations rollup fields. --></help>
+        <label><!-- Rollup N Day Value --></label>
+        <name>Rollup_N_Day_Value__c</name>
+    </fields>
+    <fields>
+        <help><!-- Checking this box will cause Allocation rollup totals to respect fiscal year, instead of calendar years settings. To set Fiscal Year information, go to Setup-&gt;Company Profile-&gt;Fiscal Year. NOTE: Custom Fiscal Year Settings are NOT supported. --></help>
+        <label><!-- Use Fiscal Year for Rollups --></label>
+        <name>Use_Fiscal_Year_for_Rollups__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Batch_Data_Entry_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Batch_Data_Entry_Settings__c-en_US.objectTranslation
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Batch Data Entry Settings</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Batch Data Entry Settings</value>
+    </caseValues>
+    <fields>
+        <help><!-- If set, then Batch Data Entry will never name Opportunities, even if they are blank (not included on the BDE page). --></help>
+        <label><!-- Allow Blank Opportunity Names --></label>
+        <name>Allow_Blank_Opportunity_Names__c</name>
+    </fields>
+    <fields>
+        <help><!-- This setting automatically generates the record name for batch entered Opportunity records based on the value of the entered fields. --></help>
+        <label><!-- Opportunity Naming --></label>
+        <name>Opportunity_Naming__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Batch__c-en_US.objectTranslation
+++ b/src/objectTranslations/Batch__c-en_US.objectTranslation
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Batch</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Batches</value>
+    </caseValues>
+    <fields>
+        <label><!-- Batch Status --></label>
+        <name>Batch_Status__c</name>
+        <picklistValues>
+            <masterLabel>Complete</masterLabel>
+            <translation><!-- Complete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>In Progress</masterLabel>
+            <translation><!-- In Progress --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <label><!-- Description --></label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <label><!-- Number of Items --></label>
+        <name>Number_of_Items__c</name>
+    </fields>
+    <fields>
+        <help><!-- API Name of the object of which this is a batch. --></help>
+        <label><!-- Object Name --></label>
+        <name>Object_Name__c</name>
+    </fields>
+    <layouts>
+        <layout>Batch Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/DataImport__c-en_US.objectTranslation
+++ b/src/objectTranslations/DataImport__c-en_US.objectTranslation
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>NPSP Data Import</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>NPSP Data Imports</value>
+    </caseValues>
+    <fields>
+        <label><!-- Account1 Import Status --></label>
+        <name>Account1ImportStatus__c</name>
+    </fields>
+    <fields>
+        <label><!-- Account1 Imported --></label>
+        <name>Account1Imported__c</name>
+        <relationshipLabel><!-- NPSP Data Imports (Account1 Imported) --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Account1.BillingCity --></help>
+        <label><!-- Account1 City --></label>
+        <name>Account1_City__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account1.BillingCountry --></help>
+        <label><!-- Account1 Country --></label>
+        <name>Account1_Country__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account1.Name --></help>
+        <label><!-- Account1 Name --></label>
+        <name>Account1_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account1.Phone --></help>
+        <label><!-- Account1 Phone --></label>
+        <name>Account1_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account1.BillingState --></help>
+        <label><!-- Account1 State/Province --></label>
+        <name>Account1_State_Province__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account1.BillingStreet --></help>
+        <label><!-- Account1 Street --></label>
+        <name>Account1_Street__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account1.Website --></help>
+        <label><!-- Account1 Website --></label>
+        <name>Account1_Website__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account1.BillingPostalCode --></help>
+        <label><!-- Account1 Zip/Postal Code --></label>
+        <name>Account1_Zip_Postal_Code__c</name>
+    </fields>
+    <fields>
+        <label><!-- Account2 Import Status --></label>
+        <name>Account2ImportStatus__c</name>
+    </fields>
+    <fields>
+        <label><!-- Account2 Imported --></label>
+        <name>Account2Imported__c</name>
+        <relationshipLabel><!-- NPSP Data Imports (Account2 Imported) --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Account2.BillingCity --></help>
+        <label><!-- Account2 City --></label>
+        <name>Account2_City__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account2.BillingCountry --></help>
+        <label><!-- Account2 Country --></label>
+        <name>Account2_Country__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account2.Name --></help>
+        <label><!-- Account2 Name --></label>
+        <name>Account2_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account2.Phone --></help>
+        <label><!-- Account2 Phone --></label>
+        <name>Account2_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account2.BillingState --></help>
+        <label><!-- Account2 State/Province --></label>
+        <name>Account2_State_Province__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account2.BillingStreet --></help>
+        <label><!-- Account2 Street --></label>
+        <name>Account2_Street__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account2.Website --></help>
+        <label><!-- Account2 Website --></label>
+        <name>Account2_Website__c</name>
+    </fields>
+    <fields>
+        <help><!-- Account2.BillingPostalCode --></help>
+        <label><!-- Account2 Zip/Postal Code --></label>
+        <name>Account2_Zip_Postal_Code__c</name>
+    </fields>
+    <fields>
+        <help><!-- The ApexJobID of the Batch Job that processed the record. --></help>
+        <label><!-- ApexJobId --></label>
+        <name>ApexJobId__c</name>
+    </fields>
+    <fields>
+        <label><!-- Campaign Member Status --></label>
+        <name>Campaign_Member_Status__c</name>
+    </fields>
+    <fields>
+        <label><!-- Contact1 Import Status --></label>
+        <name>Contact1ImportStatus__c</name>
+    </fields>
+    <fields>
+        <label><!-- Contact1 Imported --></label>
+        <name>Contact1Imported__c</name>
+        <relationshipLabel><!-- NPSP Data Imports (Contact1 Imported) --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Contact1.npe01__AlternateEmail__c --></help>
+        <label><!-- Contact1 Alternate Email --></label>
+        <name>Contact1_Alternate_Email__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.Birthdate --></help>
+        <label><!-- Contact1 Birthdate --></label>
+        <name>Contact1_Birthdate__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.Firstname --></help>
+        <label><!-- Contact1 First Name --></label>
+        <name>Contact1_Firstname__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.HomePhone --></help>
+        <label><!-- Contact1 Home Phone --></label>
+        <name>Contact1_Home_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.Lastname --></help>
+        <label><!-- Contact1 Last Name --></label>
+        <name>Contact1_Lastname__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.MobilePhone --></help>
+        <label><!-- Contact1 Mobile Phone --></label>
+        <name>Contact1_Mobile_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.OtherPhone --></help>
+        <label><!-- Contact1 Other Phone --></label>
+        <name>Contact1_Other_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.npe01__HomeEmail__c --></help>
+        <label><!-- Contact1 Personal Email --></label>
+        <name>Contact1_Personal_Email__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.npe01__Preferred_Email__c --></help>
+        <label><!-- Contact1 Preferred Email --></label>
+        <name>Contact1_Preferred_Email__c</name>
+        <picklistValues>
+            <masterLabel>Alternate</masterLabel>
+            <translation><!-- Alternate --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Personal</masterLabel>
+            <translation><!-- Personal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation><!-- Work --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Contact1.npe01__PreferredPhone__c --></help>
+        <label><!-- Contact1 Preferred Phone --></label>
+        <name>Contact1_Preferred_Phone__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation><!-- Home --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mobile</masterLabel>
+            <translation><!-- Mobile --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation><!-- Other --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation><!-- Work --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Contact1.Salutation --></help>
+        <label><!-- Contact1 Salutation --></label>
+        <name>Contact1_Salutation__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.Title --></help>
+        <label><!-- Contact1 Title --></label>
+        <name>Contact1_Title__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.npe01__WorkEmail__c --></help>
+        <label><!-- Contact1 Work Email --></label>
+        <name>Contact1_Work_Email__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact1.npe01__WorkPhone__c --></help>
+        <label><!-- Contact1 Work Phone --></label>
+        <name>Contact1_Work_Phone__c</name>
+    </fields>
+    <fields>
+        <label><!-- Contact2 Import Status --></label>
+        <name>Contact2ImportStatus__c</name>
+    </fields>
+    <fields>
+        <label><!-- Contact2 Imported --></label>
+        <name>Contact2Imported__c</name>
+        <relationshipLabel><!-- NPSP Data Imports (Contact2 Imported) --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Contact2.npe01__AlternateEmail__c --></help>
+        <label><!-- Contact2 Alternate Email --></label>
+        <name>Contact2_Alternate_Email__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.Birthdate --></help>
+        <label><!-- Contact2 Birthdate --></label>
+        <name>Contact2_Birthdate__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.Firstname --></help>
+        <label><!-- Contact2 First Name --></label>
+        <name>Contact2_Firstname__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.HomePhone --></help>
+        <label><!-- Contact2 Home Phone --></label>
+        <name>Contact2_Home_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.Lastname --></help>
+        <label><!-- Contact2 Last Name --></label>
+        <name>Contact2_Lastname__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.MobilePhone --></help>
+        <label><!-- Contact2 Mobile Phone --></label>
+        <name>Contact2_Mobile_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.OtherPhone --></help>
+        <label><!-- Contact2 Other Phone --></label>
+        <name>Contact2_Other_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.npe01__HomeEmail__c --></help>
+        <label><!-- Contact2 Personal Email --></label>
+        <name>Contact2_Personal_Email__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.npe01__Preferred_Email__c --></help>
+        <label><!-- Contact2 Preferred Email --></label>
+        <name>Contact2_Preferred_Email__c</name>
+        <picklistValues>
+            <masterLabel>Alternate</masterLabel>
+            <translation><!-- Alternate --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Personal</masterLabel>
+            <translation><!-- Personal --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation><!-- Work --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Contact2.npe01__PreferredPhone__c --></help>
+        <label><!-- Contact2 Preferred Phone --></label>
+        <name>Contact2_Preferred_Phone__c</name>
+        <picklistValues>
+            <masterLabel>Home</masterLabel>
+            <translation><!-- Home --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Mobile</masterLabel>
+            <translation><!-- Mobile --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Other</masterLabel>
+            <translation><!-- Other --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Work</masterLabel>
+            <translation><!-- Work --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Contact2.Salutation --></help>
+        <label><!-- Contact2 Salutation --></label>
+        <name>Contact2_Salutation__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.Title --></help>
+        <label><!-- Contact2 Title --></label>
+        <name>Contact2_Title__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.npe01__WorkEmail__c --></help>
+        <label><!-- Contact2 Work Email --></label>
+        <name>Contact2_Work_Email__c</name>
+    </fields>
+    <fields>
+        <help><!-- Contact2.npe01__WorkPhone__c --></help>
+        <label><!-- Contact2 Work Phone --></label>
+        <name>Contact2_Work_Phone__c</name>
+    </fields>
+    <fields>
+        <label><!-- Donation Import Status --></label>
+        <name>DonationImportStatus__c</name>
+    </fields>
+    <fields>
+        <label><!-- Donation Imported --></label>
+        <name>DonationImported__c</name>
+        <relationshipLabel><!-- NPSP Data Imports --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.Amount --></help>
+        <label><!-- Donation Amount --></label>
+        <name>Donation_Amount__c</name>
+    </fields>
+    <fields>
+        <label><!-- Campaign Name --></label>
+        <name>Donation_Campaign_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.CloseDate --></help>
+        <label><!-- Donation Date --></label>
+        <name>Donation_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.Description --></help>
+        <label><!-- Donation Description --></label>
+        <name>Donation_Description__c</name>
+    </fields>
+    <fields>
+        <help><!-- Specifies whether the donation is an individual donation from Contact1, or an organizational donation from Account1. --></help>
+        <label><!-- Donation Donor --></label>
+        <name>Donation_Donor__c</name>
+        <picklistValues>
+            <masterLabel>Account1</masterLabel>
+            <translation><!-- Account1 --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Contact1</masterLabel>
+            <translation><!-- Contact1 --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.npe01__Member_Level__c --></help>
+        <label><!-- Donation Member Level --></label>
+        <name>Donation_Member_Level__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.npe01__Membership_End_Date__c --></help>
+        <label><!-- Donation Membership End Date --></label>
+        <name>Donation_Membership_End_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.npe01__Membership_Origin__c --></help>
+        <label><!-- Donation Membership Origin --></label>
+        <name>Donation_Membership_Origin__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.npe01__Membership_Start_Date__c --></help>
+        <label><!-- Donation Membership Start Date --></label>
+        <name>Donation_Membership_Start_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.Name --></help>
+        <label><!-- Donation Name --></label>
+        <name>Donation_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- The Name of the Opportunity Record Type to use for the donation. Uses default Record Type if left blank. --></help>
+        <label><!-- Donation Record Type Name --></label>
+        <name>Donation_Record_Type_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.StageName --></help>
+        <label><!-- Donation Stage --></label>
+        <name>Donation_Stage__c</name>
+    </fields>
+    <fields>
+        <help><!-- Opportunity.Type --></help>
+        <label><!-- Donation Type --></label>
+        <name>Donation_Type__c</name>
+    </fields>
+    <fields>
+        <help><!-- Description of what caused the Data Import record to fail to be imported. --></help>
+        <label><!-- Failure Information --></label>
+        <name>FailureInformation__c</name>
+    </fields>
+    <fields>
+        <label><!-- Home Address Import Status --></label>
+        <name>HomeAddressImportStatus__c</name>
+    </fields>
+    <fields>
+        <label><!-- Home Address Imported --></label>
+        <name>HomeAddressImported__c</name>
+        <relationshipLabel><!-- NPSP Data Imports --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Address.npsp__MailingCity__c --></help>
+        <label><!-- Home City --></label>
+        <name>Home_City__c</name>
+    </fields>
+    <fields>
+        <help><!-- Address.npsp__MailingCountry__c --></help>
+        <label><!-- Home Country --></label>
+        <name>Home_Country__c</name>
+    </fields>
+    <fields>
+        <help><!-- Address.npsp__MailingState__c --></help>
+        <label><!-- Home State/Province --></label>
+        <name>Home_State_Province__c</name>
+    </fields>
+    <fields>
+        <help><!-- Address.npsp__MailingStreet__c --></help>
+        <label><!-- Home Street --></label>
+        <name>Home_Street__c</name>
+    </fields>
+    <fields>
+        <help><!-- Address.npsp__MailingPostalCode__c --></help>
+        <label><!-- Home Zip/Postal Code --></label>
+        <name>Home_Zip_Postal_Code__c</name>
+    </fields>
+    <fields>
+        <label><!-- Household Account Imported --></label>
+        <name>HouseholdAccountImported__c</name>
+        <relationshipLabel><!-- NPSP Data Imports (Household Account Imported) --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- Household.Phone --></help>
+        <label><!-- Household Phone --></label>
+        <name>Household_Phone__c</name>
+    </fields>
+    <fields>
+        <help><!-- When the Data Import record was successfully imported. --></help>
+        <label><!-- Imported Date --></label>
+        <name>ImportedDate__c</name>
+    </fields>
+    <fields>
+        <help><!-- Payment.npe01__Check_Reference_Number__c --></help>
+        <label><!-- Payment Check/Reference Number --></label>
+        <name>Payment_Check_Reference_Number__c</name>
+    </fields>
+    <fields>
+        <help><!-- Payment.npe01__Payment_Method__c --></help>
+        <label><!-- Payment Method --></label>
+        <name>Payment_Method__c</name>
+    </fields>
+    <fields>
+        <help><!-- The status of importing the Data Import record. --></help>
+        <label><!-- Status --></label>
+        <name>Status__c</name>
+        <picklistValues>
+            <masterLabel>Failed</masterLabel>
+            <translation><!-- Failed --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Imported</masterLabel>
+            <translation><!-- Imported --></translation>
+        </picklistValues>
+    </fields>
+    <layouts>
+        <layout>Data Import Layout</layout>
+        <sections>
+            <label><!-- Account1 Organization Information --></label>
+            <section>Account1 Organization Information</section>
+        </sections>
+        <sections>
+            <label><!-- Account2 Organization Information --></label>
+            <section>Account2 Organization Information</section>
+        </sections>
+        <sections>
+            <label><!-- Campaign Information --></label>
+            <section>Campaign Information</section>
+        </sections>
+        <sections>
+            <label><!-- Contact1 Information --></label>
+            <section>Contact1 Information</section>
+        </sections>
+        <sections>
+            <label><!-- Contact2 Information --></label>
+            <section>Contact2 Information</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label><!-- Donation Information --></label>
+            <section>Donation Information</section>
+        </sections>
+        <sections>
+            <label><!-- Home Address --></label>
+            <section>Home Address</section>
+        </sections>
+        <sections>
+            <label><!-- Household Account Information --></label>
+            <section>Household Account Information</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+    <webLinks>
+        <label><!-- Delete_All_Data_Import_Records --></label>
+        <name>Delete_All_Data_Import_Records</name>
+    </webLinks>
+    <webLinks>
+        <label><!-- Delete_Imported_Data_Import_Records --></label>
+        <name>Delete_Imported_Data_Import_Records</name>
+    </webLinks>
+    <webLinks>
+        <label><!-- Process_Data_Import --></label>
+        <name>Process_Data_Import</name>
+    </webLinks>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Data_Import_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Data_Import_Settings__c-en_US.objectTranslation
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Data Import Settings</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Data Import Settings</value>
+    </caseValues>
+    <fields>
+        <help><!-- An optional Unique Id field to use for Organization Account matching --></help>
+        <label><!-- Account Custom Unique ID --></label>
+        <name>Account_Custom_Unique_ID__c</name>
+    </fields>
+    <fields>
+        <help><!-- Specifies which rule to follow when trying to match Accounts in Data Import records against existing Accounts. --></help>
+        <label><!-- Account Matching Rule --></label>
+        <name>Account_Matching_Rule__c</name>
+    </fields>
+    <fields>
+        <help><!-- The number of NPSP Data Import records to process in each batch. --></help>
+        <label><!-- Batch Size --></label>
+        <name>Batch_Size__c</name>
+    </fields>
+    <fields>
+        <help><!-- An optional Unique Id field to use for Contact matching --></help>
+        <label><!-- Contact Custom Unique ID --></label>
+        <name>Contact_Custom_Unique_ID__c</name>
+    </fields>
+    <fields>
+        <help><!-- Specifies which rule to follow when trying to match Contacts in Data Import records against existing Contacts. --></help>
+        <label><!-- Contact Matching Rule --></label>
+        <name>Contact_Matching_Rule__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Error_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Error_Settings__c-en_US.objectTranslation
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Error Settings</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Error Settings</value>
+    </caseValues>
+    <fields>
+        <help><!-- If checked, NPSP&apos;s error handling framework is disabled. --></help>
+        <label><!-- Disable Error Handling --></label>
+        <name>Disable_Error_Handling__c</name>
+    </fields>
+    <fields>
+        <help><!-- Turn this on to enable debug statements in managed package code. --></help>
+        <label><!-- Enable Debug --></label>
+        <name>Enable_Debug__c</name>
+    </fields>
+    <fields>
+        <help><!-- Check this if you&apos;d like the system to post notifications for certain type of errors. --></help>
+        <label><!-- Error Notifications --></label>
+        <name>Error_Notifications_On__c</name>
+    </fields>
+    <fields>
+        <help><!-- Select the type of user to send notifications to. --></help>
+        <label><!-- Error Notification Recipients --></label>
+        <name>Error_Notifications_To__c</name>
+    </fields>
+    <fields>
+        <help><!-- Check this if you&apos;d like errors to be stored in the database. --></help>
+        <label><!-- Store Errors --></label>
+        <name>Store_Errors_On__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Error__c-en_US.objectTranslation
+++ b/src/objectTranslations/Error__c-en_US.objectTranslation
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Error</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Errors</value>
+    </caseValues>
+    <fields>
+        <help><!-- Context that generated the error, if known. --></help>
+        <label><!-- Context Type --></label>
+        <name>Context_Type__c</name>
+    </fields>
+    <fields>
+        <help><!-- Date &amp; time the error occurred --></help>
+        <label><!-- Datetime --></label>
+        <name>Datetime__c</name>
+    </fields>
+    <fields>
+        <help><!-- Indicates whether an email notification has been sent regarding this error. --></help>
+        <label><!-- Email Sent --></label>
+        <name>Email_Sent__c</name>
+    </fields>
+    <fields>
+        <help><!-- Type of error that occurred --></help>
+        <label><!-- Error Type --></label>
+        <name>Error_Type__c</name>
+    </fields>
+    <fields>
+        <help><!-- Full text of the error message --></help>
+        <label><!-- Full Message --></label>
+        <name>Full_Message__c</name>
+    </fields>
+    <fields>
+        <help><!-- Type of object on which the error occurred, if known. --></help>
+        <label><!-- Object Type --></label>
+        <name>Object_Type__c</name>
+    </fields>
+    <fields>
+        <help><!-- Indicates whether the error has been posted in Chatter. --></help>
+        <label><!-- Posted in Chatter --></label>
+        <name>Posted_in_Chatter__c</name>
+    </fields>
+    <fields>
+        <help><!-- A link to the record which caused the error, if available. --></help>
+        <label><!-- Record URL --></label>
+        <name>Record_URL__c</name>
+    </fields>
+    <fields>
+        <help><!-- Stack trace for the thrown error, if available at runtime. --></help>
+        <label><!-- Stack Trace --></label>
+        <name>Stack_Trace__c</name>
+    </fields>
+    <layouts>
+        <layout>Error Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Fund__c-en_US.objectTranslation
+++ b/src/objectTranslations/Fund__c-en_US.objectTranslation
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>DEPRECATED-Fund</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>DEPRECATED-Funds</value>
+    </caseValues>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/General_Accounting_Unit__c-en_US.objectTranslation
+++ b/src/objectTranslations/General_Accounting_Unit__c-en_US.objectTranslation
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>General Accounting Unit</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>General Accounting Units</value>
+    </caseValues>
+    <fields>
+        <help><!-- Active general accounting units are available for selection on allocations. Inactive general accounting units can&apos;t have new allocations to them. --></help>
+        <label><!-- Active --></label>
+        <name>Active__c</name>
+    </fields>
+    <fields>
+        <help><!-- The average of all allocations of all time to this general accounting unit. --></help>
+        <label><!-- Average Allocation --></label>
+        <name>Average_Allocation__c</name>
+    </fields>
+    <fields>
+        <help><!-- Extra information about this general accounting unit. --></help>
+        <label><!-- Description --></label>
+        <name>Description__c</name>
+    </fields>
+    <fields>
+        <help><!-- The first Opportunity Close Date of an allocation associated with this general accounting unit. --></help>
+        <label><!-- First Allocation Date --></label>
+        <name>First_Allocation_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- The largest allocation of all time to this general accounting unit. --></help>
+        <label><!-- Largest Allocation --></label>
+        <name>Largest_Allocation__c</name>
+    </fields>
+    <fields>
+        <help><!-- The last Opportunity Close Date of an allocation associated with this general accounting unit. --></help>
+        <label><!-- Last Allocation Date --></label>
+        <name>Last_Allocation_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- Total number of allocations of opportunities in a closed and won stage in the last N days. The value of N can be modified in settings. --></help>
+        <label><!-- Number of Allocations Last N Days --></label>
+        <name>Number_of_Allocations_Last_N_Days__c</name>
+    </fields>
+    <fields>
+        <help><!-- Total number of allocations of opportunities in a closed and won stage last year. --></help>
+        <label><!-- Number of Allocations Last Year --></label>
+        <name>Number_of_Allocations_Last_Year__c</name>
+    </fields>
+    <fields>
+        <help><!-- Total number of allocations of opportunities in a closed and won stage this year. --></help>
+        <label><!-- Number of Allocations This Year --></label>
+        <name>Number_of_Allocations_This_Year__c</name>
+    </fields>
+    <fields>
+        <help><!-- Total number of allocations of opportunities in a closed and won stage two years ago. --></help>
+        <label><!-- Number of Allocations Two Years Ago --></label>
+        <name>Number_of_Allocations_Two_Years_Ago__c</name>
+    </fields>
+    <fields>
+        <help><!-- The smallest allocation of all time to this general accounting unit. --></help>
+        <label><!-- Smallest Allocation --></label>
+        <name>Smallest_Allocation__c</name>
+    </fields>
+    <fields>
+        <help><!-- Sum total of all allocations of opportunities in a closed and won stage in the last N days. The value of N can be modified in settings. --></help>
+        <label><!-- Total Allocations Last N Days --></label>
+        <name>Total_Allocations_Last_N_Days__c</name>
+    </fields>
+    <fields>
+        <help><!-- Sum total of all allocations of opportunities in a closed and won stage last year. --></help>
+        <label><!-- Total Allocations Last Year --></label>
+        <name>Total_Allocations_Last_Year__c</name>
+    </fields>
+    <fields>
+        <help><!-- Sum total of all allocations of opportunities in a closed and won stage this year. --></help>
+        <label><!-- Total Allocations This Year --></label>
+        <name>Total_Allocations_This_Year__c</name>
+    </fields>
+    <fields>
+        <help><!-- Sum total of all allocations of opportunities in a closed and won stage two years ago. --></help>
+        <label><!-- Total Allocations Two Years Ago --></label>
+        <name>Total_Allocations_Two_Years_Ago__c</name>
+    </fields>
+    <fields>
+        <help><!-- Sum total of all allocations of opportunities in a closed and won stage. --></help>
+        <label><!-- Total Allocations --></label>
+        <name>Total_Allocations__c</name>
+    </fields>
+    <fields>
+        <help><!-- Total number of allocations of opportunities in a closed and won stage. --></help>
+        <label><!-- Total Number of Allocations --></label>
+        <name>Total_Number_of_Allocations__c</name>
+    </fields>
+    <layouts>
+        <layout>General Accounting Unit Layout</layout>
+        <sections>
+            <label><!-- Allocation Information --></label>
+            <section>Allocation Information</section>
+        </sections>
+        <sections>
+            <label><!-- Allocation Totals --></label>
+            <section>Allocation Totals</section>
+        </sections>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+    <webLinks>
+        <label><!-- Recalculate_Rollups --></label>
+        <name>Recalculate_Rollups</name>
+    </webLinks>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Grant_Deadline__c-en_US.objectTranslation
+++ b/src/objectTranslations/Grant_Deadline__c-en_US.objectTranslation
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Grant Deadline</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Grant Deadlines</value>
+    </caseValues>
+    <fields>
+        <label><!-- Grant Deadline Due Date --></label>
+        <name>Grant_Deadline_Due_Date__c</name>
+    </fields>
+    <fields>
+        <help><!-- The date on which the deliverable was actually submitted. --></help>
+        <label><!-- Grant Deliverable Close Date --></label>
+        <name>Grant_Deliverable_Close_Date__c</name>
+    </fields>
+    <fields>
+        <label><!-- Grant Deliverable Requirements --></label>
+        <name>Grant_Deliverable_Requirements__c</name>
+    </fields>
+    <fields>
+        <label><!-- Grant Opportunity --></label>
+        <name>Opportunity__c</name>
+        <relationshipLabel><!-- Grant Deadlines --></relationshipLabel>
+    </fields>
+    <layouts>
+        <layout>Grant Deadline Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+        <sections>
+            <label><!-- Grant Deliverable Requirements --></label>
+            <section>Grant Deliverable Requirements</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Household_Naming_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Household_Naming_Settings__c-en_US.objectTranslation
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Household Naming Settings</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Household Naming Settings</value>
+    </caseValues>
+    <fields>
+        <help><!-- Specifies the number of Contacts to explicitly list in a name.  After that amount, the Name Overrun will be used. --></help>
+        <label><!-- Contact Overrun Count --></label>
+        <name>Contact_Overrun_Count__c</name>
+    </fields>
+    <fields>
+        <help><!-- The format to use for the Household Formal Greeting. --></help>
+        <label><!-- Formal Greeting Format --></label>
+        <name>Formal_Greeting_Format__c</name>
+    </fields>
+    <fields>
+        <help><!-- The format to use for the Household Name. --></help>
+        <label><!-- Household Name Format --></label>
+        <name>Household_Name_Format__c</name>
+    </fields>
+    <fields>
+        <help><!-- The name of a Class that implements the HH_INaming interface to use for Household Naming. --></help>
+        <label><!-- Implementing Class --></label>
+        <name>Implementing_Class__c</name>
+    </fields>
+    <fields>
+        <help><!-- The format to use for the Household Informal Greeting. --></help>
+        <label><!-- Informal Greeting Format --></label>
+        <name>Informal_Greeting_Format__c</name>
+    </fields>
+    <fields>
+        <help><!-- The string to use to connect pairs in a name.  For example, John &amp; Jane, or John and Jane. --></help>
+        <label><!-- Name Connector --></label>
+        <name>Name_Connector__c</name>
+    </fields>
+    <fields>
+        <help><!-- The string to use when replacing long lists of names. --></help>
+        <label><!-- Name Overrun --></label>
+        <name>Name_Overrun__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Opportunity_Naming_Settings__c-en_US.objectTranslation
+++ b/src/objectTranslations/Opportunity_Naming_Settings__c-en_US.objectTranslation
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Opportunity Naming Settings</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Opportunity Naming Settings</value>
+    </caseValues>
+    <fields>
+        <help><!-- Whether this setting applies to individual opportunities, organizational opportunities, or both. --></help>
+        <label><!-- Attribution --></label>
+        <name>Attribution__c</name>
+    </fields>
+    <fields>
+        <help><!-- The format for dates included in this opportunity name. --></help>
+        <label><!-- Date Format --></label>
+        <name>Date_Format__c</name>
+    </fields>
+    <fields>
+        <help><!-- The format to use for Opportunity naming. --></help>
+        <label><!-- Opportunity Name Format --></label>
+        <name>Opportunity_Name_Format__c</name>
+    </fields>
+    <fields>
+        <help><!-- Specifies the opportunity record type that this naming scheme is for. --></help>
+        <label><!-- Opportunity Record Types --></label>
+        <name>Opportunity_Record_Types__c</name>
+    </fields>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Partial_Soft_Credit__c-en_US.objectTranslation
+++ b/src/objectTranslations/Partial_Soft_Credit__c-en_US.objectTranslation
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Partial Soft Credit</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Partial Soft Credits</value>
+    </caseValues>
+    <fields>
+        <help><!-- The amount to be soft credited. --></help>
+        <label><!-- Amount --></label>
+        <name>Amount__c</name>
+    </fields>
+    <fields>
+        <help><!-- The contact&apos;s full name. --></help>
+        <label><!-- Contact Name --></label>
+        <name>Contact_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- The OpportunityContactRole this soft credit applies to. --></help>
+        <label><!-- Contact Role ID --></label>
+        <name>Contact_Role_ID__c</name>
+    </fields>
+    <fields>
+        <help><!-- The contact who gets this soft credit. --></help>
+        <label><!-- Contact --></label>
+        <name>Contact__c</name>
+        <relationshipLabel><!-- Partial Soft Credits --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The Opportunity this soft credit applies to. --></help>
+        <label><!-- Opportunity --></label>
+        <name>Opportunity__c</name>
+        <relationshipLabel><!-- Partial Soft Credits --></relationshipLabel>
+    </fields>
+    <fields>
+        <help><!-- The Role of this soft credit. --></help>
+        <label><!-- Role Name --></label>
+        <name>Role_Name__c</name>
+    </fields>
+    <layouts>
+        <layout>Partial Soft Credit Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+    <webLinks>
+        <label><!-- Manage_Soft_Credits --></label>
+        <name>Manage_Soft_Credits</name>
+    </webLinks>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Schedulable__c-en_US.objectTranslation
+++ b/src/objectTranslations/Schedulable__c-en_US.objectTranslation
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Schedulable</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Schedulabls</value>
+    </caseValues>
+    <fields>
+        <help><!-- Determines if the job will be active or not. --></help>
+        <label><!-- Active --></label>
+        <name>Active__c</name>
+    </fields>
+    <fields>
+        <help><!-- Class that will be scheduled to run at a certain frequency. --></help>
+        <label><!-- Class Name --></label>
+        <name>Class_Name__c</name>
+    </fields>
+    <fields>
+        <help><!-- How ofter to run the job. --></help>
+        <label><!-- Frequency --></label>
+        <name>Frequency__c</name>
+        <picklistValues>
+            <masterLabel>Daily</masterLabel>
+            <translation><!-- Daily --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Hourly</masterLabel>
+            <translation><!-- Hourly --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Monthly</masterLabel>
+            <translation><!-- Monthly --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Quarterly</masterLabel>
+            <translation><!-- Quarterly --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>Weekly</masterLabel>
+            <translation><!-- Weekly --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Last time the job was run. --></help>
+        <label><!-- Last Time Run --></label>
+        <name>Last_Time_Run__c</name>
+    </fields>
+    <layouts>
+        <layout>Schedulable Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Trigger_Handler__c-en_US.objectTranslation
+++ b/src/objectTranslations/Trigger_Handler__c-en_US.objectTranslation
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Trigger Handler</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Trigger Handlers</value>
+    </caseValues>
+    <fields>
+        <help><!-- Indicates that this module is active --></help>
+        <label><!-- Active --></label>
+        <name>Active__c</name>
+    </fields>
+    <fields>
+        <help><!-- Indicates that this module should be run asynchronously in this transaction, for any of its After events. --></help>
+        <label><!-- Asynchronous After Events --></label>
+        <name>Asynchronous__c</name>
+    </fields>
+    <fields>
+        <help><!-- Name of the class to be run --></help>
+        <label><!-- Class --></label>
+        <name>Class__c</name>
+    </fields>
+    <fields>
+        <help><!-- Order in which this module should be run, helps maintain dependencies in the modules and data. --></help>
+        <label><!-- Load Order --></label>
+        <name>Load_Order__c</name>
+    </fields>
+    <fields>
+        <help><!-- Name of the object this handler should be run for --></help>
+        <label><!-- Object --></label>
+        <name>Object__c</name>
+    </fields>
+    <fields>
+        <help><!-- Trigger Action in which this module should fire --></help>
+        <label><!-- Trigger Action --></label>
+        <name>Trigger_Action__c</name>
+        <picklistValues>
+            <masterLabel>AfterDelete</masterLabel>
+            <translation><!-- AfterDelete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterInsert</masterLabel>
+            <translation><!-- AfterInsert --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterUndelete</masterLabel>
+            <translation><!-- AfterUndelete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>AfterUpdate</masterLabel>
+            <translation><!-- AfterUpdate --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeDelete</masterLabel>
+            <translation><!-- BeforeDelete --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeInsert</masterLabel>
+            <translation><!-- BeforeInsert --></translation>
+        </picklistValues>
+        <picklistValues>
+            <masterLabel>BeforeUpdate</masterLabel>
+            <translation><!-- BeforeUpdate --></translation>
+        </picklistValues>
+    </fields>
+    <fields>
+        <help><!-- Check it if you intent to manage the record yourself. Be aware that updates to the package won&apos;t update the record. --></help>
+        <label><!-- User Managed --></label>
+        <name>User_Managed__c</name>
+    </fields>
+    <layouts>
+        <layout>Trigger Handler Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1349,27 +1349,46 @@
     </types>
     <types>
         <members>Account-es</members>
+        <members>Addr_Verification_Settings__c-en_US</members>
         <members>Addr_Verification_Settings__c-es</members>
+        <members>Address_Verification_Settings__c-en_US</members>
         <members>Address_Verification_Settings__c-es</members>
+        <members>Address__c-en_US</members>
         <members>Address__c-es</members>
+        <members>Allocation__c-en_US</members>
         <members>Allocation__c-es</members>
+        <members>Allocations_Settings__c-en_US</members>
         <members>Allocations_Settings__c-es</members>
+        <members>Batch_Data_Entry_Settings__c-en_US</members>
         <members>Batch_Data_Entry_Settings__c-es</members>
+        <members>Batch__c-en_US</members>
         <members>Batch__c-es</members>
         <members>Contact-es</members>
+        <members>DataImport__c-en_US</members>
         <members>DataImport__c-es</members>
+        <members>Data_Import_Settings__c-en_US</members>
         <members>Data_Import_Settings__c-es</members>
+        <members>Error_Settings__c-en_US</members>
         <members>Error_Settings__c-es</members>
+        <members>Error__c-en_US</members>
         <members>Error__c-es</members>
+        <members>Fund__c-en_US</members>
         <members>Fund__c-es</members>
+        <members>General_Accounting_Unit__c-en_US</members>
         <members>General_Accounting_Unit__c-es</members>
+        <members>Grant_Deadline__c-en_US</members>
         <members>Grant_Deadline__c-es</members>
+        <members>Household_Naming_Settings__c-en_US</members>
         <members>Household_Naming_Settings__c-es</members>
         <members>Lead-es</members>
         <members>Opportunity-es</members>
+        <members>Opportunity_Naming_Settings__c-en_US</members>
         <members>Opportunity_Naming_Settings__c-es</members>
+        <members>Partial_Soft_Credit__c-en_US</members>
         <members>Partial_Soft_Credit__c-es</members>
+        <members>Schedulable__c-en_US</members>
         <members>Schedulable__c-es</members>
+        <members>Trigger_Handler__c-en_US</members>
         <members>Trigger_Handler__c-es</members>
         <members>npe01__Contacts_And_Orgs_Settings__c-es</members>
         <members>npe01__OppPayment__c-es</members>


### PR DESCRIPTION
Omitting the english translations for default objects was causing an issue in the build scripts, since they were attempting to do a partial delete of metadata from the packaging org that did not exist in the repository.

I have added back the english translations for standard objects.  These translations are not intended to provide any overrides of the native labels.