### PR TITLE
Rewrite UTIL_RecordTypes class

### DIFF
--- a/src/classes/ALLO_Allocations_TEST.cls
+++ b/src/classes/ALLO_Allocations_TEST.cls
@@ -397,8 +397,8 @@ private with sharing class ALLO_Allocations_TEST {
         General_Accounting_Unit__c defaultgau = new General_Accounting_Unit__c(Name='General');
         insert defaultgau;
 
-        string rtname = UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity');
-        id rtid = UTIL_RecordTypes.GetRecordTypeId('Opportunity',rtname);
+        string rtname = UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType);
+        id rtid = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType,rtname);
 
         setupSettings(new Allocations_Settings__c(Default_Allocations_Enabled__c = true, Default__c = defaultGau.id, Excluded_Opp_Types__c='foo;bar', Excluded_Opp_RecTypes__c=rtid));
         Account acc = new Account(Name='foo');

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -1540,7 +1540,7 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
             }
                 
             if (di.Donation_Record_Type_Name__c != null) {
-                Id idRt = UTIL_RecordTypes.GetRecordTypeId('Opportunity', di.Donation_Record_Type_Name__c);
+                Id idRt = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, di.Donation_Record_Type_Name__c);
                 if (idRt == null) {
                     LogBDIError(di, label.bdiErrorInvalidOppRTName, 'DonationImportStatus__c');
                     continue;

--- a/src/classes/HH_Households_TEST.cls
+++ b/src/classes/HH_Households_TEST.cls
@@ -669,7 +669,7 @@ public with sharing class HH_Households_TEST {
         );            
         insert c1;  
         
-        id rtid = UTIL_RecordTypes.GetRecordTypeId ('Opportunity',UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity'));
+        id rtid = UTIL_RecordTypes.GetRecordTypeId (Opportunity.sObjectType,UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType));
         Opportunity newOpp = New Opportunity (
                 Name = 'Test Opp ',
                 Amount = 100,

--- a/src/classes/OPP_OpportunityNaming_TEST.cls
+++ b/src/classes/OPP_OpportunityNaming_TEST.cls
@@ -47,7 +47,7 @@ private class OPP_OpportunityNaming_TEST
     * @description Returns an active record type id for the current profile.
     */
     private static boolean hasActiveRecType() {
-        Schema.RecordTypeInfo giftRecTypeInfo = UTIL_RecordTypes.getRecordTypeInfoForGiftsTests('Opportunity');
+        Schema.RecordTypeInfo giftRecTypeInfo = UTIL_RecordTypes.getRecordTypeInfoForGiftsTests(Opportunity.sObjectType);
 
         if (giftRecTypeInfo == null) {
             return false;
@@ -71,7 +71,7 @@ private class OPP_OpportunityNaming_TEST
             Attribution__c = Label.oppNamingBoth
         );
         if (hasActiveRecType())
-            ons.Opportunity_Record_Types__c = UTIL_RecordTypes.getrecordTypeIdForGiftsTests('Opportunity');
+            ons.Opportunity_Record_Types__c = UTIL_RecordTypes.getrecordTypeIdForGiftsTests(Opportunity.sObjectType);
         insert ons;
 
         Account acc = new Account(Name='accname');
@@ -89,13 +89,13 @@ private class OPP_OpportunityNaming_TEST
             Primary_Contact__c = con.id
         );
         if (hasActiveRecType())
-            opp.RecordTypeId = UTIL_RecordTypes.GetRecordTypeId('Opportunity', UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity'));
+            opp.RecordTypeId = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, UTIL_RecordTypes.getrecordTypeNameForGiftsTests(Opportunity.sObjectType));
         insert opp;
 
         list<Opportunity> queryOpp = [SELECT Name FROM Opportunity WHERE Id = :opp.id];
         string oppName = 'accname conname 2000.01.01';
         if (hasActiveRecType())
-            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
+            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests(Opportunity.sObjectType);
         system.assertEquals(oppName, queryOpp[0].Name, 'The name should be calculated based on the setting.');
 
         acc.Name = 'newname';
@@ -113,7 +113,7 @@ private class OPP_OpportunityNaming_TEST
         queryOpp = [SELECT Name FROM Opportunity WHERE Id = :opp.id];
         oppname = 'newname conname 2000.01.01';
         if (hasActiveRecType())
-            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
+            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests(Opportunity.sObjectType);
         system.assertEquals(oppName, queryOpp[0].Name, 'The name should be recalculated after clicking the button.');
 
     }
@@ -132,7 +132,7 @@ private class OPP_OpportunityNaming_TEST
             Attribution__c = Label.oppNamingBoth
         );
         if (hasActiveRecType())
-            ons.Opportunity_Record_Types__c = UTIL_RecordTypes.getrecordTypeIdForGiftsTests('Opportunity');
+            ons.Opportunity_Record_Types__c = UTIL_RecordTypes.getrecordTypeIdForGiftsTests(Opportunity.sObjectType);
         insert ons;
 
         Account acc = new Account(Name='accname');
@@ -150,14 +150,14 @@ private class OPP_OpportunityNaming_TEST
             npe01__Contact_Id_for_Role__c = con.id
         );
         if (hasActiveRecType())
-            opp.RecordTypeId = UTIL_RecordTypes.GetRecordTypeId('Opportunity', UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity'));
+            opp.RecordTypeId = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, UTIL_RecordTypes.getrecordTypeNameForGiftsTests(Opportunity.sObjectType));
         insert opp;
 
         list<Opportunity> queryOpp = [SELECT Name FROM Opportunity WHERE Id = :opp.id];
 
         string oppname = 'accname';
         if (hasActiveRecType())
-            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
+            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests(Opportunity.sObjectType);
         system.assertEquals(oppname, queryOpp[0].Name, 'The name should be calculated based on the setting; missing fields should be excluded.');
 
     }
@@ -185,7 +185,7 @@ private class OPP_OpportunityNaming_TEST
         ));
 
         if (hasActiveRecType())
-            onsList[1].Opportunity_Record_Types__c = UTIL_RecordTypes.getRecordTypeIdForGiftsTests('Opportunity');
+            onsList[1].Opportunity_Record_Types__c = UTIL_RecordTypes.getRecordTypeIdForGiftsTests(Opportunity.sObjectType);
 
         Contact con = new Contact(LastName='conname', HasOptedOutOfFax=true);
         insert con;
@@ -206,7 +206,7 @@ private class OPP_OpportunityNaming_TEST
             npe01__Contact_Id_for_Role__c = con.id
         );
         if (hasActiveRecType())
-            opp.RecordTypeId = UTIL_RecordTypes.getRecordTypeIdForGiftsTests('Opportunity');
+            opp.RecordTypeId = UTIL_RecordTypes.getRecordTypeIdForGiftsTests(Opportunity.sObjectType);
         listOpp.add(opp);
         insert listOpp;
 
@@ -231,7 +231,7 @@ private class OPP_OpportunityNaming_TEST
 
         string oppname = 'conname true';
         if (hasActiveRecType())
-            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity');
+            oppname += ' ' + UTIL_RecordTypes.getrecordTypeNameForGiftsTests(Opportunity.sObjectType);
 
         system.assertEquals(oppname, queryOpp[0].Name, 'The name should be calculated based on the individual attributed setting.');
 

--- a/src/classes/PMT_PaymentCreator_TEST.cls
+++ b/src/classes/PMT_PaymentCreator_TEST.cls
@@ -254,7 +254,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         if (strTestOnly != '*' && strTestOnly != 'createOppWithRecordTypeExcluded') return;
         
         // see if this org has any record types we can use!
