### PR TITLE
Adding basic currency locale awareness to Manage Allocations page

### DIFF
--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -87,6 +87,9 @@ public with sharing class ALLO_ManageAllocations_CTRL {
     /** @description Row number sent back by page for add and delete row methods.*/
     public integer rowNumber {get;set;}
 
+    /** @description The currency symbol or ISO code of the related record or org default */
+    private String currencySymbol;
+
     /** @description Constructor queries for the parent object and the allocations, and fills out attributes.*/
     public ALLO_ManageAllocations_CTRL(ApexPages.StandardSetController ssc) {
 
@@ -149,6 +152,39 @@ public with sharing class ALLO_ManageAllocations_CTRL {
         keyPrefix = describe.getKeyPrefix();
         objectAPIName = describe.getName();
         objectLabelPlural = describe.getLabelPlural();
+    }
+
+    /**
+     * @description Return the currency symbol appropriate for the current
+     * user/org/record.  If the org is multi currency enabled, it will use the
+     * currency iso code from the related record.  If the org is not multi
+     * currency enabled, it will return the symbol for the currency of the org,
+     * or the currency iso code if no symbol is known.
+     *
+     * @return String A currency symbol or currency ISO code
+     */
+    public String getCurrencySymbol() {
+        if (currencySymbol == null) {
+            String parentObjectName = parentId.getSobjectType().getDescribe().getName();
+            if (UserInfo.isMultiCurrencyOrganization()) {
+                sObject parentObject = Database.query('SELECT CurrencyIsoCode FROM ' + parentObjectName + ' LIMIT 1');
+                currencySymbol = (String) parentObject.get('CurrencyIsoCode');
+            } else {
+                Map<String, String> currencySymbols = new Map<String, String>{
+                    'USD' => '$', 'CNY' => '¥', 'JPY' => '¥', 'EUR' => '€',
+                        'GBP' => '£', 'BRL' => 'R$', 'INR' => '₹', 'RUB' => '₽',
+                        'CAD' => '$', 'AUD' => '$', 'KRW' => '₩', 'MXN' => '$',
+                        'IDR' => 'Rp', 'TRY' => '₺','SAR' => '﷼'
+                        };
+                String orgCurrency = UserInfo.getDefaultCurrency();
+                if (currencySymbols.containsKey(orgCurrency)) {
+                    currencySymbol = currencySymbols.get(orgCurrency);
+                } else {
+                    currencySymbol = orgCurrency;
+                }
+            }
+        }
+        return currencySymbol;
     }
 
     /** @description Adds an empty row to the bottom of the list and refreshes the page.*/

--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -87,7 +87,11 @@ public with sharing class ALLO_ManageAllocations_CTRL {
     /** @description Row number sent back by page for add and delete row methods.*/
     public integer rowNumber {get;set;}
 
-    /** @description The currency symbol or ISO code of the related record or org default */
+    /**
+     * @description The currency symbol or ISO code of the related record or
+     * org default
+     */
+    @TestVisible
     private String currencySymbol;
 
     /** @description Constructor queries for the parent object and the allocations, and fills out attributes.*/
@@ -146,6 +150,12 @@ public with sharing class ALLO_ManageAllocations_CTRL {
             addRow();
     }
 
+    /**
+     * @description Private default constructor
+     */
+    @TestVisible
+    private ALLO_ManageAllocations_CTRL() {}
+
     /** @description Adds an empty row to the bottom of the list and refreshes the page.*/
     private void populateObjectParameters(Schema.sObjectType st) {
         DescribeSObjectResult describe = st.getDescribe();
@@ -165,24 +175,7 @@ public with sharing class ALLO_ManageAllocations_CTRL {
      */
     public String getCurrencySymbol() {
         if (currencySymbol == null) {
-            String parentObjectName = parentId.getSobjectType().getDescribe().getName();
-            if (UserInfo.isMultiCurrencyOrganization()) {
-                sObject parentObject = Database.query('SELECT CurrencyIsoCode FROM ' + parentObjectName + ' LIMIT 1');
-                currencySymbol = (String) parentObject.get('CurrencyIsoCode');
-            } else {
-                Map<String, String> currencySymbols = new Map<String, String>{
-                    'USD' => '$', 'CNY' => '¥', 'JPY' => '¥', 'EUR' => '€',
-                        'GBP' => '£', 'BRL' => 'R$', 'INR' => '₹', 'RUB' => '₽',
-                        'CAD' => '$', 'AUD' => '$', 'KRW' => '₩', 'MXN' => '$',
-                        'IDR' => 'Rp', 'TRY' => '₺','SAR' => '﷼'
-                        };
-                String orgCurrency = UserInfo.getDefaultCurrency();
-                if (currencySymbols.containsKey(orgCurrency)) {
-                    currencySymbol = currencySymbols.get(orgCurrency);
-                } else {
-                    currencySymbol = orgCurrency;
-                }
-            }
+            currencySymbol = UTIL_Currency.getInstance().getCurrencySymbol(parentId);
         }
         return currencySymbol;
     }

--- a/src/classes/ALLO_ManageAllocations_TEST.cls
+++ b/src/classes/ALLO_ManageAllocations_TEST.cls
@@ -211,4 +211,43 @@ private class ALLO_ManageAllocations_TEST {
         list<Allocation__c> queryAllo = [SELECT Id, Percent__c, Amount__c FROM Allocation__c WHERE Recurring_Donation__c=:rd.id];
         system.assertEquals(2,queryAllo.size(),'2 allocations should be saved, one original allocation should be deleted.');
     }
+
+    /**
+     * @description getCurrencySymbol() should return the appropriate currency
+     * symbol as returned by UTIL_Currency
+     */
+    @isTest
+    private static void testGetCurrencySymbolCallsUtilCurrency() {
+        UTIL_Currency_TEST.UtilCurrencyMock mock = new UTIL_Currency_TEST.UtilCurrencyMock();
+        mock.getCurrencySymbolReturn = 'FOO';
+        UTIL_Currency.instance = mock;
+
+        ALLO_ManageAllocations_CTRL controller = new ALLO_ManageAllocations_CTRL();
+        controller.parentId = Account.sObjectType.getDescribe().getKeyPrefix() + '000000000001AAA';
+
+        System.assertEquals(
+            'FOO',
+            controller.getCurrencySymbol()
+        );
+
+        System.assertEquals(
+            controller.parentId,
+            mock.getCurrencySymbolRecordId
+        );
+    }
+
+    /**
+     * @description getCurrencySymbol() should returned a cached currency
+     * symbol, if it has been set
+     */
+    @isTest
+    private static void testGetCurrencySymbolReturnsCachedSymbol() {
+        ALLO_ManageAllocations_CTRL controller = new ALLO_ManageAllocations_CTRL();
+        controller.currencySymbol = 'FOO';
+
+        System.assertEquals(
+            'FOO',
+            controller.getCurrencySymbol()
+        );
+    }
 }

--- a/src/classes/UTIL_Currency.cls
+++ b/src/classes/UTIL_Currency.cls
@@ -1,0 +1,164 @@
+/*
+    Copyright (c) 2016, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Util
+* @description Utilities for working with currencies
+*/
+public with sharing class UTIL_Currency implements UTIL_Currency.Interface_x {
+
+    public interface Interface_x {
+        Boolean isMultiCurrencyOrganization();
+        String getDefaultCurrency();
+        String getDefaultCurrencySymbol();
+        String getCurrencySymbol(Id recordId);
+        String getCurrencyIsoCodeQuery(Id recordId);
+        String queryCurrencyIsoCode(Id recordId);
+    }
+
+    /** @description Store instance for Singleton pattern */
+    @TestVisible
+    private static Interface_x instance;
+
+    /**
+     * @description Get the singleton instance of the UTIL_Currency class
+     * @return UTIL_Currency.Interface_x
+     */
+    public static Interface_x getInstance() {
+        if (instance == null) {
+            instance = new UTIL_Currency();
+        }
+        return instance;
+    }
+
+    /** @description Private constructor for Singleton pattern */
+    @TestVisible
+    private UTIL_Currency() {}
+
+    /**
+     * @description Wrapper for UserInfo.isMultiCurrencyOrganization()
+     */
+    public Boolean isMultiCurrencyOrganization() {
+        return UserInfo.isMultiCurrencyOrganization();
+    }
+
+    /**
+     * @description Wrapper for UserInfo.getDefaultCurrency()
+     */
+    public String getDefaultCurrency() {
+        return UserInfo.getDefaultCurrency();
+    }
+
+    /**
+     * @description For single currency orgs, return the symbol of the org's
+     * currency or the org's currency ISO code if no symbol is known for that
+     * currency
+     *
+     * @return String
+     */
+    public String getDefaultCurrencySymbol() {
+        String orgCurrency = UTIL_Currency.getInstance().getDefaultCurrency();
+        if (currencySymbols.containsKey(orgCurrency)) {
+            return currencySymbols.get(orgCurrency);
+        } else {
+            return orgCurrency;
+        }
+    }
+
+    /**
+     * @description Return the currency symbol appropriate for the given record
+     * id.
+     * If the org is multi currency enabled, it will return the
+     * currency iso code from the given record.  If the org is not multi
+     * currency enabled, it will return the symbol for the currency of the org,
+     * or the currency iso code if no symbol is known.
+     *
+     * @param recordId The id of the record to determine currency symbol from
+     * @return String
+     */
+    public String getCurrencySymbol(Id recordId) {
+        Interface_x currencyUtil = UTIL_Currency.getInstance();
+        if (currencyUtil.isMultiCurrencyOrganization()) {
+            return currencyUtil.queryCurrencyIsoCode(recordId);
+        } else {
+            return currencyUtil.getDefaultCurrencySymbol();
+        }
+    }
+
+    /**
+     * @description Build a SOQL string to query CurrencyIsoCode from the
+     * object identified by the given record id
+     *
+     * @param recordId The id of the record that should be queried
+     * @return String
+     */
+    public String getCurrencyIsoCodeQuery(Id recordId) {
+        String objectName = recordId.getSobjectType().getDescribe().getName();
+        return String.format(
+            'SELECT CurrencyIsoCode FROM {0} WHERE Id = \'\'{1}\'\' LIMIT 1',
+            new List<String>{objectName, recordId}
+        );
+    }
+
+    /**
+     * @description Query the database for the CurrencyIsoCode of the object
+     * identified by the given record id
+     *
+     * @param recordId The id of the record that should be queried
+     * @return String
+     */
+    public String queryCurrencyIsoCode(Id recordId) {
+        String isoCodeQuery = UTIL_Currency.getInstance().getCurrencyIsoCodeQuery(recordId);
+        sObject objectWithCurrency = Database.query(isoCodeQuery);
+        return (String) objectWithCurrency.get('CurrencyIsoCode');
+    }
+
+    /**
+     * @description Mapping of common currency ISO codes to currency symbols
+     */
+    private static Map<String, String> currencySymbols = new Map<String, String>{
+        'USD' => '$',
+        'CNY' => '¥',
+        'JPY' => '¥',
+        'EUR' => '€',
+        'GBP' => '£',
+        'BRL' => 'R$',
+        'INR' => '₹',
+        'RUB' => '₽',
+        'CAD' => '$',
+        'AUD' => '$',
+        'KRW' => '₩',
+        'MXN' => '$',
+        'IDR' => 'Rp',
+        'TRY' => '₺',
+        'SAR' => '﷼'
+    };
+}

--- a/src/classes/UTIL_Currency.cls-meta.xml
+++ b/src/classes/UTIL_Currency.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/UTIL_Currency_TEST.cls
+++ b/src/classes/UTIL_Currency_TEST.cls
@@ -1,0 +1,224 @@
+/*
+    Copyright (c) 2016, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Util
+* @description Tests for currency utility class
+*/
+@isTest
+public class UTIL_Currency_TEST {
+
+    /**
+     * @description UTIL_Currency.isMultiCurrencyOrganization() should return
+     * the same value as UserInfo.isMultiCurrencyOrganization()
+     */
+    @isTest
+    private static void testIsMultiCurrencyOrganizationWrapsUserInfoMethod() {
+        UTIL_Currency actual = new UTIL_Currency();
+        System.assertEquals(
+            UserInfo.isMultiCurrencyOrganization(),
+            actual.isMultiCurrencyOrganization()
+        );
+    }
+
+    /**
+     * @description UTIL_Currency.getDefaultCurrency() should return the same
+     * value as UserInfo.getDefaultCurrency()
+     */
+    @isTest
+    private static void testGetDefaultCurrencyWrapsUserInfoMethod() {
+        UTIL_Currency actual = new UTIL_Currency();
+        System.assertEquals(
+            UserInfo.getDefaultCurrency(),
+            actual.getDefaultCurrency()
+        );
+    }
+
+    /**
+     * @description UTIL_Currency implements the Singleton pattern.  If the
+     * class has already been instantiated, it should be returned by
+     * getInstance().
+     */
+    @isTest
+    private static void testSingletonReturnsExistingInstance() {
+        UtilCurrencyMock existingInstance = new UtilCurrencyMock();
+        UTIL_Currency.instance = existingInstance;
+
+        System.assertEquals(
+            existingInstance,
+            UTIL_Currency.getInstance()
+        );
+    }
+
+    /**
+     * @description UTIL_Currency implements the Singleton pattern.  If the
+     * class has not already been instantiated, then UTIL_Currency should be
+     * instantiated when getInstance() is called.
+     */
+    @isTest
+    private static void testSingletonReturnsNewInstanceIfNoExisting() {
+        System.assertEquals(null, UTIL_Currency.instance);
+        System.assert(UTIL_Currency.getInstance() instanceof UTIL_Currency);
+    }
+
+    /**
+     * @description If the org's default currency iso code maps to a known
+     * currency symbol, then getDefaultCurrencySymbol() should return that
+     * symbol (and not the ISO code)
+     */
+    @isTest
+    private static void testGetDefaultCurrencySymbolReturnsKnownSymbol() {
+        UTIL_Currency actual = new UTIL_Currency();
+        UtilCurrencyMock mock = new UtilCurrencyMock();
+        mock.getDefaultCurrencyReturn = 'EUR';
+        UTIL_Currency.instance = mock;
+
+        System.assertEquals(
+            '€',
+            actual.getDefaultCurrencySymbol()
+        );
+    }
+
+    /**
+     * @description If the org's default currency iso code does not have a
+     * known currency symbol, then getDefaultCurrencySymbol() should return the
+     * currency ISO code.
+     */
+    @isTest
+    private static void testGetDefaultCurrencySymbolReturnsIsoCodeIfUnknownSymbol() {
+        UTIL_Currency actual = new UTIL_Currency();
+        UtilCurrencyMock mock = new UtilCurrencyMock();
+        mock.getDefaultCurrencyReturn = 'FOO';
+        UTIL_Currency.instance = mock;
+
+        System.assertEquals(
+            'FOO',
+            actual.getDefaultCurrencySymbol()
+        );
+    }
+
+    /**
+     * @description If the organization is multi-currency enabled, then calling
+     * getCurrencySymbol() should query for the given record id and return the
+     * currency iso code of that record.
+     */
+    @isTest
+    private static void testGetCurrencySymbolQueriesForCodeIfMultiCurrency() {
+        Id recordId = Account.sObjectType.getDescribe().getKeyPrefix() + '000000000001AAA';
+        UTIL_Currency actual = new UTIL_Currency();
+        UtilCurrencyMock mock = new UtilCurrencyMock();
+        mock.isMultiCurrencyOrganizationReturn = true;
+        mock.queryCurrencyIsoCodeReturn = 'FOO';
+        UTIL_Currency.instance = mock;
+
+        System.assertEquals(
+            'FOO',
+            actual.getCurrencySymbol(recordId)
+        );
+
+        System.assertEquals(
+            recordId,
+            mock.queryCurrencyIsoCodeRecordId
+        );
+    }
+
+    /**
+     * @description If the organization is single currency, then calling
+     * getCurrencySymbol() should return the currency symbol corresponding to
+     * the org's default currency
+     */
+    @isTest
+    private static void testGetCurrencySymbolReturnsDefaultCurrencySymbolIfSingleCurrency() {
+        Id recordId = Account.sObjectType.getDescribe().getKeyPrefix() + '000000000001AAA';
+        UTIL_Currency actual = new UTIL_Currency();
+        UtilCurrencyMock mock = new UtilCurrencyMock();
+        mock.isMultiCurrencyOrganizationReturn = false;
+        mock.getDefaultCurrencySymbolReturn = '$';
+        UTIL_Currency.instance = mock;
+
+        System.assertEquals(
+            '$',
+            actual.getCurrencySymbol(recordId)
+        );
+    }
+
+    /**
+     * @description Calling getCurrencyIsoCodeQuery() should properly build a
+     * query that retrieves the CurrencyIsoCode of the given record.
+     */
+    @isTest
+    private static void testGetCurrencyIsoCodeQueryBuildsCorrectQuery() {
+        Id recordId = Account.sObjectType.getDescribe().getKeyPrefix() + '000000000001AAA';
+
+        System.assertEquals(
+            'SELECT CurrencyIsoCode FROM Account WHERE Id = \'001000000000001AAA\' LIMIT 1',
+            UTIL_Currency.getInstance().getCurrencyIsoCodeQuery(recordId)
+        );
+    }
+
+    /**
+     * @description A mock implementation of UTIL_Currency.Interface_x that can
+     * be used to provide pre-set return values from methods and store
+     * parameters passed to methods.
+     */
+    public class UtilCurrencyMock implements UTIL_Currency.Interface_x {
+        public Boolean isMultiCurrencyOrganizationReturn;
+        public String getDefaultCurrencyReturn;
+        public String getDefaultCurrencySymbolReturn;
+        public Id getCurrencySymbolRecordId;
+        public String getCurrencySymbolReturn;
+        public Id getCurrencyIsoCodeQueryRecordId;
+        public String getCurrencyIsoCodeQueryReturn;
+        public Id queryCurrencyIsoCodeRecordId;
+        public String queryCurrencyIsoCodeReturn;
+        public Boolean isMultiCurrencyOrganization() {
+            return isMultiCurrencyOrganizationReturn;
+        }
+        public String getDefaultCurrency() {
+            return getDefaultCurrencyReturn;
+        }
+        public String getDefaultCurrencySymbol() {
+            return getDefaultCurrencySymbolReturn;
+        }
+        public String getCurrencySymbol(Id recordId) {
+            getCurrencySymbolRecordId = recordId;
+            return getCurrencySymbolReturn;
+        }
+        public String getCurrencyIsoCodeQuery(Id recordId) {
+            getCurrencyIsoCodeQueryRecordId = recordId;
+            return getCurrencyIsoCodeQueryReturn;
+        }
+        public String queryCurrencyIsoCode(Id recordId) {
+            queryCurrencyIsoCodeRecordId = recordId;
+            return queryCurrencyIsoCodeReturn;
+        }
+    }
+}

--- a/src/classes/UTIL_Currency_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Currency_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -216,6 +216,8 @@
         <members>TDTM_TriggerScaffolds_TEST</members>
         <members>TDTM_iTableDataGateway</members>
         <members>UTIL_AbstractRollup_BATCH</members>
+        <members>UTIL_Currency</members>
+        <members>UTIL_Currency_TEST</members>
         <members>UTIL_CustomSettingsFacade</members>
         <members>UTIL_CustomSettings_API</members>
         <members>UTIL_Debug</members>

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -1,6 +1,6 @@
 <apex:page standardController="Allocation__c" recordSetVar="allocations" extensions="ALLO_ManageAllocations_CTRL" title="Manage Allocations" tabStyle="Allocation__c" showHeader="true" sidebar="true" standardStylesheets="false" cache="false" >
     <apex:includeScript value="{!URLFOR($Resource.CumulusStaticResources, '/jquery/jquery-1.10.2.min.js')}"/>
-    <apex:stylesheet value="{!URLFOR($Resource.SLDS, '/0_12_2/assets/styles/salesforce-lightning-design-system-vf.min.css')}" />
+    <apex:stylesheet value="{!URLFOR($Resource.SLDS, '/1_0_3/assets/styles/salesforce-lightning-design-system-vf.min.css')}" />
     <apex:stylesheet value="{!URLFOR($Resource.CumulusStaticResources, '/npsp-slds/npsp-common.css')}" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -8,10 +8,8 @@
     (function($) {
 
         var sumAmount;
-        var sumPercent;
         
         var parentAmount = {!parentAmount};
-        var dollarSign = '{!$Label.npe01__DefaultContactTransactionCurrency}';
         var defaultEnabled = {!Settings.Default_Allocations_Enabled__c};
 
         function isLightningExperienceOrSalesforce1() {
@@ -32,8 +30,6 @@
             $('.alloAmount').each(function(i,o){
                 var thisRowAmount = $('.amount'+i);
                 var thisRowPercent = $('.percent'+i);
-
-                //thisRowAmount.val(thisRowAmount.val().toFixed(2));
 
                 //if amount and percent are blank, enable them both
                 if (isBlankOrEmpty(thisRowAmount)){
@@ -58,7 +54,7 @@
             //if we're over the parent amount, make it red.
             if (parentAmount > 0) {
                 var unallocated = (Math.round((parentAmount*100) - sumAmount)/100).toFixed(2);
-                $('#totalAmount').text(dollarSign + unallocated);
+                $('#totalAmount').text(unallocated);
                 if (unallocated < 0) {
                     $('#totalAmount').css({ "color": "red", "font-weight": "bold" });
                     $('[id$="saveCloseBTN"]').attr('disabled','disabled');
@@ -67,7 +63,7 @@
                     $('[id$="saveCloseBTN"]').removeAttr('disabled');
                 }
             } else {
-                $('#totalAmount').text(dollarSign + (Math.round(sumAmount)/100).toFixed(2));
+                $('#totalAmount').text((Math.round(sumAmount)/100).toFixed(2));
             }
             
         }
@@ -177,23 +173,19 @@
                                 </td>
                                 <td>
                                     <div class="slds-form-element">
-                                        <label for="alloInputAmount{!cnt}" class="slds-form-element__label slds-assistive-text">{!$ObjectType.Allocation__c.Fields.Amount__c.Label} {!cnt}</label>
-                                        <div class="slds-form-element__control slds-input-has-icon slds-input-has-icon">
-                                            <span class="slds-input__icon">&nbsp;{!$Label.npe01__DefaultContactTransactionCurrency}</span>
-                                            <div id="alloInputAmount{!cnt}">
-                                                <apex:inputField styleClass="slds-input alloAmount amount{!cnt}" onkeyup="window.initOrReload()"  value="{!Allo.Amount__c}"/>
-                                            </div>
+                                        <label for="{!$Component.alloInputAmount}" class="slds-form-element__label slds-assistive-text">{!$ObjectType.Allocation__c.Fields.Amount__c.Label} {!cnt}</label>
+                                        <div class="slds-form-element__control slds-input-has-fixed-addon">
+                                            <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                            <apex:inputField id="alloInputAmount" styleClass="slds-input alloAmount amount{!cnt}" onkeyup="window.initOrReload()"  value="{!Allo.Amount__c}"/>
                                         </div>
                                     </div>
                                 </td>
                                 <td>
                                     <div class="slds-form-element">
-                                        <label for="alloInputPercent{!cnt}" class="slds-form-element__label slds-assistive-text">{!$ObjectType.Allocation__c.Fields.Percent__c.Label} {!cnt}</label>
-                                        <div class="slds-form-element__control slds-input-has-icon slds-input-has-icon--right">
-                                            <div id="alloInputPercent{!cnt}">
-                                                <apex:inputField styleClass="slds-input alloPercent percent{!cnt}" onkeyup="window.changePercent({!cnt})" value="{!Allo.Percent__c}"/>
-                                            </div>
-                                            <span class="slds-input__icon">%</span>
+                                        <label for="{!$Component.alloInputPercent}" class="slds-form-element__label slds-assistive-text">{!$ObjectType.Allocation__c.Fields.Percent__c.Label} {!cnt}</label>
+                                        <div class="slds-form-element__control slds-input-has-fixed-addon">
+                                            <apex:inputField id="alloInputPercent" styleClass="slds-input slds-size--2-of-3 alloPercent percent{!cnt}" onkeyup="window.changePercent({!cnt})" value="{!Allo.Percent__c}"/>
+                                            <span class="slds-form-element__addon">%</span>
                                         </div>
                                     </div>
                                 </td>
@@ -215,10 +207,14 @@
                                 <apex:outputField value="{!defaultAllo.General_Accounting_Unit__c}"/>
                             </td>
                             <td>
-                                <div id="totalAmount"></div>
+                                <div class="slds-form-element">
+                                    <div class="slds-form-element__control">
+                                        <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                        <span class="slds-form-element__static" id="totalAmount"></span>
+                                    </div>
+                                </div>
                             </td>
                             <td>
-                                <div id="totalPercent"></div>
                             </td>
                             <td>
                                 <apex:commandButton styleClass="slds-button slds-button--neutral slds-button--small" value="{!$Label.alloAddRow}" id="addRowBTN" title="{!$Label.alloAddRow}" action="{!addRow}" reRender="theTable" immediate="true" rendered="{!listAlloSize==0}">

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -128,7 +128,7 @@
                                 </li>
                                 <li class="slds-list__item slds-text-heading--label">
                                     <a class="slds-type-focus" href="/{!parentId}">
-                                        {!objectName}<apex:outputText rendered="{!parentAmount<>0}" value=" - {0,number,currency}"><apex:param value="{!parentAmount}"/></apex:outputText>
+                                        {!objectName}<apex:outputText rendered="{!parentAmount<>0}"><apex:outputText value=" - {!currencySymbol}{!IF(LEN(currencySymbol) == 3, ' ', '')}{0,number,#.##}"><apex:param value="{!parentAmount}"/></apex:outputText></apex:outputText>
                                     </a>
                                 </li>
                             </ol>


### PR DESCRIPTION
Adding org/related record currency detection to Manage Allocations
controller, along with some support for ISO code to currency symbol
mapping.

Reformatting currency input fields and totals to use SLDS 'addon'
styling, and to dynamically show detected org/related record currency
symbol.

Adding utility class for currency handling.

Removing some cruft from Manage Allocations page.

## Warning

## Info
Added basic currency locale awareness to Manage Allocations page.  Now, for some commonly used currencies, the correct currency symbol will be displayed.  For multi-currency orgs, the currency ISO code of the related opportunity, recurring donation, or campaign will be displayed. 

## Issues
#1941 