### PR TITLE
ManageHHUI Save fixes

### DIFF
--- a/src/aura/HH_Canvas/HH_Canvas.cmp
+++ b/src/aura/HH_Canvas/HH_Canvas.cmp
@@ -22,7 +22,7 @@
             <li class="slds-list__item" style="margin: 0; border: 0; vertical-align: top" data-icontact="{!icon}">
                 <c:HH_ContactCard contact="{!con}" />
             </li>
-        </aura:iteration>
+        </aura:iteration> 
     </ul>
 
 </aura:component>

--- a/src/aura/HH_Container/HH_Container.cmp
+++ b/src/aura/HH_Container/HH_Container.cmp
@@ -39,7 +39,7 @@
     <aura:handler event="c:HH_ContactReorderEvent" action="{!c.handleContactReorderEvent}"/>
     <aura:handler event="c:HH_AddressChangedEvent" action="{!c.handleAddressChangedEvent}"/>
     <aura:handler event="c:autocompleteSelectListOption" name="optionSelected" action="{!c.handleAutoCompleteOptionSelectedEvent}" />    
-    <aura:handler event="c:HH_ContactNewEvent" name="ContactNewEvent" action="{!c.handleContactNewEvent}" />    
+    <aura:handler event="c:HH_ContactNewEvent" name="ContactNewEvent" action="{!c.handleContactNewEvent}" />
 
     <!-- markup follows... -->
 

--- a/src/aura/HH_Container/HH_ContainerController.js
+++ b/src/aura/HH_Container/HH_ContainerController.js
@@ -59,7 +59,7 @@
 
     // close and return to the household
     close : function(component, event, helper) {
-        helper.close(component);
+        helper.closePage(component);
     },
 
     // the default Address has changed, so update our Contacts

--- a/src/aura/HH_Container/HH_ContainerHelper.js
+++ b/src/aura/HH_Container/HH_ContainerHelper.js
@@ -236,14 +236,28 @@
             }
         };
 
-        // first need to merge any households (Accounts only) before we save contacts
-        // so we avoid deleting a household if that contact was the last one in the hh.
-        var listHHMerge = component.get('v.listHHMerge');
+        // get our objects
         var hh = component.get('v.hh');
         var listCon = component.get("v.listCon");
+        var listHHMerge = component.get('v.listHHMerge');
+        var listConRemove = component.get("v.listConRemove");
         var namespacePrefix = component.get('v.namespacePrefix');
+
+        // update our auto-naming exclusion states
+        this.updateNamingExclusions(component, hh);
+
+        // save the Household
         hh.Number_of_Household_Members__c = listCon.length; 
         hh = this.addPrefixToObjectFields(namespacePrefix, hh);
