### PR TITLE
Update autocomplete component to manually track input focus

### DIFF
--- a/src/aura/autocomplete/autocomplete.cmp
+++ b/src/aura/autocomplete/autocomplete.cmp
@@ -7,6 +7,7 @@
 
     <aura:attribute name="items" type="Object[]" default="[]" access="private"/>
     <aura:attribute name="keyword" type="String" access="private"/>
+    <aura:attribute name="inputFocused" type="Boolean" default="false" access="private"/>
     <aura:attribute name="placeholder" type="String" default="" access="public"/>
     <aura:attribute name="label" type="String" default="" access="public"/>
     <aura:attribute name="searchContext" type="String" default="" access="public"/>

--- a/src/aura/autocomplete/autocompleteController.js
+++ b/src/aura/autocomplete/autocompleteController.js
@@ -1,5 +1,5 @@
 ({
-    doInit: function (component, event, helper) {
+    doInit: function (component) {
         var inputCmp = component.find('input');
 
         if (inputCmp) {
@@ -13,10 +13,10 @@
         var makeDelay = function () {
             var timer = 0;
             return function(callback, ms){
-                clearTimeout(timer);
-                timer = setTimeout(callback, ms);
+                window.clearTimeout(timer);
+                timer = window.setTimeout(callback, ms);
             };
-        }
+        };
 
         component._delay = makeDelay(); // this one is for pausing before doing autocomplete
         component._focus = makeDelay(); // this one is to accumulate focus/blur events to determine if component has focus
@@ -38,6 +38,7 @@
     },
 
     handleInputFocus: function (component, event, helper) {
+        component.set('v.inputFocused', true);
         var inputCmp = component.find('input');
         if ('' !== inputCmp.get('v.value')) {
             helper.setListVisibilityDelayed(component, true);
@@ -45,6 +46,7 @@
     },
 
     handleInputBlur: function (component, event, helper) {
+        component.set('v.inputFocused', false);
         helper.setListVisibilityDelayed(component, false);
     },
 
@@ -68,7 +70,7 @@
         helper.setListVisibilityDelayed(component, isListVisible);
     },
 
-    handleRemovePill: function (component, event, helper) {
+    handleRemovePill: function (component) {
         component.set('v.value', '');
         component.set('v.displayValue', '');
         component.set('v.keyword', '');

--- a/src/aura/autocomplete/autocompleteHelper.js
+++ b/src/aura/autocomplete/autocompleteHelper.js
@@ -9,7 +9,7 @@
         // causing it to reopen.
         //
         // if this event is fired and the element is not focused, ignore
-        if (el === document.activeElement) {
+        if (component.get('v.inputFocused')) {
             component.set('v.keyword', keyword);
 
             if (!keyword) {
@@ -61,5 +61,5 @@
         var listComponent = component.find('list');
         $A.util.toggleClass(listComponent, "slds-hide", !visible);
         component.set('v.isListVisible', visible);
-    },
+    }
 })


### PR DESCRIPTION
Using document.activeElement conflicted with LockerService, so this update adds manual tracking of the input element focus, storing the focused state in a component attribute.

Also contains other LockerService linter related updates.