-        Id rtIdGift = UTIL_RecordTypes.getRecordTypeIdForGiftsTests('Opportunity');
+        Id rtIdGift = UTIL_RecordTypes.getRecordTypeIdForGiftsTests(Opportunity.sObjectType);
 
         npe01__Contacts_And_Orgs_Settings__c PaymentsSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
             new npe01__Contacts_And_Orgs_Settings__c(
@@ -649,12 +649,12 @@ private with sharing class PMT_PaymentCreator_TEST {
         Id rtIdGift = null;
         
         //only attempt a recordtype exclusion if we have a record type that isn't default
-        for (string recTypeName : new list<string>{UTIL_RecordTypes.getrecordTypeNameForGiftsTests('Opportunity'),UTIL_RecordTypes.getrecordTypeNameForMembershipTests('Opportunity')}) {
+        for (string recTypeName : new list<string>{UTIL_RecordTypes.getrecordTypeNameForGiftsTests(Opportunity.sObjectType),UTIL_RecordTypes.getrecordTypeNameForMembershipTests(Opportunity.sObjectType)}) {
             if (!string.isBlank(recTypeName) && 
-                UTIL_RecordTypes.isRecordTypeActive('Opportunity', recTypeName) && 
-                !UTIL_RecordTypes.isRecordTypeDefault('Opportunity', recTypeName)) {
+                UTIL_RecordTypes.isRecordTypeActive(Opportunity.sObjectType, recTypeName) && 
+                !UTIL_RecordTypes.isRecordTypeDefault(Opportunity.sObjectType, recTypeName)) {
 
-                rtIdGift = UTIL_RecordTypes.GetRecordTypeId('Opportunity', recTypeName);
+                rtIdGift = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, recTypeName);
                 consSettings.Opp_RecTypes_Excluded_for_Payments__c=rtIdGift;
             }
         }

--- a/src/classes/RLLP_OppRollupBATCH_TEST.cls
+++ b/src/classes/RLLP_OppRollupBATCH_TEST.cls
@@ -69,7 +69,7 @@ private class RLLP_OppRollupBATCH_TEST {
     	setup();
     	
         //The record type is an optional parameter when creating opps
-        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity');
+        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType);
          
         // create & insert contact
         Contact contact = UTIL_UnitTestData_TEST.getContact(); 
@@ -98,7 +98,7 @@ private class RLLP_OppRollupBATCH_TEST {
         setup();
         
         //The record type is an optional parameter when creating opps
-        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity');
+        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType);
          
         // create & insert contact
         Contact contact = UTIL_UnitTestData_TEST.getContact(); 
@@ -133,7 +133,7 @@ private class RLLP_OppRollupBATCH_TEST {
         if (strTestOnly != '*' && strTestOnly != 'testOppSoftCreditRollupBatch') return;
         setup();
         
-        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity');
+        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType);
          
         // create & insert contact
         Contact contact18 = UTIL_UnitTestData_TEST.getContact();
@@ -173,7 +173,7 @@ private class RLLP_OppRollupBATCH_TEST {
         if (strTestOnly != '*' && strTestOnly != 'testOppPartialSoftCreditRollupBatch') return;
         setup();
         
-        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity');
+        String giftRecordTypeNameForTests = UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType);
          
         // create & insert contact
         Contact contact18 = UTIL_UnitTestData_TEST.getContact();

--- a/src/classes/RLLP_OppRollup_TEST.cls
+++ b/src/classes/RLLP_OppRollup_TEST.cls
@@ -52,9 +52,9 @@ public with sharing class RLLP_OppRollup_TEST {
     /** @description The date of January 1st, four years ago */
     static Date dat4YearAgo = Date.newInstance( datToday.year()-4,1,1);
     /** @description Default gift record type for tests. */
-    static String giftRecordTypeIdForTests = UTIL_RecordTypes.getRecordTypeIdForGiftsTests('Opportunity');
+    static String giftRecordTypeIdForTests = UTIL_RecordTypes.getRecordTypeIdForGiftsTests(Opportunity.sObjectType);
     /** @description Default membership record type for tests. */
-    static String membershipRecordTypeIdForTests = UTIL_RecordTypes.getRecordTypeIdForMembershipTests('Opportunity');
+    static String membershipRecordTypeIdForTests = UTIL_RecordTypes.getRecordTypeIdForMembershipTests(Opportunity.sObjectType);
     /** @description List of test contacts. */
     static list<Contact> listConTest;
     /** @description List of test opportunities. */

--- a/src/classes/RLLP_OppRollup_TEST2.cls
+++ b/src/classes/RLLP_OppRollup_TEST2.cls
@@ -40,7 +40,7 @@ public with sharing class RLLP_OppRollup_TEST2 {
     // if you want to run all tests, then use '*'
     private static String strTestOnly = '*';
     
-    static String giftRecordTypeIdForTests = UTIL_RecordTypes.GetRecordTypeId('Opportunity', UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity'));
+    static String giftRecordTypeIdForTests = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType));
     
     /*********************************************************************************************************
     * @description Runs testOpportunityUtilityErrorHandling test method for the One to One account processor.
@@ -358,7 +358,7 @@ public with sharing class RLLP_OppRollup_TEST2 {
         Contact c = new Contact(LastName = 'Lastname', BirthDate = system.today().addDays(-4));
         insert c;
 
-        id rtid = UTIL_RecordTypes.GetRecordTypeId ('Opportunity',UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity'));
+        id rtid = UTIL_RecordTypes.GetRecordTypeId (Opportunity.sObjectType,UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType));
         Opportunity newOpp = New Opportunity (
                 Name = 'Test Opp ',
                 Amount = 100,
@@ -955,7 +955,7 @@ public with sharing class RLLP_OppRollup_TEST2 {
 
         c = database.query(q);
 
-        id rtid = UTIL_RecordTypes.GetRecordTypeId ('Opportunity',UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity'));
+        id rtid = UTIL_RecordTypes.GetRecordTypeId (Opportunity.sObjectType,UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType));
         Opportunity newOpp = New Opportunity (
                 Name = 'Test Opp ',
                 Amount = 100,

--- a/src/classes/RLLP_OppRollup_UTIL.cls
+++ b/src/classes/RLLP_OppRollup_UTIL.cls
@@ -276,7 +276,7 @@ public without sharing class RLLP_OppRollup_UTIL {
     */
     public static boolean areRecordTypesOnOpps(){
         if (recordTypesOnOpps==null){
-            String giftRt = UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity');
+            String giftRt = UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType);
             if (giftRt!=null&&giftRt!=''){
                 recordTypesOnOpps = true;
             } 

--- a/src/classes/STG_Panel.cls
+++ b/src/classes/STG_Panel.cls
@@ -176,7 +176,7 @@ public with sharing virtual class STG_Panel {
             if (listSOContactRecTypes == null) {
                 listSOContactRecTypes = new list<SelectOption>();
                 listSOContactRecTypes.add(new SelectOption('', Label.stgLabelNone));
-                listSOContactRecTypes.addAll(UTIL_RecordTypes.getStringRecordTypesForSelectList('Contact'));            
+                listSOContactRecTypes.addAll(UTIL_RecordTypes.getStringRecordTypesForSelectList(Contact.sObjectType));            
             }       
             return listSOContactRecTypes;
         }
@@ -191,7 +191,7 @@ public with sharing virtual class STG_Panel {
             if (listSOContactRecTypeIds == null) {
                 listSOContactRecTypeIds = new list<SelectOption>();
                 listSOContactRecTypeIds.add(new SelectOption('', Label.stgLabelNone));
-                listSOContactRecTypeIds.addAll(UTIL_RecordTypes.getRecordTypesForSelectList('Contact'));            
+                listSOContactRecTypeIds.addAll(UTIL_RecordTypes.getRecordTypesForSelectList(Contact.sObjectType));            
             }
             return listSOContactRecTypeIds;
         }
@@ -206,7 +206,7 @@ public with sharing virtual class STG_Panel {
             if (listSOAccountRecTypeIds == null) {
                 listSOAccountRecTypeIds = new list<SelectOption>();
                 listSOAccountRecTypeIds.add(new SelectOption('', Label.stgLabelNone));
-                listSOAccountRecTypeIds.addAll(UTIL_RecordTypes.getRecordTypesForSelectList('Account'));            
+                listSOAccountRecTypeIds.addAll(UTIL_RecordTypes.getRecordTypesForSelectList(Account.sObjectType));            
             }       
             return listSOAccountRecTypeIds;
         }
@@ -221,7 +221,7 @@ public with sharing virtual class STG_Panel {
             if (listSOOppRecTypes == null) {
                 listSOOppRecTypes = new list<SelectOption>();
                 listSOOppRecTypes.add(new SelectOption('', Label.stgLabelNone));
-                listSOOppRecTypes.addAll(UTIL_RecordTypes.getStringRecordTypesForSelectList('Opportunity'));            
+                listSOOppRecTypes.addAll(UTIL_RecordTypes.getStringRecordTypesForSelectList(Opportunity.sObjectType));            
             }       
             return listSOOppRecTypes;
         }
@@ -236,7 +236,7 @@ public with sharing virtual class STG_Panel {
             if (listSOOppRecTypesIds == null) {
                 listSOOppRecTypesIds = new list<SelectOption>();
                 listSOOppRecTypesIds.add(new SelectOption('', Label.stgLabelNone));
-                listSOOppRecTypesIds.addAll(UTIL_RecordTypes.getRecordTypesForSelectList('Opportunity'));            
+                listSOOppRecTypesIds.addAll(UTIL_RecordTypes.getRecordTypesForSelectList(Opportunity.sObjectType));            
             }       
             return listSOOppRecTypesIds;
         }
@@ -343,7 +343,7 @@ public with sharing virtual class STG_Panel {
     static public string strHHAccountRecordTypeLabel {
     	get {
     		if (strHHAccountRecordTypeLabel == null) {
-    			strHHAccountRecordTypeLabel = UTIL_RecordTypes.GetRecordTypeName('Account', stgService.stgCon.npe01__HH_Account_RecordTypeID__c);
+    			strHHAccountRecordTypeLabel = UTIL_RecordTypes.GetRecordTypeName(Account.sObjectType, stgService.stgCon.npe01__HH_Account_RecordTypeID__c);
     		}
     		return strHHAccountRecordTypeLabel;
     	}
@@ -356,7 +356,7 @@ public with sharing virtual class STG_Panel {
     static public string strOneToOneRecordTypeLabel {
         get {
             if (strOneToOneRecordTypeLabel == null) {
-                strOneToOneRecordTypeLabel = UTIL_RecordTypes.GetRecordTypeName('Account', stgService.stgCon.npe01__One_to_One_RecordTypeID__c);
+                strOneToOneRecordTypeLabel = UTIL_RecordTypes.GetRecordTypeName(Account.sObjectType, stgService.stgCon.npe01__One_to_One_RecordTypeID__c);
             }
             return strOneToOneRecordTypeLabel;
         }

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -406,21 +406,21 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
     */
     private void verifyRecordTypes() {
     
-        checkRecordTypeId('Account', STG_Panel.stgService.stgCon.npe01__HH_Account_RecordTypeID__c, 
+        checkRecordTypeId(Account.sObjectType, STG_Panel.stgService.stgCon.npe01__HH_Account_RecordTypeID__c, 
             'npe01__Contacts_And_Orgs_Settings__c', 'npe01__HH_Account_RecordTypeID__c', Label.stgNavPeople, Label.stgNavAccountModel);
-        checkRecordTypeId('Account', STG_Panel.stgService.stgCon.npe01__One_to_One_RecordTypeID__c, 
+        checkRecordTypeId(Account.sObjectType, STG_Panel.stgService.stgCon.npe01__One_to_One_RecordTypeID__c, 
             'npe01__Contacts_And_Orgs_Settings__c', 'npe01__One_to_One_RecordTypeID__c', Label.stgNavPeople, Label.stgNavAccountModel);        
-        checkRecordTypeId('Opportunity', STG_Panel.stgService.stgRD.npe03__Record_Type__c, 
+        checkRecordTypeId(Opportunity.sObjectType, STG_Panel.stgService.stgRD.npe03__Record_Type__c, 
             'npe03__Recurring_Donations_Settings__c', 'npe03__Record_Type__c', Label.stgNavRecurringDonations, Label.stgNavRecurringDonations);       
-        checkRecordTypeMulti('Contact', STG_Panel.stgService.stgHH.npo02__Household_Creation_Excluded_Recordtypes__c, true,
+        checkRecordTypeMulti(Contact.sObjectType, STG_Panel.stgService.stgHH.npo02__Household_Creation_Excluded_Recordtypes__c, true,
             'npo02__Households_Settings__c', 'npo02__Household_Creation_Excluded_Recordtypes__c', Label.stgNavPeople, Label.stgNavHouseholds);
-        checkRecordTypeMulti('Contact', STG_Panel.stgService.stgHH.npo02__Household_OCR_Excluded_Recordtypes__c, true,
+        checkRecordTypeMulti(Contact.sObjectType, STG_Panel.stgService.stgHH.npo02__Household_OCR_Excluded_Recordtypes__c, true,
             'npo02__Households_Settings__c', 'npo02__Household_OCR_Excluded_Recordtypes__c', Label.stgNavDonations, Label.stgNavContactRoles);            
-        checkRecordTypeMulti('Opportunity', STG_Panel.stgService.stgHH.npo02__Excluded_Account_Opp_Rectypes__c, true,
+        checkRecordTypeMulti(Opportunity.sObjectType, STG_Panel.stgService.stgHH.npo02__Excluded_Account_Opp_Rectypes__c, true,
             'npo02__Households_Settings__c', 'npo02__Excluded_Account_Opp_Rectypes__c', Label.stgNavDonations, Label.stgNavDonorStatistics);
-        checkRecordTypeMulti('Opportunity', STG_Panel.stgService.stgHH.npo02__Excluded_Contact_Opp_Rectypes__c, true,
+        checkRecordTypeMulti(Opportunity.sObjectType, STG_Panel.stgService.stgHH.npo02__Excluded_Contact_Opp_Rectypes__c, true,
             'npo02__Households_Settings__c', 'npo02__Excluded_Contact_Opp_Rectypes__c', Label.stgNavDonations, Label.stgNavDonorStatistics);
-        checkRecordTypeMulti('Opportunity', STG_Panel.stgService.stgHH.npo02__Membership_Record_Types__c, true,
+        checkRecordTypeMulti(Opportunity.sObjectType, STG_Panel.stgService.stgHH.npo02__Membership_Record_Types__c, true,
             'npo02__Households_Settings__c', 'npo02__Membership_Record_Types__c', Label.stgNavDonations, Label.stgNavMembership);   
             
         // avoid reusing the same recordtype in Account models
@@ -435,7 +435,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
 
     /*********************************************************************************************************
     * @description Checks a setting that contains multiple recordType Id's in a semi-colon delimeted string
-    * @param strObject The Object to check recordtypes against
+    * @param objectType The Object to check recordtypes against
     * @param strValues A semicolon separated string of values to check
     * @param isIds Whether the values are Ids or Names
     * @param strSettingObj The Settings object
@@ -444,14 +444,14 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
     * @param strTabname The tab the setting is on
     * @return void
     */
-    private void checkRecordTypeMulti(string strObject, string strValues, boolean isIds, string strSettingObj, string strSettingField, string strTabLevel, string strTabname) {
+    private void checkRecordTypeMulti(sObjectType objectType, string strValues, boolean isIds, string strSettingObj, string strSettingField, string strTabLevel, string strTabname) {
         if (strValues != null) {
             list<string> listStr = strValues.split(';',0);
             for (string strRT : listStr) {
                 if (isIds)
-                    checkRecordTypeId(strObject, strRT, strSettingObj, strSettingField, strTabLevel, strTabname);
+                    checkRecordTypeId(objectType, strRT, strSettingObj, strSettingField, strTabLevel, strTabname);
                 else
-                    checkRecordTypeName(strObject, strRT, strSettingObj, strSettingField, strTabLevel, strTabname);              
+                    checkRecordTypeName(objectType, strRT, strSettingObj, strSettingField, strTabLevel, strTabname);              
             }
         } else {
             string strField = UTIL_Describe.getFieldLabel(strSettingObj, strSettingField);
@@ -461,7 +461,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
 
     /*********************************************************************************************************
     * @description Checks whether the recordType Id is valid, and logs an appropriate DetectResult
-    * @param strObject The Object to check recordtypes against
+    * @param objectType The Object to check recordtypes against
     * @param rtId A recordtype Id
     * @param strSettingObj The Settings object
     * @param strSettingField The Settings field
@@ -469,9 +469,9 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
     * @param strTabname The tab the setting is on
     * @return void
     */
-    private void checkRecordTypeId(string strObject, string rtId, string strSettingObj, string strSettingField, string strTabLevel, string strTabname) {
+    private void checkRecordTypeId(sObjectType objectType, Id rtId, string strSettingObj, string strSettingField, string strTabLevel, string strTabname) {
         string strField = UTIL_Describe.getFieldLabel(strSettingObj, strSettingField);
-        string strRT = UTIL_RecordTypes.GetRecordTypeName(strObject, rtId);
+        string strRT = UTIL_RecordTypes.GetRecordTypeName(objectType, rtId);
         if (rtId != null && strRT == null) {
             createDR(strField, statusError, 
                 string.format(label.healthDetailsInvalidRecordtypeId, new string[]{rtId}),        
@@ -484,7 +484,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
     
     /*********************************************************************************************************
     * @description Checks whether the recordType Name is valid, and logs an appropriate DetectResult
-    * @param strObject The Object to check recordtypes against
+    * @param objectType The Object to check recordtypes against
     * @param strRTName A recordtype name
     * @param strSettingObj The Settings object
     * @param strSettingField The Settings field
@@ -492,9 +492,9 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
     * @param strTabname The tab the setting is on
     * @return void
     */
-    private void checkRecordTypeName(string strObject, string strRTName, string strSettingObj, string strSettingField, string strTabLevel, string strTabname) {
+    private void checkRecordTypeName(sObjectType objectType, string strRTName, string strSettingObj, string strSettingField, string strTabLevel, string strTabname) {
         string strField = UTIL_Describe.getFieldLabel(strSettingObj, strSettingField);
-        if (strRTName != null && UTIL_RecordTypes.GetRecordTypeId(strObject, strRTName) == null) {
+        if (strRTName != null && UTIL_RecordTypes.GetRecordTypeId(objectType, strRTName) == null) {
             createDR(strField, statusError, 
                 string.format(label.healthDetailsInvalidRecordtypeName, new string[]{strRTName}),        
                 string.format(label.healthSolutionEditSetting, new string[]{strField, strTabLevel, strTabname}));        

--- a/src/classes/STG_PanelRD_CTRL.cls
+++ b/src/classes/STG_PanelRD_CTRL.cls
@@ -154,7 +154,7 @@ public with sharing class STG_PanelRD_CTRL extends STG_Panel {
     static public string strRDOppRecordTypeLabel {
         get {
             if (strRDOppRecordTypeLabel == null) {
-                strRDOppRecordTypeLabel = UTIL_RecordTypes.GetRecordTypeName('Opportunity', STG_Panel.stgService.stgRD.npe03__Record_Type__c);
+                strRDOppRecordTypeLabel = UTIL_RecordTypes.GetRecordTypeName(Opportunity.sObjectType, STG_Panel.stgService.stgRD.npe03__Record_Type__c);
             }
             return strRDOppRecordTypeLabel;
         }

--- a/src/classes/UTIL_RecordTypes.cls
+++ b/src/classes/UTIL_RecordTypes.cls
@@ -1,329 +1,332 @@
-/**
-* @author Evan Callahan
-* @date 2010 
-* @group Utilities
-* @description Provides recordtype wrapper for easy access in other codeblocks 
+/*
+    Copyright (c) 2016 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
 */
-
-public class UTIL_RecordTypes {
-/*-----------------------------------------------------------------------------------------------
-* Written by Evan Callahan, copyright (c) 2010 Groundwire
-* This program is released under the GNU General Public License. http://www.gnu.org/licenses/
-* 
-* This class is meant to allow for access to Record Type information from within other classes.
+/**
+* @author Salesforce.org
+* @date 2016
+* @group Utilities
 *
-* It is called statically, and therefore will supply the same information to all calls made from
-* within one transaction, or Set of trigger calls. This is beneficial because this info should
-* be the same for all calls in a transaction, and by calling it statically we reduce the calls
-* that are made, making the total transaction more efficient
------------------------------------------------------------------------------------------------*/
-    
-    //Maps to hold the record type info
-    private static Map<String, Schema.SObjectType> gd;
-    private static Map<String, Map<Id, Schema.RecordTypeInfo>> recordTypesById = new Map<String, Map<Id, Schema.RecordTypeInfo>>();
-    private static Map<String, Map<String, Schema.RecordTypeInfo>> recordTypesByName = new Map<String, Map<String, Schema.RecordTypeInfo>>();
-    private static List<Schema.Recordtypeinfo> recordTypesList = New List<Schema.Recordtypeinfo>();
-    
-    public static String giftrecordTypeNameForTests;
-    public static Schema.RecordTypeInfo giftRecordTypeInfoForTests;
-    public static String membershiprecordTypeNameForTests;
-    public static Schema.RecordTypeInfo membershipRecordTypeInfoForTests;
-    
-    /*******************************************************************************************************
-    * @description Populates the static properties of the class, that store information about and Object and 
-    *              its Record Types.
-    * @param objectName The name of the Object.
-    * @return void
-    */
-    private static void fillMapsForObject(String objectName) {
-        // get the object map the first time
-        if (gd==null) gd = Schema.getGlobalDescribe();
-        
-        // get the object description
-        if (gd.containsKey(objectName)) {
-            Schema.DescribeSObjectResult d = gd.get(objectName).getDescribe();
-            recordTypesByName.put(objectName, d.getRecordTypeInfosByName());
-            recordTypesById.put(objectName, d.getRecordTypeInfosById());
-            recordTypesList = d.getRecordTypeInfos();
-            for(integer i=recordTypesList.size()-1;i>=0;i--){
-                if(recordTypesList[i].getName()=='Master' || !recordTypesList[i].isAvailable()){
-                    recordTypesList.remove(i);
-                }
-            }
-        }
-    }
-
-    /*******************************************************************************************************
-    * @description Provides the Id of the Record Type with an specific name in an specific Object.
-    * @param objectName The name of the Object.
-    * @param  recordTypeName The name of the Record Type.
-    * @return Id The Id of the Record Type.
-    */
-    public static Id GetRecordTypeId(String objectName, String recordTypeName) {
-        // make sure we have this object's record types Mapped
-        if (!recordTypesByName.containsKey(objectName)) 
-            fillMapsForObject(objectName);
-        
-        // now grab and return the requested id 
-        Map<String, Schema.RecordTypeInfo> rtMap = recordTypesByName.get(objectName);
-        if (rtMap != null && rtMap.containsKey(recordTypeName)) {
-            return rtMap.get(recordTypeName).getRecordTypeId();
-        } else {
-            return null;
-        }
-    }
-
-    /*******************************************************************************************************
-    * @description Determines whether a record type is active for the current profile.
-    * @param objectName The name of the Object.
-    * @param  recordTypeName The name of the Record Type.
-    * @return Boolean Whether this record type is active for the current profile.
-    */
-    public static boolean isRecordTypeActive(string objectName, String recordTypeName) {
-        if (!recordTypesByName.containsKey(objectName)) 
-            fillMapsForObject(objectName);
-
-        Map<String, Schema.RecordTypeInfo> rtMap = recordTypesByName.get(objectName);
-        if (rtMap != null && rtMap.containsKey(recordTypeName)) {
-            return rtMap.get(recordTypeName).isAvailable();
-        } else {
-            return false;
-        }
-    }
-
-    /*******************************************************************************************************
-    * @description Determines whether a record type is default for the current profile.
-    * @param objectName The name of the Object.
-    * @param  recordTypeName The name of the Record Type.
-    * @return Boolean Whether this record type is default for the current profile.
-    */
-    public static boolean isRecordTypeDefault(string objectName, String recordTypeName) {
-        if (!recordTypesByName.containsKey(objectName)) 
-            fillMapsForObject(objectName);
-
-        Map<String, Schema.RecordTypeInfo> rtMap = recordTypesByName.get(objectName);
-        if (rtMap != null && rtMap.containsKey(recordTypeName)) {
-            return rtMap.get(recordTypeName).isDefaultRecordTypeMapping();
-        } else {
-            return false;
-        }
-    }
-
+* @description Methods for obtaining information about record types
+*/
+public class UTIL_RecordTypes {
     /**
-     * @description Provides the RecordTypeInfo of the first Record Type found
-     * in an specific Object, or null if the object does not have any Record
-     * Types.
-     * @param objectName The name of the Object.
-     * @return Schema.RecordTypeInfo
-     */
-    public static Schema.RecordTypeInfo getRecordTypeInfoForGiftsTests(String objectName) {
-        if (giftRecordTypeInfoForTests == null){
-             // make sure we have this object's record types Mapped
-            if (!recordTypesByName.containsKey(objectName)) {
-                fillMapsForObject(objectName);
-            }
-
-            if (recordTypesList.size() > 0) {
-                giftRecordTypeInfoForTests = recordTypesList[0];
-            }
-        }
-
-        return giftRecordTypeInfoForTests;
-    }
-
-    /*******************************************************************************************************
-    * @description Provides the Id of the first Record Type found in an specific Object, or a blank string if the
-    *              Object does not have any Record Types.
-    * @param objectName The name of the Object.
-    * @return String The name of a Record Type that belongs to the specified Object, if at least one exists. Blank 
-    *                string otherwise.
-    */
-    public static String getRecordTypeNameForGiftsTests(String objectName) {
-        Schema.RecordTypeInfo rti = getRecordTypeInfoForGiftsTests(objectName);
-        if (rti == null) {
-            return '';
-        } else {
-            return rti.getName();
-        }
-    }
-
-    /**
-     * @descroption Provides the Id of the first record type found for a
-     * specific object, or null if the object does not have any record types.
+     * @description Get the ids of the record types for the given record type names
      *
-     * @param objectName The name of the object
-     * @return Id
+     * @param objectType The type of the object
+     * @param recordTypeNames The names of the record types
+     * @return Set<Id>
      */
-    public static Id getRecordTypeIdForGiftsTests(String objectName) {
-        Schema.RecordTypeInfo rti = getRecordTypeInfoForGiftsTests(objectName);
-        if (rti == null) {
-            return null;
-        } else {
-            return rti.getRecordTypeId();
-        }
-    }
+    public static Set<Id> getRecordTypeIdSet(sObjectType objectType, Set<String> recordTypeNames) {
+        Map<String, Schema.RecordTypeInfo> recordTypeInfos = objectType.getDescribe().getRecordTypeInfosByName();
 
-    /**
-     * @description Provides the RecordTypeInfo of the first Record Type found
-     * in an specific Object, or null if the object does not have any Record
-     * Types.
-     * @param objectName The name of the Object.
-     * @return Schema.RecordTypeInfo
-     */
-    public static Schema.RecordTypeInfo getRecordTypeInfoForMembershipTests(String objectName) {
-        if (membershipRecordTypeInfoForTests == null){
-             // make sure we have this object's record types Mapped
-            if (!recordTypesByName.containsKey(objectName)) {
-                fillMapsForObject(objectName);
-            }
-
-            if (recordTypesList.size() > 0) {
-                membershipRecordTypeInfoForTests = recordTypesList[0];
-            }
-        }
-
-        return membershipRecordTypeInfoForTests;
-    }
-
-    /*******************************************************************************************************
-    * @description Provides the Id of the first Record Type found in an specific Object, or a blank string if the
-    *              Object does not have any Record Types.
-    * @param objectName The name of the Object.
-    * @return String The name of a Record Type that belongs to the specified Object, if at least one exists. Blank 
-    *                string otherwise.
-    */
-    public static String getRecordTypeNameForMembershipTests(String objectName) {
-        Schema.RecordTypeInfo rti = getRecordTypeInfoForMembershipTests(objectName);
-        if (rti == null) {
-            return '';
-        } else {
-            return rti.getName();
-        }
-    }
-
-    /**
-     * @descroption Provides the Id of the first record type found for a
-     * specific object, or null if the object does not have any record types.
-     *
-     * @param objectName The name of the object
-     * @return Id
-     */
-    public static Id getRecordTypeIdForMembershipTests(String objectName) {
-        Schema.RecordTypeInfo rti = getRecordTypeInfoForMembershipTests(objectName);
-        if (rti == null) {
-            return null;
-        } else {
-            return rti.getRecordTypeId();
-        }
-    }
-
-    /*******************************************************************************************************
-    * @description Provides the name of the Record Type with an specific Id in an specific Object.
-    * @param objectName The name of the Object.
-    * @param  recordTypId The Id of the Record Type.
-    * @return String The name of the Record Type.
-    */
-    public static String GetrecordTypeName(String objectName, String RecordTypeId) {
-    	try {
-	        // make sure we have this object's record types Mapped
-	        if (!recordTypesById.containsKey(objectName)) 
-	            fillMapsForObject(objectName);
-	        
-	        // now grab and return the requested id
-	        Map<Id, Schema.RecordTypeInfo> rtMap = recordTypesById.get(objectName);
-	        if (rtMap != null && rtMap.containsKey(RecordTypeId)) {
-	            return rtMap.get(RecordTypeId).getName();
-	        } else {
-	            return null;
-	        }
-    	} catch(exception ex) {
-	    	return null;
-	    }
-    }
-    
-    /*******************************************************************************************************
-    * @description Provides the Ids of the Record Types with specific names in an specific Object.
-    * @param objectName The name of the Object.
-    * @param  recordTypeNameSet The names of the Record Types.
-    * @return Set<Id> The Ids of the Record Types.
-    */
-    public static Set<Id> GetRecordTypeIdSet(String objectName, Set<String> recordTypeNameSet) {
         Set<Id> recordTypeIds = new Set<Id>();
 
-        // make sure we have this object's record types Mapped
-        if (!recordTypesByName.containsKey(objectName)) 
-            fillMapsForObject(objectName);
-
-        // fill the id Set from the name Set
-        if (recordTypesByName.containsKey(objectName)) { 
-            Map<String, Schema.RecordTypeInfo> rtMap = recordTypesByName.get(objectName);
-            for (String recTypeName : recordTypeNameSet) {
-                if (rtMap.containsKey(recTypeName)) {
-                    recordTypeIds.add(rtMap.get(recTypeName).getRecordTypeId());
-                }
+        for (String recordTypeName : recordTypeNames) {
+            if (recordTypeInfos.containsKey(recordTypeName)) {
+                recordTypeIds.add(
+                    recordTypeInfos.get(recordTypeName).getRecordTypeId()
+                );
             }
         }
+
         return recordTypeIds;
     }
-    
-    /*******************************************************************************************************
-    * @description Provides the names and Ids of all the Record Types with the specified name.
-    * @param objectName The name of the Object.
-    * @return Map<String, Id> The name and Id of each Record Type.
-    */
-    public static Map<String, Id> GetRecordTypeIdMap(String objectName) {
-        Map<String, Id> recordTypeMap = new Map<String, Id>();  
-        // make sure we have this object's record types Mapped
-        if (!recordTypesByName.containsKey(objectName)) 
-            fillMapsForObject(objectName);
 
-        // fill the name to id Map
-        if (recordTypesByName.containsKey(objectName)) { 
-            Map<String, Schema.RecordTypeInfo> rtMap = recordTypesByName.get(objectName);
-            for (recordTypeInfo rti : rtMap.values()) {
-                if (rti.getName() != 'Master')
-                    recordTypeMap.put(rti.getName(), rti.getRecordTypeId());
-            }
+    /**
+     * @description Return the record type info for a record type with the
+     * given name for the given object.  This will return an instance
+     * conforming to the UTIL_RecordTypes.RecordTypeInfo interface, not an
+     * instance of Schema.RecordTypeInfo.  In the case where the record type
+     * does not exist, an UnavailableRecordTypeInfo "null object" will be
+     * returned.
+     *
+     * @param objectType The type of the object
+     * @param The name of the record type
+     * @return UTIL_RecordTypes.RecordTypeInfo
+     */
+    private static RecordTypeInfo getRecordTypeInfo(sObjectType objectType, String recordTypeName) {
+        Map<String, Schema.RecordTypeInfo> recordTypeInfos = objectType.getDescribe().getRecordTypeInfosByName();
+        if (recordTypeInfos.containsKey(recordTypeName)) {
+            return new RecordTypeInfoWrapper(recordTypeInfos.get(recordTypeName));
+        } else {
+            return new UnavailableRecordTypeInfo();
         }
-        
-        return recordTypeMap;
-    }
-    
-    /*******************************************************************************************************
-    * @description Provides the Record Types of an specific Object as a list of Select Options, to be displayed in
-    *              a Visualforce page as a drop-down.
-    * @param objectName The name of the Object.
-    * @return List<SelectOption> The list of Record Types wrapped in a Select Option each.
-    */
-    public static List<SelectOption> getRecordTypesForSelectList(String objectName) {
-        
-        List<SelectOption> recordTypesOptions = new List<SelectOption>();     
-        Map<String, Id> availRecordTypes = getRecordTypeIdMap(objectName);
-        if (!availRecordTypes.isEmpty()) {
-            for (String thisRecordType : availRecordTypes.keySet()) {
-                recordTypesOptions.add(new SelectOption(availRecordTypes.get(thisRecordType), thisRecordType)); 
-            }
-        }
-        return recordTypesOptions;
-    }
-    
-    /*******************************************************************************************************
-    * @description Provides the names of the Record Types of an specific Object as a list of Select Options, to be displayed 
-    *              in a Visualforce page as a drop-down.
-    * @param objectName The name of the Object.
-    * @return List<SelectOption> The list of Record Type names wrapped in a Select Option each.
-    */
-    public static List<SelectOption> getStringRecordTypesForSelectList(String objectName) {
-        
-        List<SelectOption> recordTypesOptions = new List<SelectOption>();
-        Map<String, Id> availRecordTypes = getRecordTypeIdMap(objectName);
-        if (!availRecordTypes.isEmpty()) {
-            for (String thisRecordType : availRecordTypes.keySet()) {
-                recordTypesOptions.add(new SelectOption(thisRecordType, thisRecordType));   
-            }
-        }
-        return recordTypesOptions;
     }
 
 
+    /**
+     * @description Get the id of the given record type name for the given
+     * object type, or null if the record type is not available or does not
+     * exist.
+     *
+     * @param objectType The type of the object
+     * @param recordTypeName The name of the record type
+     * @return Id
+     */
+    public static Id getRecordTypeId(sObjectType objectType, String recordTypeName) {
+        return getRecordTypeInfo(objectType, recordTypeName).getRecordTypeId();
+    }
+
+
+    /**
+     * @description Get the name of the record type for the given record type
+     * id and object type, or null if the record type is not available or does
+     * not exist.
+     *
+     * @param objectType The type of the object
+     * @param recordTypeId The id of the record type
+     * @return String
+     */
+    public static String getRecordTypeName(sObjectType objectType, Id recordTypeId) {
+        Map<Id, Schema.RecordTypeInfo> rtiById = objectType.getDescribe().getRecordTypeInfosById();
+        if (rtiById.containsKey(recordTypeId)) {
+            Schema.RecordTypeInfo rti = rtiById.get(recordTypeId);
+            if (!rti.isMaster() && rti.isAvailable()) {
+                return rti.getName();
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @description Is the given record type name active for the current user?
+     *
+     * @param objectType The type of the object
+     * @param recordTypeName The name of the record type
+     * @return Boolean
+     */
+    public static Boolean isRecordTypeActive(sObjectType objectType, String recordTypeName) {
+        return getRecordTypeInfo(objectType, recordTypeName).isAvailable();
+    }
+
+    /**
+     * @description Is the given record type name the default record type for
+     * the current user?
+     *
+     * @param objectType The type of the object
+     * @param recordTypeName The name of the record type
+     * @return Boolean
+     */
+    public static Boolean isRecordTypeDefault(sObjectType objectType, String recordTypeName) {
+        return getRecordTypeInfo(objectType, recordTypeName).isDefaultRecordTypeMapping();
+    }
+
+    /**
+     * @description Return a record type info appropriate for using in tests,
+     * that belongs to the given object type.  This will return an instance
+     * conforming to the UTIL_RecordTypes.RecordTypeInfo interface, not an
+     * instance of Schema.RecordTypeInfo.  In the case where the record type
+     * does not exist, an UnavailableRecordTypeInfo "null object" will be
+     * returned.
+     *
+     * @param objectType The type of the object
+     * @return UTIL_RecordTypes.RecordTypeInfo
+     */
+    private static RecordTypeInfo getRecordTypeInfoForTests(sObjectType objectType) {
+        List<Schema.RecordTypeInfo> recordTypeInfos = objectType.getDescribe().getRecordTypeInfos();
+        for (Schema.RecordTypeInfo rti : recordTypeInfos) {
+            if (!rti.isMaster() && rti.isAvailable()) {
+                return new RecordTypeInfoWrapper(rti);
+            }
+        }
+        return new UnavailableRecordTypeInfo();
+    }
+
+    /**
+     * @description Return the name of a record type that can be used for
+     * tests, if one exists in the org.  Otherwise, return a blank string.
+     *
+     * @param objectType The type of the object
+     * @return String
+     */
+    public static String getRecordTypeNameForGiftsTests(sObjectType objectType) {
+        return getRecordTypeInfoForTests(objectType).getName();
+    }
+
+    /**
+     * @description Return the id of a record type that can be used for tests,
+     * if one exists in the org.  Otherwise, return null.
+     *
+     * @param objectType The type of the object
+     * @return Id
+     */
+    public static Id getRecordTypeIdForGiftsTests(sObjectType objectType) {
+        return getRecordTypeInfoForTests(objectType).getRecordTypeId();
+    }
+
+    /**
+     * @description Return RecordTypeInfo of a record type that can be used for
+     * tests, if one exists in the org.  Otherwise, return null.
+     *
+     * @param objectType The type of the object
+     * @return Schema.RecordTypeInfo
+     */
+    public static Schema.RecordTypeInfo getRecordTypeInfoForGiftsTests(sObjectType objectType) {
+        return getRecordTypeInfoForTests(objectType).getRecordTypeInfo();
+    }
+
+    /**
+     * @description Return the name of a record type that can be used for
+     * tests, if one exists in the org.  Otherwise, return a blank string.
+     *
+     * @param objectType The type of the object
+     * @return String
+     */
+    public static String getRecordTypeNameForMembershipTests(sObjectType objectType) {
+        return getRecordTypeInfoForTests(objectType).getName();
+    }
+
+    /**
+     * @description Return the id of a record type that can be used for tests,
+     * if one exists in the org.  Otherwise, return null.
+     *
+     * @param objectType The type of the object
+     * @return Id
+     */
+    public static Id getRecordTypeIdForMembershipTests(sObjectType objectType) {
+        return getRecordTypeInfoForTests(objectType).getRecordTypeId();
+    }
+
+    /**
+     * @description Return a list of SelectOptions where the label is the
+     * record type name and the value is the record type id of a record type
+     * that belongs to the given object type.  The 'master' record type is
+     * omitted from this list of options.
+     *
+     * @param objectType The type of the object
+     * @return List<SelectOption>
+     */
+    public static List<SelectOption> getRecordTypesForSelectList(sObjectType objectType) {
+        Map<String, Schema.RecordTypeInfo> recordTypeInfos = objectType.getDescribe().getRecordTypeInfosByName();
+        List<SelectOption> options = new List<SelectOption>();
+        for (String recordTypeName : recordTypeInfos.keySet()) {
+            Schema.RecordTypeInfo rti = recordTypeInfos.get(recordTypeName);
+            options.add(new SelectOption(rti.getRecordTypeId(), recordTypeName));
+        }
+        return options;
+    }
+
+    /**
+     * @description Return a list of SelectOptions where both the value and the
+     * label are the record type name of a record type that belongs to the
+     * given object type.  The 'master' record type is omitted from this list
+     * of options.
+     *
+     * @param objectType The type of the object
+     * @return List<SelectOption>
+     */
+    public static List<SelectOption> getStringRecordTypesForSelectList(sObjectType objectType) {
+        Map<String, Schema.RecordTypeInfo> recordTypeInfos = objectType.getDescribe().getRecordTypeInfosByName();
+        List<SelectOption> options = new List<SelectOption>();
+        for (String recordTypeName : recordTypeInfos.keySet()) {
+            Schema.RecordTypeInfo rti = recordTypeInfos.get(recordTypeName);
+            options.add(new SelectOption(recordTypeName, recordTypeName));
+        }
+        return options;
+    }
+
+    /**
+     * @description This interface replicates all of the methods available from
+     * the Schema.RecordTypeInfo class, intended to be used as a transparent
+     * wrapper around the Schema.RecordTypeInfo class.  Additionally, a method
+     * is available to access the wrapped Schema.RecordTypeInfo instance.
+     */
+    private interface RecordTypeInfo {
+        Schema.RecordTypeInfo getRecordTypeInfo();
+        String getName();
+        Id getRecordTypeId();
+        Boolean isAvailable();
+        Boolean isDefaultRecordTypeMapping();
+        Boolean isMaster();
+    }
+
+    /**
+     * @description This class replicates all of the methods available from
+     * the Schema.RecordTypeInfo class, intended to be used as a transparent
+     * wrapper around the Schema.RecordTypeInfo class.  Additionally, a method
+     * is available to access the wrapped Schema.RecordTypeInfo instance.
+     */
+    private class RecordTypeInfoWrapper implements RecordTypeInfo {
+        private Schema.RecordTypeInfo rti;
+        public RecordTypeInfoWrapper(Schema.RecordTypeInfo rti) {
+            this.rti = rti;
+        }
+        public Schema.RecordTypeInfo getRecordTypeInfo() {
+            return this.rti;
+        }
+        public String getName() {
+            return rti.getName();
+        }
+        public Id getRecordTypeId() {
+            return rti.getRecordTypeId();
+        }
+        public Boolean isAvailable() {
+            return rti.isAvailable();
+        }
+        public Boolean isDefaultRecordTypeMapping() {
+            return rti.isDefaultRecordTypeMapping();
+        }
+        public Boolean isMaster() {
+            return rti.isMaster();
+        }
+    }
+
+    /**
+     * @description This class replicates all of the methods available from the
+     * Schema.RecordTypeInfo class, except it is intended to be used in places
+     * where an actual Schema.RecordTypeInfo instance is not available.  The
+     * methods of this class will return the appropriate null, blank string, or
+     * negative boolean values.  This class is intended to reduce the need to
+     * perform null checks within this utility class, as per the Null Object
+     * pattern.
+     */
+    private class UnavailableRecordTypeInfo implements RecordTypeInfo {
+        public Schema.RecordTypeInfo getRecordTypeInfo() {
+            return null;
+        }
+        public String getName() {
+            return '';
+        }
+        public Id getRecordTypeId() {
+            return null;
+        }
+        public Boolean isAvailable() {
+            return false;
+        }
+        public Boolean isDefaultRecordTypeMapping() {
+            return false;
+        }
+        public Boolean isMaster() {
+            return false;
+        }
+    }
 }

--- a/src/classes/UTIL_RecordTypes.cls-meta.xml
+++ b/src/classes/UTIL_RecordTypes.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>33.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_RecordTypes_API.cls
+++ b/src/classes/UTIL_RecordTypes_API.cls
@@ -44,7 +44,7 @@ global with sharing class UTIL_RecordTypes_API {
     * @return Id The Id of the Record Type.
     */
     global static Id GetRecordTypeId(String objectName, String recordTypeName) {
-        return UTIL_RecordTypes.GetRecordTypeId(objectName, recordTypeName);
+        return UTIL_RecordTypes.GetRecordTypeId(getSObjectTypeForName(objectName), recordTypeName);
     }
     
     /*******************************************************************************************************
@@ -54,7 +54,7 @@ global with sharing class UTIL_RecordTypes_API {
     * @return String The name of the Record Type.
     */
     global static String GetRecordTypeName(String objectName, String recordTypeId) {
-        return UTIL_RecordTypes.GetRecordTypeName(objectName, recordTypeId);
+        return UTIL_RecordTypes.GetRecordTypeName(getSObjectTypeForName(objectName), recordTypeId);
     }
     
     /*******************************************************************************************************
@@ -64,6 +64,10 @@ global with sharing class UTIL_RecordTypes_API {
     * @return Set<Id> The Ids of the Record Types.
     */
 	global static Set<Id> GetRecordTypeIdSet(String objectName, Set<String> recordTypeNameSet) {
-        return UTIL_RecordTypes.GetRecordTypeIdSet(objectName, recordTypeNameSet);
+        return UTIL_RecordTypes.GetRecordTypeIdSet(getSObjectTypeForName(objectName), recordTypeNameSet);
+    }
+
+    private static sObjectType getSObjectTypeForName(String objectName) {
+        return Schema.describeSObjects(new List<String>{objectName}).get(0).getSObjectType();
     }
 }

--- a/src/classes/UTIL_RecordTypes_TEST.cls
+++ b/src/classes/UTIL_RecordTypes_TEST.cls
@@ -40,47 +40,40 @@ private class UTIL_RecordTypes_TEST {
     // TEST
     static testmethod void testRecTypes() {
         // try bogus values
-        Id reallyBogus = UTIL_RecordTypes.GetRecordTypeId('Bogus', 'Bogus');
-        Id bogus = UTIL_RecordTypes.GetRecordTypeId('Opportunity', 'Bogus');
-        bogus = UTIL_RecordTypes.GetRecordTypeId('Contact', 'Bogus');
+        Id bogus = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, 'Bogus');
+        bogus = UTIL_RecordTypes.GetRecordTypeId(Contact.sObjectType, 'Bogus');
         bogus = UTIL_RecordTypes_API.GetRecordTypeId('Campaign', 'Bogus');
         
         // try all the functions
         set<Id> oppRtSet = UTIL_RecordTypes_API.GetRecordTypeIdSet('Opportunity', (new set<string>{'Bogus', 'Master', 'Grant'}));
-        Map<String, Id> oppTypeMap = UTIL_RecordTypes.GetRecordTypeIdMap('Opportunity');
-        List<SelectOption> rtOptions = UTIL_RecordTypes.getRecordTypesForSelectList('Opportunity');
+        List<SelectOption> rtOptions = UTIL_RecordTypes.getRecordTypesForSelectList(Opportunity.sObjectType);
         
         // check against queried rectypes
         list<recordtype> ort = [select id, name from recordtype where isactive=true and sobjecttype='Opportunity' limit 1];
         if (!ort.isEmpty()) {
-            Id rtId = UTIL_RecordTypes.GetRecordTypeId('Opportunity', ort[0].name);
+            Id rtId = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, ort[0].name);
             system.assertEquals(ort[0].id, rtId); 
             String rtName = UTIL_RecordTypes_API.GetRecordTypeName('Opportunity', ort[0].id);
             system.assertEquals(ort[0].name, rtName); 
 
             // the sets above should contain something too
             system.assert(oppRtSet.size() > 0);
-            system.assert(oppTypeMap.size() > 0);
             system.assert(rtOptions.size() > 0);            
         }       
     }
     
     static testMethod void TestRecordTypes() {
 
-        ID idGift = UTIL_RecordTypes.GetRecordTypeId('Opportunity', UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity'));
+        ID idGift = UTIL_RecordTypes.GetRecordTypeId(Opportunity.sObjectType, UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType));
         
-        Set<String> setStr = new Set<String>{UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity')};
-        Set<Id> setId = UTIL_RecordTypes.GetRecordTypeIdSet('Opportunity', setStr);
+        Set<String> setStr = new Set<String>{UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType)};
+        Set<Id> setId = UTIL_RecordTypes.GetRecordTypeIdSet(Opportunity.sObjectType, setStr);
         if(idGift!=null){
             system.Assert(setId.contains(idGift));
         
-            Map<String, Id> mapRCId = UTIL_RecordTypes.GetRecordTypeIdMap('Opportunity');
-        
-            system.AssertEquals(idGift, mapRCId.get(UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity')));       
-            
-            system.AssertEquals(UTIL_RecordTypes.getRecordTypeNameForGiftsTests('Opportunity'), UTIL_RecordTypes.GetRecordTypeName('Opportunity', idGift));        
+            system.AssertEquals(UTIL_RecordTypes.getRecordTypeNameForGiftsTests(Opportunity.sObjectType), UTIL_RecordTypes.GetRecordTypeName(Opportunity.sObjectType, idGift));        
                 
-            List<SelectOption> listSO = UTIL_RecordTypes.getRecordTypesForSelectList('Opportunity');
+            List<SelectOption> listSO = UTIL_RecordTypes.getRecordTypesForSelectList(Opportunity.sObjectType);
             system.Assert(listSO.IsEmpty() == false);       
         }
     }       

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -155,7 +155,7 @@ public class UTIL_UnitTestData_TEST {
     */
 
     public static List<Opportunity> OppsForContactList (List<Contact> Cons, id CampId, string Stage, date Close, double Amt, string rectype, string oppType) {
-        id rtid = UTIL_RecordTypes.GetRecordTypeId ('Opportunity',rectype);
+        id rtid = UTIL_RecordTypes.GetRecordTypeId (Opportunity.sObjectType,rectype);
         return OppsForContactListByRecTypeId(Cons, CampId, Stage, Close, Amt, rtid, oppType);
     }
 
@@ -190,7 +190,7 @@ public class UTIL_UnitTestData_TEST {
     * @description Create an Opportunity for each Contact, using their Account as the Opportunity's Account.
     */
     public static List<Opportunity> OppsForContactWithAccountList (List<Contact> Cons, id CampId, string Stage, date Close, double Amt, string rectype, string oppType) {
-        id rtid = UTIL_RecordTypes.GetRecordTypeId ('Opportunity',rectype);
+        id rtid = UTIL_RecordTypes.GetRecordTypeId (Opportunity.sObjectType,rectype);
         return OppsForContactWithAccountListByRecTypeId(Cons, CampId, Stage, Close, Amt, rtid, oppType);
     }
 
@@ -225,7 +225,7 @@ public class UTIL_UnitTestData_TEST {
     }
 
     public static List<Opportunity> OppsForAccountList (List<Account> listAcc, id CampId, string Stage, date Close, double Amt, string rectype, string oppType) {
-        id rtid = UTIL_RecordTypes.GetRecordTypeId ('Opportunity',rectype);
+        id rtid = UTIL_RecordTypes.GetRecordTypeId (Opportunity.sObjectType,rectype);
         return OppsForAccountListByRecTypeId(listAcc, CampId, Stage, Close, Amt, rtid, oppType);
     }
 


### PR DESCRIPTION
Modify signatures of all UTIL_RecordTypes methods to accept an SObjectType instead of a string.  Modify all calling code to use SObjectType literal instead of string literal to refer to object types.

Also remove any methods not called from external code.

Modify some test classes to remove calls to methods that were being tested but never used by external code (since these methods are no longer needed)