+        action = component.get("c.updateHousehold");
+        action.setParams({
+            hh: hh
+        });
+        action.setCallback(this, callback);
+        $A.enqueueAction(action);
+
+        // need to merge any households (Accounts only) before we save contacts
+        // so we avoid deleting a household if that contact was the last one in the hh.
         if (listHHMerge && listHHMerge.length > 0) {
             listHHMerge = this.addPrefixToListObjectFields(namespacePrefix, listHHMerge);
             action = component.get("c.mergeHouseholds");
@@ -266,19 +280,7 @@
         action.setCallback(this, callback);
         $A.enqueueAction(action);
 
-        // update our auto-naming exclusion states
-        this.updateNamingExclusions(component, hh);
-
-        // save the Household
-        action = component.get("c.updateHousehold");
-        action.setParams({
-            hh: hh
-        });
-        action.setCallback(this, callback);
-        $A.enqueueAction(action);
-
         // remove any contacts
-        var listConRemove = component.get("v.listConRemove");
         listConRemove = this.addPrefixToListObjectFields(namespacePrefix, listConRemove);
         action = component.get("c.upsertContacts");
         action.setParams({

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -183,11 +183,12 @@ public with sharing class HH_Container_LCTRL {
             strSoql += strComma + strF;
             strComma = ',';
         }
-        // add a few fields we need for contact merge code
+        // add a few fields we need for contact merge and standard code that
         // we don't have these in our set of fields, because we want to avoid FLS on them,
         // since we want to support both HH Accounts and Objects, but we expect customers might
         // only grant permissions on the model they are currently using, but we may have data in both models.
         // the find autocomplete lookup also uses this code, so it needs to see both types of households.
+        strSoql += ', npo02__Household__c'; 
         strSoql += ', Account.Number_of_Household_Members__c, npo02__Household__r.Number_of_Household_Members__c ';
         strSoql += ', Account.Name, npo02__Household__r.Name ';
         strSoql += ' FROM Contact ';
@@ -208,7 +209,6 @@ public with sharing class HH_Container_LCTRL {
                 'Salutation', 
                 'Name',
                 'npo02__Naming_Exclusions__c', 
-                'npo02__Household__c', 
                 'AccountId', 
                 UTIL_Namespace.StrTokenNSPrefix('HHId__c'),
                 UTIL_Namespace.StrTokenNSPrefix('Exclude_from_Household_Name__c'), 
@@ -246,7 +246,6 @@ public with sharing class HH_Container_LCTRL {
     private static set<String> setUpdateableContactFields() {
         set<String> setContactFields = new Set<String>{
             'AccountId',
-            'npo02__Household__c',
             'FirstName',
             'LastName',
             'Salutation',

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -311,6 +311,13 @@ public with sharing class HH_Container_LCTRL {
                     listInsert.add(con2);
                 }
             }
+            
+
+            // avoid saving of contacts from updating household names
+            // to avoid record lock errors.  let the household be responsible
+            // for updating its name.
+            HH_ProcessControl.inFutureContext = true;
+            
             // allow potential duplicates when rules to warn are turned on.
             Database.DMLOptions dml = new Database.DMLOptions();
             dml.DuplicateRuleHeader.AllowSave = true;

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -413,12 +413,41 @@ public with sharing class HH_Container_LCTRL {
                 !Account.sObjectType.getDescribe().isDeletable()) {
                     throw new System.NoAccessException(); 
                }
+            
             for (Account loser : listHHMerge)
                 merge hhWinner loser;
         } catch (Exception ex) {
             throw new AuraHandledException(ex.getMessage());
         }
     }
+
+    /*******************************************************************************************************
+    * @description saves all changes from the Manage Household UI page to the database
+    * @param hh The Household
+    * @param listCon The list of Contacts to save (update and insert)
+    * @param listConRemove The list of Contacts to remove from the household
+    * @param listHHMerge the list of Households to merge into the winner
+    * @return void
+    */
+    @AuraEnabled
+    public static void saveHouseholdPage(SObject hh, list<Contact> listCon, list<Contact> listConRemove, list<Account>listHHMerge) {
+
+        // save the Household
+        updateHousehold(hh);
+        
+        // need to merge any households (Accounts only) before we save contacts
+        // so we avoid deleting a household if that contact was the last one in the hh.
+        if (listHHMerge != null && listHHMerge.size() > 0) {
+            mergeHouseholds((Account)hh, listHHMerge);
+        }
+        
+        // save the contacts
+        upsertContacts(listCon);
+        
+        // remove any contacts
+        upsertContacts(listConRemove);                
+    }
+
 
     /*******************************************************************************************************
     * @description sets the Household Name and Greetings on the Household object, given the list of Contacts

--- a/src/classes/HH_ManageHH_CTRL.cls
+++ b/src/classes/HH_ManageHH_CTRL.cls
@@ -132,25 +132,15 @@ public with sharing class HH_ManageHH_CTRL {
     }
 
     /*******************************************************************************************************
-    * @description ActionMethod to save the Household and close the page.
-    * @return PageReference the original calling page's URL.
+    * @description ActionMethod to save the Household
+    * @return null
     */
     public PageReference save() {
         try {
-            // we've already saved the data for the contacts in the household.
-            // now we only need to save the account fields an update, and we don't want
-            // any of the normal account trigger work to run again.  specifically,
-            // we may have updated the names and greetings, because the contacts have changed,
-            // but the user still may want auto-naming turned on.  our normal trigger flow
-            // would think the user updated the name from what it was, and thus it should be
-            // excluded from auto-naming!
-            HH_ProcessControl.inFutureContext = true;
             update hh;
         } catch (Exception ex) {
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, ex.getMessage()));
-            return null;
-        }
-        
-        return new PageReference('/' + hhId);
+        }        
+        return null; 
     }
 }

