### PR TITLE
Duplicate Contacts and Rollup Values Health Check

### DIFF
--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -682,23 +682,38 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
      */
      public void verifyNoDuplicateContactRoles() {
         try {
+            Set<String> softCreditRoles = RLLP_OppRollup_UTIL.softCreditRoles;
+
             List<AggregateResult> results = [
                 SELECT
                     COUNT(Id),
                     OpportunityId,
                     ContactId
                 FROM OpportunityContactRole
+                WHERE Opportunity.IsWon = true
+                AND Role IN :softCreditRoles
                 GROUP BY OpportunityId, ContactId
                 HAVING Count(Id) > 1
                 LIMIT 1
             ];
+
+            List<String> quotedSoftCreditRoles = new List<String>();
+
+            for (String role : softCreditRoles) {
+                quotedSoftCreditRoles.add('\'' + String.escapeSingleQuotes(role) + '\'');
+            }
 
             if (results.size() > 0) {
                 createDR(
                     Label.healthLabelDuplicateContactRoles,
                     statusWarning,
                     Label.healthDetailsDuplicateContactRoles,
-                    Label.healthSolutionDuplicateContactRoles
+                    String.format(
+                        Label.healthSolutionDuplicateContactRoles,
+                        new List<String>{
+                            String.join(quotedSoftCreditRoles, ', ')
+                        }
+                    )
                 );
             } else {
                 createDR(

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -182,6 +182,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
         verifyOppContactRoles();
         verifyTriggerHandlers();
         verifyNoMissingOppPayments();
+        verifyNoDuplicateContactRoles();
         
         DateTime dtEnd = system.now();
         double msec = dtEnd.getTime() - dtStart.getTime();
@@ -673,5 +674,47 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
         }    
         
     }
-    
+
+    /**
+     * @description Detect if any opportunities exists where the same contact
+     * is associated with that opportunity multiple times through multiple
+     * opportunity contact role records.
+     */
+     public void verifyNoDuplicateContactRoles() {
+        try {
+            List<AggregateResult> results = [
+                SELECT
+                    COUNT(Id),
+                    OpportunityId,
+                    ContactId
+                FROM OpportunityContactRole
+                GROUP BY OpportunityId, ContactId
+                HAVING Count(Id) > 1
+                LIMIT 1
+            ];
+
+            if (results.size() > 0) {
+                createDR(
+                    Label.healthLabelDuplicateContactRoles,
+                    statusWarning,
+                    Label.healthDetailsDuplicateContactRoles,
+                    Label.healthSolutionDuplicateContactRoles
+                );
+            } else {
+                createDR(
+                    Label.healthLabelDuplicateContactRoles,
+                    statusSuccess,
+                    null,
+                    label.healthLabelNoDuplicateContactRoles
+                );
+            }
+        } catch (Exception e) {
+            createDR(
+                Label.healthLabelDuplicateContactRoles,
+                statusError,
+                e.getMessage(),
+                null
+            );
+        }
+     }
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1436,7 +1436,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>The details displayed when the duplicate contact roles health check fails</shortDescription>
-        <value>There were opportunities with duplicate contact roles detected in your org.</value>
+        <value>Health Check found Opportunities with duplicate Contacts and rollup values.</value>
     </labels>
     <labels>
         <fullName>healthDetailsGenderField</fullName>
@@ -1772,7 +1772,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Label for Duplicate Contact Role health check</shortDescription>
-        <value>Duplicate Contact Roles</value>
+        <value>Duplicate Contacts and Rollup Values</value>
     </labels>
     <labels>
         <fullName>healthLabelErrorRecipientValid</fullName>
@@ -1844,7 +1844,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>The message displayed when the duplicate contact roles health check passes</shortDescription>
-        <value>There were no opportunities with duplicate contact roles detected.</value>
+        <value>Health Check did not find any Opportunities with duplicate Contacts or rollup values.</value>
     </labels>
     <labels>
         <fullName>healthLabelNoMissingOppPayments</fullName>
@@ -2083,7 +2083,9 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>The recommended solution for when the duplicate contact roles health check fails</shortDescription>
-        <value>You should expect these contacts to have different roll-up values than before, since duplicate contacts are no longer counted twice.  To discover duplicate opportunities and contacts in your org, you can run the following SOQL query in the Developer Console: &apos;SELECT Count(Id), OpportunityId, Opportunity.Name OpportunityName, ContactId, Contact.Name ContactName FROM OpportunityContactRole GROUP BY OpportunityId, Opportunity.Name, ContactId, Contact.Name HAVING Count(Id) &gt; 1&apos;</value>
+        <value>In the past, the NPSP double-counted soft credit rollup values for Contacts that were twice associated with an Opportunity through two different Opportunity Contact Roles. The NPSP now only counts these rollup values once, regardless of how many associations a Contact has on an Opportunity.&lt;br/&gt;
+&lt;br/&gt;
+If you want to know which Opportunities would have previously included this double rollup value counting, run this SOQL query in the Developer Console: &apos;&apos;SELECT Count(Id), OpportunityId, Opportunity.Name OpportunityName, ContactId, Contact.Name ContactName FROM OpportunityContactRole WHERE Opportunity.IsWon = true AND Role IN ({0}) GROUP BY OpportunityId, Opportunity.Name, ContactId, Contact.Name HAVING Count(Id) &gt; 1&apos;&apos;</value>
     </labels>
     <labels>
         <fullName>healthSolutionEditSetting</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1431,6 +1431,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>You cannot specify the same Account Record Type for the Household Account Record Type and One-to-One Record Type.</value>
     </labels>
     <labels>
+        <fullName>healthDetailsDuplicateContactRoles</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>The details displayed when the duplicate contact roles health check fails</shortDescription>
+        <value>There were opportunities with duplicate contact roles detected in you org.</value>
+    </labels>
+    <labels>
         <fullName>healthDetailsGenderField</fullName>
         <categories>Health Check</categories>
         <language>en_US</language>
@@ -1759,6 +1767,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Contact Data</value>
     </labels>
     <labels>
+        <fullName>healthLabelDuplicateContactRoles</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Label for Duplicate Contact Role health check</shortDescription>
+        <value>Duplicate Contact Roles</value>
+    </labels>
+    <labels>
         <fullName>healthLabelErrorRecipientValid</fullName>
         <categories>Health Check</categories>
         <language>en_US</language>
@@ -1821,6 +1837,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <protected>false</protected>
         <shortDescription>healthLabelLastRun</shortDescription>
         <value>Last run: {0}</value>
+    </labels>
+    <labels>
+        <fullName>healthLabelNoDuplicateContactRoles</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>The message displayed when the duplicate contact roles health check passes</shortDescription>
+        <value>There were no opportunities with duplicate contact roles detected.</value>
     </labels>
     <labels>
         <fullName>healthLabelNoMissingOppPayments</fullName>
@@ -2052,6 +2076,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <protected>false</protected>
         <shortDescription>healthSolutionContactData</shortDescription>
         <value>View these Contacts by running the &lt;b&gt;Contacts without Accounts&lt;/b&gt; report in the NPSP Health Check reports folder.</value>
+    </labels>
+    <labels>
+        <fullName>healthSolutionDuplicateContactRoles</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>The recommended solution for when the duplicate contact roles health check fails</shortDescription>
+        <value>You should expect these contacts to have different roll-up values than before, since duplicate contacts are no longer counted twice.  To discover duplicate opportunities and contacts in your org, you can run the following SOQL query in the Developer Console: &apos;SELECT Count(Id), OpportunityId, Opportunity.Name OpportunityName, ContactId, Contact.Name ContactName FROM OpportunityContactRole GROUP BY OpportunityId, Opportunity.Name, ContactId, Contact.Name HAVING Count(Id) &gt; 1&apos;</value>
     </labels>
     <labels>
         <fullName>healthSolutionEditSetting</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1436,7 +1436,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>The details displayed when the duplicate contact roles health check fails</shortDescription>
-        <value>There were opportunities with duplicate contact roles detected in you org.</value>
+        <value>There were opportunities with duplicate contact roles detected in your org.</value>
     </labels>
     <labels>
         <fullName>healthDetailsGenderField</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -850,6 +850,7 @@
         <members>healthDetailsBadReportId</members>
         <members>healthDetailsContactData</members>
         <members>healthDetailsDuplicateAcctRT</members>
+        <members>healthDetailsDuplicateContactRoles</members>
         <members>healthDetailsGenderField</members>
         <members>healthDetailsHHAccountModel</members>
         <members>healthDetailsHHActNoContacts</members>
@@ -891,6 +892,7 @@
         <members>healthLabelAllTestsPassed</members>
         <members>healthLabelAutoRelValid</members>
         <members>healthLabelContactData</members>
+        <members>healthLabelDuplicateContactRoles</members>
         <members>healthLabelErrorRecipientValid</members>
         <members>healthLabelFailed</members>
         <members>healthLabelFiscalYearsValid</members>
@@ -899,6 +901,7 @@
         <members>healthLabelHHObjData</members>
         <members>healthLabelIntro</members>
         <members>healthLabelLastRun</members>
+        <members>healthLabelNoDuplicateContactRoles</members>
         <members>healthLabelNoMissingOppPayments</members>
         <members>healthLabelNone</members>
         <members>healthLabelOCRCheck</members>
@@ -928,6 +931,7 @@
         <members>healthSolutionAutoRelInvalidLookupField</members>
         <members>healthSolutionBadRDField</members>
         <members>healthSolutionContactData</members>
+        <members>healthSolutionDuplicateContactRoles</members>
         <members>healthSolutionEditSetting</members>
         <members>healthSolutionHHAccNoContacts</members>
         <members>healthSolutionHHObjNoContacts</members>

--- a/src/translations/es.translation
+++ b/src/translations/es.translation
@@ -742,6 +742,10 @@
         <name>healthDetailsDuplicateAcctRT</name>
     </customLabels>
     <customLabels>
+        <label><!-- The details displayed when the duplicate contact roles health check fails --></label>
+        <name>healthDetailsDuplicateContactRoles</name>
+    </customLabels>
+    <customLabels>
         <label>El campo de género {0} no existe en el Contacto.</label>
         <name>healthDetailsGenderField</name>
     </customLabels>
@@ -906,6 +910,10 @@
         <name>healthLabelContactData</name>
     </customLabels>
     <customLabels>
+        <label><!-- Label for Duplicate Contact Role health check --></label>
+        <name>healthLabelDuplicateContactRoles</name>
+    </customLabels>
+    <customLabels>
         <label>Receptor de notificaciones de errores válido.</label>
         <name>healthLabelErrorRecipientValid</name>
     </customLabels>
@@ -936,6 +944,10 @@
     <customLabels>
         <label>Corrió por última vez: {0}</label>
         <name>healthLabelLastRun</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- The message displayed when the duplicate contact roles health check passes --></label>
+        <name>healthLabelNoDuplicateContactRoles</name>
     </customLabels>
     <customLabels>
         <label>Todas las Oportunidades con Pagos tienen los Pagos esperados.</label>
@@ -1052,6 +1064,10 @@
     <customLabels>
         <label>Vea estos contactos en el informe &lt;b&gt;Contacts without Accounts&lt;/b&gt; en la carpeta de informes NPSP Health Check.</label>
         <name>healthSolutionContactData</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- The recommended solution for when the duplicate contact roles health check fails --></label>
+        <name>healthSolutionDuplicateContactRoles</name>
     </customLabels>
     <customLabels>
         <label>En la pestaña Configuración del NPSP, haga clic en {0} | {1}, y elimine el registro inválido Auto creación de relaciones.</label>


### PR DESCRIPTION
Adding a health check to detect the case where an opportunity has the
same contact associated via more than one OpportunityContactRole.

The reason this health check is being added is because we are changing
the behavior of how partial soft credits are counted.  In the future, we
will only credit a contact associated with an opportunity once for that
opportunity, NOT multiple times based on how many times the contact is
associated with the opportunity.

This health check brings with it some labels for displaying error,
success, and solution messages.

# Warning

# Info
We've changed the way the NPSP treats soft credit Opportunity Rollup values for Contacts that are doubly associated with an Opportunity through two different Opportunity Contact Roles. In the past these rollup values were double-counted for the Contact; now they're only counted once. We've provided a new Health Check that lets you detect Opportunities that formerly would have rolled up soft credit values twice for these double-associated Contacts.

# Issues
#2082