### PR TITLE
Fix tests that refer to record type ids

### DIFF
--- a/src/classes/PMT_PaymentCreator_TEST.cls
+++ b/src/classes/PMT_PaymentCreator_TEST.cls
@@ -254,23 +254,13 @@ private with sharing class PMT_PaymentCreator_TEST {
         if (strTestOnly != '*' && strTestOnly != 'createOppWithRecordTypeExcluded') return;
         
         // see if this org has any record types we can use!
-        string strGift = UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
-        Id rtIdGift = null;
-        if (strGift != null && strGift != '' && UTIL_RecordTypes.isRecordTypeActive('Opportunity', strGift)) {
-            rtIdGift = UTIL_RecordTypes.GetRecordTypeId('Opportunity', strGift);
-        }
-
-        npe01__Contacts_And_Orgs_Settings__c defaultSettingsForTests = new npe01__Contacts_And_Orgs_Settings__c(
-            npe01__Payments_Enabled__c = true,
-            Opp_RecTypes_Excluded_for_Payments__c = ''
-        );
-
-        if (rtIdGift != null) {
-            defaultSettingsForTests.Opp_RecTypes_Excluded_for_Payments__c = rtIdGift;
-        }
+        Id rtIdGift = UTIL_RecordTypes.getRecordTypeIdForGiftsTests('Opportunity');
 
         npe01__Contacts_And_Orgs_Settings__c PaymentsSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            defaultSettingsForTests
+            new npe01__Contacts_And_Orgs_Settings__c(
+                npe01__Payments_Enabled__c = true,
+                Opp_RecTypes_Excluded_for_Payments__c = rtIdGift
+            )
         );
 
         // create test data
@@ -286,9 +276,11 @@ private with sharing class PMT_PaymentCreator_TEST {
             Amount = 1,
             StageName = UTIL_UnitTestData_TEST.getOpenStage()
         );
-        if (rtIdGift != null)
-            opp.RecordtypeId = rtIdGift;
-        
+
+        if (rtIdGift != null) {
+            opp.RecordTypeId = rtIdGift;
+        }
+
         Test.startTest();
         insert opp;
         Test.stopTest();

--- a/src/classes/RLLP_OppRollup_TEST.cls
+++ b/src/classes/RLLP_OppRollup_TEST.cls
@@ -337,7 +337,7 @@ public with sharing class RLLP_OppRollup_TEST {
     */
     static void testGivingRollupExcludedRTProcessor (string strProcessor) {
 
-        if(giftRecordTypeIdForTests!=''){
+        if(giftRecordTypeIdForTests != null){
             npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c (
                 npe01__Account_Processor__c = strProcessor,
                 npe01__Enable_Opportunity_Contact_Role_Trigger__c = true,
@@ -531,7 +531,7 @@ public with sharing class RLLP_OppRollup_TEST {
     */
     static void testMemberRollupProcessor (string strProcessor) {
 
-        if(membershipRecordTypeIdForTests!=''){
+        if(membershipRecordTypeIdForTests != null){
             npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c (
                 npe01__Account_Processor__c = strProcessor,
                 npe01__Enable_Opportunity_Contact_Role_Trigger__c = true,
@@ -674,7 +674,7 @@ public with sharing class RLLP_OppRollup_TEST {
     }
     static void testGivingRollupAcctMembership (string strProcessor) {
 
-        if(membershipRecordTypeIdForTests!=''){
+        if(membershipRecordTypeIdForTests != null){
             npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c (
                 npe01__Account_Processor__c = strProcessor,
                 npe01__Enable_Opportunity_Contact_Role_Trigger__c = true,


### PR DESCRIPTION
As part of the conversion from Record Type Names to Record Type Ids in Custom Settings, many of the tests were updated to expect to receive an id when requesting which record type to use in that test, where previously the test was expecting to receive a string (a record type name).

There were a few spots where, if there were no available record types for the test to use, the new code was returning null (as no id), where the old code was returning '' (as no name).  I have fixed the places where the code was comparing to the empty string instead of comparing to null.

I have also updated one of the tests to avoid attempting to look up a record type name to use in the test, then converting that record type name to an id. This was failing when the record type name was an empty string, similar to the above issue.  Now this test simply looks up a record type id to use in the test, and avoids the name lookup entirely.

These issues were only evident when the user running the tests did not have any access to any record types.

I have verified that all tests now pass if the user running the tests has access to all record types, as well as if the user has access to no record types.

(Any other configurations is another story....)