--- a/src/classes/HH_ManageHH_CTRL.cls
+++ b/src/classes/HH_ManageHH_CTRL.cls
@@ -136,7 +136,21 @@ public with sharing class HH_ManageHH_CTRL {
     * @return PageReference the original calling page's URL.
     */
     public PageReference save() {
-        update hh;
+        try {
+            // we've already saved the data for the contacts in the household.
+            // now we only need to save the account fields an update, and we don't want
+            // any of the normal account trigger work to run again.  specifically,
+            // we may have updated the names and greetings, because the contacts have changed,
+            // but the user still may want auto-naming turned on.  our normal trigger flow
+            // would think the user updated the name from what it was, and thus it should be
+            // excluded from auto-naming!
+            HH_ProcessControl.inFutureContext = true;
+            update hh;
+        } catch (Exception ex) {
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, ex.getMessage()));
+            return null;
+        }
+        
         return new PageReference('/' + hhId);
     }
 }

--- a/src/classes/HH_ManageHH_TEST.cls
+++ b/src/classes/HH_ManageHH_TEST.cls
@@ -58,7 +58,7 @@ private class HH_ManageHH_TEST {
             system.assertEquals(UTIL_Namespace.getNamespace(), ctrl.namespacePrefix);
         else
             system.assertEquals('', ctrl.namespacePrefix);
-        system.assertNotEquals(null, ctrl.save());
+        system.assertEquals(null, ctrl.save());
         
        Test.stopTest();
     }
@@ -84,7 +84,7 @@ private class HH_ManageHH_TEST {
             system.assertEquals(UTIL_Namespace.getNamespace(), ctrl.namespacePrefix);
         else
             system.assertEquals('', ctrl.namespacePrefix);
-        system.assertNotEquals(null, ctrl.save());
+        system.assertEquals(null, ctrl.save());
         
         Test.stopTest();
     }

--- a/src/pages/HH_ManageHH.page
+++ b/src/pages/HH_ManageHH.page
@@ -55,7 +55,7 @@
                 </div>                
             </div>
             <!-- we expose a javascript function our lightning component can call to save the vf fieldset & close the page -->            
-            <apex:actionFunction action="{!save}" name="saveAndCloseVisualforce" />
+            <apex:actionFunction action="{!save}" name="saveVisualforce" rerender="panelErrors, vfForm" />
         </apex:form>
         
     </html>
@@ -121,14 +121,21 @@
             j$('.initialSpinner').hide();                                       
         },
         
-        // called by our lightning component when it has finished saving its data
-        // and it wants the page to save and close.
-        HH_HouseholdSavedEvent : function(event) {
-            // show our startup spinner, because this save takes time
-            j$('.initialSpinner').show();                                       
-            saveAndCloseVisualforce();
-        } 
+        // called by our lightning component when it wants the page to save its field set
+        HH_saveHousehold : function(event) {
+            saveVisualforce();
+        },
         
+        // called by our lightning component when it has finished saving its data,
+        // so it knows whether it is safe to close the page.
+        HH_hasErrors : function() {
+            // look for both validation errors visualforce puts on fields, and our own c:UTIL_PageMessages ui
+            // yes, this is a hack, but avoid yet another round trip to the server to ask about pageMessages 
+            // which wouldn't event include the validation errors on the fields!
+            var hasErrors = j$('.errorMsg').length > 0 || j$('.slds-theme--error').length > 0;
+            return hasErrors;
+        }
+                
     };
 
     </script>

--- a/src/pages/HH_ManageHH.page-meta.xml
+++ b/src/pages/HH_ManageHH.page-meta.xml
@@ -3,7 +3,6 @@
     <apiVersion>36.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
-    <description></description>
     <label>HH_ManageHH</label>
     <packageVersions>
         <majorNumber>3</majorNumber>


### PR DESCRIPTION
This pull request is an attempt to reduce the number of errors encountered during save scenarios from the ManageHouseholdUI.  When dealing with lots of data changes thru merging in additional households, I've found that we were frequently getting record locking errors when trying to update the household.  With these changes the frequency has been greatly reduced, but there are still some scenarios where I believe it will happen.

@dospromptman This pull requests re-orders the save method, so we update the household first, then merge households, then save contacts, and finally the visualforce page's save to field sets.

@chrismcmahon I could really use some additional help testing out this scenario.  You need to disable NPSP Error Handling from the NPSP Settings page.  Then try out lots of different scenarios of making many edits and saving.  I can only now reproduce the problems when I start with a household with ~100 opportunities, and I then merge in a separate 10 person household.  When I try with fewer opps, or fewer contacts in the household merge, I don't seem to hit errors.  If you could report any reproduceable errors you see displayed on the page, or emailed to you thru the NPSP error mechanism, please let me know.  Happy to discuss further if that would be helpful.  thanks!


# Critical Changes

# Changes

# Issues Closed
Fixes #2174 
Fixes #2186 
