### PR TITLE
Update record type custom settings on new install

### DIFF
--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -63,7 +63,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
             //We won't rethrow the exception, to avoid package failure installation due to install script error
             return;
         }
-        if (context.isUpgrade() && context.previousVersion().compareTo(new Version(3, 79)) < 0) {
+        if (context.previousVersion() == null || context.previousVersion().compareTo(new Version(3, 79)) < 0) {
             // update record type settings ONLY if upgrading from a version prior to 3.78
             UTIL_RecordTypeSettingsUpdate.getInstance().updateSettings();
         }

--- a/src/classes/UTIL_RecordTypeSettingsUpdate_TEST.cls
+++ b/src/classes/UTIL_RecordTypeSettingsUpdate_TEST.cls
@@ -339,8 +339,10 @@ private class UTIL_RecordTypeSettingsUpdate_TEST {
     }
 
     @isTest
-    public static void testUpdateDoesNotRunOnNewInstall() {
-        // when new install, updateSettings() should not be called
+    public static void testUpdateRunsOnNewInstall() {
+        // when new install, updateSettings() should be called, since this
+        // will handle cases where users are updating from NPSP 2.0, and
+        // otherwise be a noop.
         UpdateSettingsRunCount stub = new UpdateSettingsRunCount();
         UTIL_RecordTypeSettingsUpdate.instance = stub;
 
@@ -350,7 +352,7 @@ private class UTIL_RecordTypeSettingsUpdate_TEST {
 
         Test.stopTest();
 
-        System.assertEquals(0, stub.runCount);
+        System.assertEquals(1, stub.runCount);
     }
 
     @isTest


### PR DESCRIPTION
If a user installs 'npsp' package when they were previously using the
underlying packages in some other way (i.e. NPSP 2.0), then that user
might have settings that need to be updated to reflect the change in
storage format.

This commit updates the post install conditions to also run the settings
update code on a new install of NPSP.  In an org where these settings
were not populated (i.e. a brand new NPSP install), this should be a
noop.

A real world QA test for this would involve installing underlying packages,
editing settings to contain record type names, and then installing the
'npsp' package.  The custom settings should have been updated with the
corresponding record type ids.