### PR TITLE
Modify spanish translation for opp picklist value

### DIFF
--- a/src/objectTranslations/Opportunity-es.objectTranslation
+++ b/src/objectTranslations/Opportunity-es.objectTranslation
@@ -27,7 +27,7 @@
         </picklistValues>
         <picklistValues>
             <masterLabel>To Be Acknowledged</masterLabel>
-            <translation>A enviar</translation>
+            <translation>Acuse de recibo pendiente</translation>
         </picklistValues>
     </fields>
     <fields>


### PR DESCRIPTION
The spanish translation for the `Opportunity.Acknowledgement_Status`
picklist value 'To Be Acknowledged' was inconsistent with the spanish
translation for the same value on the
`npe01__OppPayment__c.npsp__Payment_Acknowledgement_Status` picklist
field.

This change updates the `Opportunity` picklist value to use the same
translation as the `npe01__OppPayment__c` value.