### PR TITLE
Adding limit clause to health check

### DIFF
--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -651,10 +651,20 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
             SObjectField OppRecordTypeId = Schema.sObjectType.Opportunity.fields.getMap().get('RecordTypeId');
             if (OppRecordTypeId != null)
                 soql += ' and RecordTypeId not in :setOppRecordTypeIdNoPayment ';
-                     
+
+            soql += 'LIMIT 1001';
+
             integer cMissing = database.countQuery(soql);
             if (cMissing > 0) {
-                createDR(Label.healthLabelOppPayments, statusWarning, string.format(Label.healthDetailsMissingOppPayments, new string[]{string.valueOf(cMissing)}), label.healthSolutionMissingOppPayments);
+                String sMissing;
+
+                if (cMissing > 1000) {
+                    sMissing = '1000+';
+                } else {
+                    sMissing = String.valueOf(cMissing);
+                }
+
+                createDR(Label.healthLabelOppPayments, statusWarning, string.format(Label.healthDetailsMissingOppPayments, new string[]{sMissing}), label.healthSolutionMissingOppPayments);
             } else {
                 createDR(Label.healthLabelOppPayments, statusSuccess, null, label.healthLabelNoMissingOppPayments);
             }            


### PR DESCRIPTION
verifyNoMissingOppPayments would for sure fail if more than 50,000
opportunities did not have payments that should have.  This would throw
a query row limit exception.

Adding a limit clause will allow the health check to report a limited
number of errors, while not throwing a limit exception when large
amounts of opportunities meet the criteria.

See discussion in #2022 

## Fixes
#2022