### PR TITLE
Updating record type localizations query

### DIFF
--- a/src/classes/UTIL_RecordTypeSettingsUpdate.cls
+++ b/src/classes/UTIL_RecordTypeSettingsUpdate.cls
@@ -193,21 +193,29 @@ global virtual class UTIL_RecordTypeSettingsUpdate {
     private virtual Map<String, Id> getNameToRecordTypeIdMap(Schema.SObjectType sot) {
         String sobjectTypeName = sot.getDescribe().getName();
 
-        List<RecordType> recordTypes = [
-            SELECT
-                Name,
-                (SELECT Value FROM Localization)
-            FROM RecordType
-            WHERE SobjectType = :sobjectTypeName
-        ];
+        List<RecordType> recordTypes;
+
+        try {
+            recordTypes = Database.query(
+                'SELECT Name, (SELECT Value FROM Localization) FROM RecordType WHERE SobjectType = :sobjectTypeName'
+            );
+        } catch (QueryException e) {
+            recordTypes = Database.query(
+                'SELECT Name FROM RecordType WHERE SobjectType = :sobjectTypeName'
+            );
+        }
 
         Map<String, Id> nameMap = new Map<String, Id>();
 
         for (RecordType rt : recordTypes) {
             nameMap.put(rt.Name, rt.Id);
-            for (RecordTypeLocalization rtl : rt.Localization) {
-                // potentially overwrite existing entry due to ambiguity in naming-- fine
-                nameMap.put(rtl.Value, rt.Id);
+            try {
+                for (sObject rtl : rt.getSobjects('Localization')) {
+                    // potentially overwrite existing entry due to ambiguity in naming-- fine
+                    nameMap.put((String) rtl.get('Value'), rt.Id);
+                }
+            } catch (SObjectException e) {
+                // no localizations available
             }
         }
 


### PR DESCRIPTION
Including a query that explicitly referenced the RecordTypeLocalization
type, via the Localization relationship on the RecordType sObject, was
causing deployment errors for orgs that did not have translation
workbench enabled.  These orgs act as if RecordTypeLocalization (and the
Localization relationship on RecordType) do not exist.

I am updating the querying of record types to attempt to query record
types with translations first, but if that fails then to only query
untranslated record types.  Additionally, when iterating over the
RecordTypes returned by this query, I attempt to iterate over child
sObjects in the Localization relationship field, but if this field was
not queried, then I silently ignore this failed attempt at reading
translated values.

This should allow this code to be deployed to orgs that do not have
translation workbench enabled, and should also prevent any runtime
errors when running in orgs that do or do not have it enabled.  If
translation workbench is enabled, then it should include any record type
translations in the returned id map.