### PR TITLE
Update UTIL_RecordTypes.getRecordTypeName

### DIFF
--- a/src/classes/UTIL_RecordTypes.cls
+++ b/src/classes/UTIL_RecordTypes.cls
@@ -107,11 +107,7 @@ public class UTIL_RecordTypes {
         Map<Id, Schema.RecordTypeInfo> rtiById = objectType.getDescribe().getRecordTypeInfosById();
         if (rtiById.containsKey(recordTypeId)) {
             Schema.RecordTypeInfo rti = rtiById.get(recordTypeId);
-            if (!rti.isMaster() && rti.isAvailable()) {
-                return rti.getName();
-            } else {
-                return null;
-            }
+            return rti.getName();
         } else {
             return null;
         }


### PR DESCRIPTION
UTIL_RecordTypes.getRecordTypeName() was returning null if the running user did not have access to the requested record type.  This was a change in behavior introduced during the UTIL_RecordTypes rewrite.

This changed behavior was causing the UTIL_RecordTypes_TEST tests to fail if run in an org where a custom Opportunity record type was created, but the running user did not have access to that record type. The test would pass if there were either no custom Opportunity record types defined, or if the user running the tests had access to those record types.

This fixes the broken behavior by returning the record type name, regardless of whether the user has access to the requested record type or not.