### PR TITLE
New Health Check report for mixed account types

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1373,7 +1373,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>healthDetailsAccountProcessor</shortDescription>
-        <value>The Account Model is set to {0}, but there are a mixture of Account types being used.</value>
+        <value>The Account Model is set to {0}, but Health Check has found that you&apos;re using a mixture of Account types.</value>
     </labels>
     <labels>
         <fullName>healthDetailsAccountRTIssue</fullName>
@@ -2028,7 +2028,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>healthSolutionAccountModel</shortDescription>
-        <value>All of your Accounts should use the same Account Model. View these Accounts by running the &lt;b&gt;Individual Accounts by Account Type&lt;/b&gt; report in the NPSP Health Check reports folder.</value>
+        <value>All of your Accounts should use the same Account Model. View all of your Accounts and their types by running the &lt;b&gt;Individual Accounts by Account Type&lt;/b&gt; report in the NPSP Health Check reports folder.</value>
     </labels>
     <labels>
         <fullName>healthSolutionAccountRTIssue</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2028,7 +2028,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>healthSolutionAccountModel</shortDescription>
-        <value>All of your individual Contacts should use the same Account Model. View these Contacts by running the &lt;b&gt;Individual Contacts by Account Type&lt;/b&gt; report in the NPSP Health Check reports folder.</value>
+        <value>All of your Accounts should use the same Account Model. View these Accounts by running the &lt;b&gt;Individual Accounts by Account Type&lt;/b&gt; report in the NPSP Health Check reports folder.</value>
     </labels>
     <labels>
         <fullName>healthSolutionAccountRTIssue</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1586,6 +1586,7 @@
         <members>NPSP_Health_Check/Contacts_Without_Accounts</members>
         <members>NPSP_Health_Check/Empty_Household_Accounts</members>
         <members>NPSP_Health_Check/Empty_Household_Objects</members>
+        <members>NPSP_Health_Check/Individual_Accounts_by_Account_Type</members>
         <members>NPSP_Health_Check/Individual_Contacts_by_Account_Type</members>
         <members>NPSP_Health_Check/Opportunities_with_Primary_Contact_Roles</members>
         <members>NPSP_Health_Check/Opportunities_without_Payments</members>

--- a/src/reports/NPSP_Health_Check-meta.xml
+++ b/src/reports/NPSP_Health_Check-meta.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ReportFolder xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accessType>Hidden</accessType>
     <name>NPSP Health Check</name>
+    <publicFolderAccess>ReadWrite</publicFolderAccess>
 </ReportFolder>

--- a/src/reports/NPSP_Health_Check-meta.xml
+++ b/src/reports/NPSP_Health_Check-meta.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ReportFolder xmlns="http://soap.sforce.com/2006/04/metadata">
-    <accessType>Hidden</accessType>
     <name>NPSP Health Check</name>
-    <publicFolderAccess>ReadWrite</publicFolderAccess>
 </ReportFolder>

--- a/src/reports/NPSP_Health_Check/Individual_Accounts_by_Account_Type.report
+++ b/src/reports/NPSP_Health_Check/Individual_Accounts_by_Account_Type.report
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report xmlns="http://soap.sforce.com/2006/04/metadata">
+    <columns>
+        <field>USERS.NAME</field>
+    </columns>
+    <columns>
+        <field>ACCOUNT.NAME</field>
+    </columns>
+    <columns>
+        <field>TYPE</field>
+    </columns>
+    <columns>
+        <field>RATING</field>
+    </columns>
+    <columns>
+        <field>DUE_DATE</field>
+    </columns>
+    <columns>
+        <field>LAST_UPDATE</field>
+    </columns>
+    <columns>
+        <field>ADDRESS1_STATE</field>
+    </columns>
+    <description>Lists Accounts grouped by their system Account Type.  Details are hidden to avoid data limits.  Check the group you want to see details on and click the Drill Down button.</description>
+    <filter>
+        <criteriaItems>
+            <column>Account.npe01__SYSTEM_AccountType__c</column>
+            <operator>notEqual</operator>
+            <value></value>
+        </criteriaItems>
+        <language>en_US</language>
+    </filter>
+    <format>Summary</format>
+    <groupingsDown>
+        <dateGranularity>Day</dateGranularity>
+        <field>Account.npe01__SYSTEM_AccountType__c</field>
+        <sortOrder>Asc</sortOrder>
+    </groupingsDown>
+    <name>Individual Accounts by Account Type</name>
+    <params>
+        <name>co</name>
+        <value>1</value>
+    </params>
+    <reportType>AccountList</reportType>
+    <scope>organization</scope>
+    <showDetails>false</showDetails>
+    <timeFrameFilter>
+        <dateColumn>CREATED_DATE</dateColumn>
+        <interval>INTERVAL_CUSTOM</interval>
+    </timeFrameFilter>
+</Report>


### PR DESCRIPTION
Adding new report to better show which accounts are violating the mixed
account model.  Update health check messaging to direct users to the new
report.

# Info
* "Individual Accounts by Account Type" is a new report that lets you view all Accounts, aggregated by their Account type.  This report is recommended by Health Check for diagnosing issues related to organizations that are using a mixed Account model.

# Issues
Fixes #2130 