### PR TITLE
Feature/lex manage household

### DIFF
--- a/src/aura/HH_Container/HH_ContainerHelper.js
+++ b/src/aura/HH_Container/HH_ContainerHelper.js
@@ -350,7 +350,7 @@
             } else {
                 con.npo02__Household__c = null;
             }
-            con.hhId = null;
+            con.HHId__c = null;
             
             var listConRemove = component.get('v.listConRemove');
             if (!listConRemove)
@@ -543,7 +543,7 @@
             con.AccountId = hhId;
         else
             con.npo02__Household__c = hhId;
-        con.hhId = hhId;
+        con.HHId__c = hhId;
         // tag each new contact with a timestamp, so we can identify it if we need to Remove it.
         con.dtNewContact = Date.now();
         component.set('v.conNew', con);
@@ -836,7 +836,7 @@
             for (var fld in object) {
                 
                 // if the field is actually an object, process its fields first
-                if (typeof object[fld] === 'object') {
+                if (object[fld] !== null && typeof object[fld] === 'object') {
                     object[fld] = this.processPrefixObjectFields(namespacePrefix, object[fld], isAdd);
                 }
                 
@@ -863,6 +863,5 @@
             return object;
         }
     },
-
 
 })

--- a/src/aura/HH_Container/HH_ContainerHelper.js
+++ b/src/aura/HH_Container/HH_ContainerHelper.js
@@ -834,6 +834,12 @@
 
             // process namespace prefix from each custom field
             for (var fld in object) {
+                
+                // if the field is actually an object, process its fields first
+                if (typeof object[fld] === 'object') {
+                    object[fld] = this.processPrefixObjectFields(namespacePrefix, object[fld], isAdd);
+                }
+                
                 if (isAdd) {
                     // see if custom field has no namespace prefix
                     if (fld.endsWith('__c') && fld.indexOf('__') === fld.lastIndexOf('__')) {

--- a/src/classes/HH_ManageHH_CTRL.cls-meta.xml
+++ b/src/classes/HH_ManageHH_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>36.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>1</minorNumber>
+        <minorNumber>3</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>


### PR DESCRIPTION
@dospromptman This fixes a namespace fixup bug I uncovered when I added a namespace to my local DE org.  It showed up because any object like a contact that contained a subobject, like Account, wouldn't get the subfields namespace fixed up, and so we wouldn't see the correct data.  In practical terms, when looking at Contacts for add or merge, if we are in the HH model, I look at Contact.Account.Number_of_Household_Members__c, but in my contact object, which got fixed up, Account still held a field called djhcumulus2__Number_of_Household_Members__c.  

Please review and merge once it passes build.  thanks.