### PR TITLE
Error logging changes

### DIFF
--- a/src/classes/BDI_DataImport_API.cls
+++ b/src/classes/BDI_DataImport_API.cls
@@ -97,12 +97,16 @@ global with sharing class BDI_DataImport_API {
             return apexJobId;
 
         } catch (Exception ex) {
-            // no reason to log the error if we haven't started the batch,
-            // since it is just a validation error that we are displaying on the page.
-            if(batchRunning)
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.BDI);
-            if(ApexPages.currentPage() != null)
-                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, ex.getMessage()));
+            if (ApexPages.currentPage() != null) {
+                ApexPages.addMessage(new ApexPages.Message(
+                    ApexPages.Severity.ERROR,
+                    ex.getMessage()
+                ));
+            } else {
+                // if we are not in a context where we can notify the user of
+                // this exception, rethrow it
+                throw ex;
+            }
             return null;
         }
     }

--- a/src/classes/ERR_AddError_TEST.cls
+++ b/src/classes/ERR_AddError_TEST.cls
@@ -38,64 +38,7 @@
 @isTest
 public with sharing class ERR_AddError_TEST {
     /*******************************************************************************************************
-    * @description test error handling on a simple dml operation, single error
-    */
-    public testmethod static void simpleDml() {
-        Account acc1 = new Account(Name='testAcc1');
-        Account acc2 = new Account(Name='testAcc2');
-        Account acc3 = new Account(Name='testAcc3');
-        insert new Account[] {acc1, acc2, acc3};
-        
-        Contact contact1 = new Contact(FirstName = 'test1', LastName = 'testerson', AccountId = acc1.Id, Title = 'VP');
-        Contact contact2 = new Contact(FirstName = 'test2', LastName = 'testerson', AccountId = acc2.Id, Title = 'VP');
-        Contact contact3 = new Contact(FirstName = 'test3', LastName = 'testerson', AccountId = acc3.Id, Title = 'VP');
-        Contact[] contacts = new Contact[] {contact1, contact2, contact3};
-        
-        delete acc2;
-        
-        try {
-        	TDTM_TriggerHandler.suppressDebugAssertAfterErrorLogging = true;
-            insert contacts;
-        } catch(DmlException e) {
-            System.assertEquals(1, e.getNumDml());
-            Integer failedRecordIndex = e.getDmlIndex(0); //Position of failed record in original list
-            //The first (and only) error happened in the second record upon which the DML was performed
-            System.assertEquals(1, failedRecordIndex);
-        }
-    }
-    /*******************************************************************************************************
-    * @description test error handling on a simple dml operation, multiple errors
-    */
-    public testmethod static void simpleDmlMultipleErrors() {
-        Account acc1 = new Account(Name='testAcc1');
-        Account acc2 = new Account(Name='testAcc2');
-        Account acc3 = new Account(Name='testAcc3');
-        Account acc4 = new Account(Name='testAcc4');     
-        insert new Account[] {acc1, acc2, acc3, acc4};
-        
-        Contact contact1 = new Contact(FirstName = 'test1', LastName = 'testerson', AccountId = acc1.Id, Title = 'VP');
-        Contact contact2 = new Contact(FirstName = 'test2', LastName = 'testerson', AccountId = acc2.Id, Title = 'VP');
-        Contact contact3 = new Contact(FirstName = 'test3', LastName = 'testerson', AccountId = acc3.Id, Title = 'VP');
-        Contact contact4 = new Contact(FirstName = 'test3', LastName = 'testerson', AccountId = acc4.Id, Title = 'VP');
-        Contact[] contacts = new Contact[] {contact1, contact2, contact3, contact4};
-        
-        delete new Account[] {acc2, acc4};
-        
-        try {
-            TDTM_TriggerHandler.suppressDebugAssertAfterErrorLogging = true;
-            insert contacts;
-        } catch(DmlException e) {
-            System.assertEquals(2, e.getNumDml());
-            Integer failedRecordIndex = e.getDmlIndex(0); //Position of failed record in original list
-            //The first error happened in the second record upon which the DML was performed
-            System.assertEquals(1, failedRecordIndex);
-            Integer failedRecordIndex2 = e.getDmlIndex(1); //Position of failed record in original list
-            //The first error happened in the fourth record upon which the DML was performed
-            System.assertEquals(3, failedRecordIndex2);
-        }
-    }
-    /*******************************************************************************************************
-    * @description test error handling on a database dml operation, verify success and failure results
+    * @description test (lack of) error handling on a database dml operation, verify success and failure results
     */
     public testmethod static void databaseDml() {
     	Error_Settings__c errorSettings = UTIL_CustomSettingsFacade.getErrorSettings();
@@ -118,12 +61,16 @@ public with sharing class ERR_AddError_TEST {
         
         delete new Account[] {acc2, acc4};
         
-        TDTM_TriggerHandler.suppressDebugAssertAfterErrorLogging = true;
         List<Database.Saveresult> results = Database.insert(contacts, false);
         System.assertEquals(4, results.size());
-        System.assertEquals(true, results[0].isSuccess());
+        /* The failure of any of the contacts in the trigger, due to having a
+         * null Account lookup, will cause an unhandled exception and the
+         * entire trigger will be rolled back.  Every record will be marked as
+         * an error with the message corresponding to the unhandled exception.
+         */
+        System.assertEquals(false, results[0].isSuccess());
         System.assertEquals(false, results[1].isSuccess());
-        System.assertEquals(true, results[2].isSuccess());
+        System.assertEquals(false, results[2].isSuccess());
         System.assertEquals(false, results[3].isSuccess());
     }
 }

--- a/src/classes/ERR_AsyncErrors.cls
+++ b/src/classes/ERR_AsyncErrors.cls
@@ -1,0 +1,245 @@
+/*
+    Copyright (c) 2016 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @group ErrorHandling
+* @description A recurring job that will detect errors from asynchronous jobs
+* and log and send notifications for those errors
+*/
+public virtual class ERR_AsyncErrors implements Queueable, UTIL_MasterSchedulableHelper.UTIL_IRecurring {
+    /**
+     * @description Implementation of UTIL_IRecurring.executeReturnStatus() to
+     * be called by UTIL_MasterSchedulableHelper
+     */
+    public Boolean executeReturnStatus() {
+        System.enqueueJob(this);
+        return true;
+    }
+
+    /**
+     * @description Query for un-processed AsyncApexJob records that represent
+     * failed jobs, creates Error__c log records for those jobs, and then sends
+     * notifications for those errors
+     */
+    public void execute(QueueableContext qc) {
+        Error_Settings__c errorSettings = getErrorSettingsOrgDefaults();
+        DateTime lastRun = errorSettings.Async_Error_Check_Last_Run__c;
+
+        // we fetch the *org defaults* custom setting, because we are using the
+        // setting as a global variable to keep track of the last time we
+        // processed errors (to avoid double processing).  If we queried for
+        // the user's copy or profile copy of this setting, then the value
+        // stored back to this setting may not be available to this job the
+        // next time it runs, since it might run as a different user or
+        // profile.
+
+        DateTime now = getCurrentDateTime();
+
+        if (lastRun == null) {
+            lastRun = now.addDays(-1);
+        }
+
+        errorSettings.Async_Error_Check_Last_Run__c = now;
+        upsertErrorSettings(errorSettings);
+
+        // we only want to detect errors for this package's namespace
+        String namespace = getCurrentNamespace();
+
+        List<AsyncApexJobWrapper> asyncJobErrors = getPendingAsyncJobErrors(
+            lastRun,
+            namespace
+        );
+
+        List<Error__c> errors = new List<Error__c>();
+        for (AsyncApexJobWrapper job : asyncJobErrors) {
+            String errorMessage = job.ExtendedStatus;
+            String errorType = '';
+            if (job.JobType == 'Future') {
+                errorType = 'Future method error';
+            }
+            else if (job.JobType == 'ScheduledApex') {
+                errorType = 'Scheduled Apex error';
+            }
+            else if (job.JobType == 'BatchApex') {
+                errorType = 'Batch Apex error';
+            }
+            else if (job.JobType == 'Queueable') {
+                errorType = 'Queueable job error';
+            }
+            DateTime errorDate = job.CompletedDate;
+            String errorContext = '';
+            if (!String.isBlank(job.ApexClassNamespacePrefix)) {
+                errorContext += job.ApexClassNamespacePrefix + '__';
+            }
+            errorContext += job.ApexClassName;
+            if (job.JobType == 'Future') {
+                errorContext += '.' + job.MethodName;
+            }
+
+            errors.add(
+                new Error__c(
+                    Error_Type__c = errorType,
+                    Datetime__c = errorDate,
+                    Full_Message__c = errorMessage,
+                    Context_Type__c = errorContext
+                )
+            );
+        }
+
+        if (!errors.isEmpty()) {
+            insertErrors(errors);
+            sendErrorNotifications();
+        }
+    }
+
+    /**
+     * @description Get the current DateTime
+     */
+    @TestVisible
+    private virtual DateTime getCurrentDateTime() {
+        return DateTime.now();
+    }
+
+    @TestVisible
+    private virtual String getCurrentNamespace() {
+        return UTIL_Namespace.getNamespace();
+    }
+
+    /**
+     * @description Query for the org default custom settings for Error
+     * Settings
+     *
+     * @return Error_Settings__c
+     */
+    @TestVisible
+    private virtual Error_Settings__c getErrorSettingsOrgDefaults() {
+        return Error_Settings__c.getOrgDefaults();
+    }
+
+    /**
+     * @description Save the given Error_Settings__c
+     * @param errorSettings
+     */
+    @TestVisible
+    private virtual void upsertErrorSettings(Error_Settings__c errorSettings) {
+        upsert errorSettings;
+    }
+
+    /**
+     * @description Insert the given list of Error__c objects
+     * @param errors The Error__c objects to insert
+     */
+    @TestVisible
+    private virtual void insertErrors(List<Error__c> errors) {
+        insert errors;
+    }
+
+    /**
+     * @description Initiate the sending of error notifications
+     */
+    @TestVisible
+    private virtual void sendErrorNotifications() {
+        ERR_Notifier.sendErrorNotifications('');
+    }
+
+    /**
+     * @description Get a list of AsyncApexJob records that represent jobs that
+     * have errors, where the jobs were completed at or after the given lastRun
+     * time, and where the associated ApexClass has the given namespace.
+     *
+     * @param lastRun The DateTime when the list of AsyncApexJobs was last queried/processed
+     * @param namespace The namespace of the associated ApexClass of the ApexAsyncJob
+     * @return List<AsyncApexJobWrapper>
+     */
+    @TestVisible
+    private virtual List<AsyncApexJobWrapper> getPendingAsyncJobErrors(DateTime lastRun, String namespace) {
+        List<AsyncApexJobWrapper> asyncJobErrors = new List<AsyncApexJobWrapper>();
+
+        for (AsyncApexJob job : [
+            SELECT
+                CompletedDate,
+                ExtendedStatus,
+                JobItemsProcessed,
+                TotalJobItems,
+                NumberOfErrors,
+                JobType,
+                ApexClass.NamespacePrefix,
+                ApexClass.Name,
+                MethodName
+            FROM AsyncApexJob
+            WHERE ApexClass.NamespacePrefix = :namespace
+            AND JobType IN ('Future', 'ScheduledApex', 'BatchApex', 'Queueable')
+            AND (Status = 'Failed' OR NumberOfErrors > 0)
+            AND CompletedDate >= :lastRun
+        ]) {
+            asyncJobErrors.add(new AsyncApexJobWrapper(job));
+        }
+        return asyncJobErrors;
+    }
+
+    /**
+     * @description A simple wrapper class around the AsyncApexJob object.
+     */
+    @TestVisible
+    private class AsyncApexJobWrapper {
+        public String JobType;
+        public String ApexClassName;
+        public String ApexClassNamespacePrefix;
+        public String MethodName;
+        public DateTime CompletedDate;
+        public String ExtendedStatus;
+        public AsyncApexJobWrapper() {}
+        public AsyncApexJobWrapper(
+            String JobType,
+            String ApexClassName,
+            String ApexClassNamespacePrefix,
+            String MethodName,
+            DateTime CompletedDate,
+            String ExtendedStatus
+        ) {
+            this.JobType = JobType;
+            this.ApexClassName = ApexClassName;
+            this.ApexClassNamespacePrefix = ApexClassNamespacePrefix;
+            this.MethodName = MethodName;
+            this.CompletedDate = CompletedDate;
+            this.ExtendedStatus = ExtendedStatus;
+        }
+        public AsyncApexJobWrapper(AsyncApexJob job) {
+            this(
+                job.JobType,
+                job.ApexClass.Name,
+                job.ApexClass.NamespacePrefix,
+                job.MethodName,
+                job.CompletedDate,
+                job.ExtendedStatus
+            );
+        }
+    }
+}

--- a/src/classes/ERR_AsyncErrors.cls-meta.xml
+++ b/src/classes/ERR_AsyncErrors.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>3</minorNumber>
+        <minorNumber>4</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>5</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ERR_AsyncErrors.cls-meta.xml
+++ b/src/classes/ERR_AsyncErrors.cls-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>3</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>5</minorNumber>
+        <namespace>npo02</namespace>
+    </packageVersions>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ERR_AsyncErrors_TEST.cls
+++ b/src/classes/ERR_AsyncErrors_TEST.cls
@@ -1,0 +1,285 @@
+/*
+    Copyright (c) 2016 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @group ErrorHandling
+* @description Unit tests for ERR_AsyncErrors
+*/
+@isTest
+public class ERR_AsyncErrors_TEST {
+    @isTest
+    private static void testQueryForErrorsInLastDayIfNotPreviouslyRun() {
+        /*
+         * Given that there is no 'last run' date/time stored in custom settings
+         * And the current date/time is 2016-08-29 08:00:00
+         * When I call execute()
+         * Then async job records starting from 2016-08-28 08:00:00 should be queried
+         */
+        AsyncErrorsStub stub = new AsyncErrorsStub();
+
+        stub.currentDateTime = DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0);
+
+        stub.errorSettingsOrgDefaults = new Error_Settings__c(
+            Async_Error_Check_Last_Run__c = null
+        );
+
+        stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>();
+
+        stub.execute(null);
+
+        System.assertEquals(
+            DateTime.newInstanceGmt(2016, 8, 28, 8, 0, 0),
+            stub.pendingAsyncJobErrorsLastRun
+        );
+    }
+
+    @isTest
+    private static void testQueryForErrorsSinceLastRun() {
+        /*
+         * Given that the date/time 2016-08-28 08:00:00 is stored in custom settings as last run time
+         * When I call execute()
+         * Then async job records starting from 2016-08-29 08:00:00 should be queried
+         */
+        AsyncErrorsStub stub = new AsyncErrorsStub();
+
+        stub.currentDateTime = DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0);
+
+        stub.errorSettingsOrgDefaults = new Error_Settings__c(
+            Async_Error_Check_Last_Run__c = DateTime.newInstanceGmt(
+                2016, 8, 29, 8, 0, 0
+            )
+        );
+
+        stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>();
+
+        stub.execute(null);
+
+        System.assertEquals(
+            DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0),
+            stub.pendingAsyncJobErrorsLastRun
+        );
+    }
+
+    @isTest
+    private static void testQueriesForErrorsInCurrentNamespace() {
+        /*
+         * Given that the current namespace is 'npsp'
+         * When I call execute()
+         * Then async job records with namespace 'npsp' should be queried
+         */
+        AsyncErrorsStub stub = new AsyncErrorsStub();
+
+        stub.currentDateTime = DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0);
+
+        stub.errorSettingsOrgDefaults = new Error_Settings__c(
+            Async_Error_Check_Last_Run__c = null
+        );
+
+        stub.currentNamespace = 'npsp';
+
+        stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>();
+
+        stub.execute(null);
+
+        System.assertEquals(
+            'npsp',
+            stub.pendingAsyncJobErrorsNamespace
+        );
+    }
+
+    @isTest
+    private static void testUpdatesLastRunSetting() {
+        /*
+         * Given that the current date/time is 2016-08-29 08:00:00
+         * When I call execute()
+         * Then the 'last run' date/time stored in custom settings should be 2016-08-29 08:00:00
+         */
+        AsyncErrorsStub stub = new AsyncErrorsStub();
+
+        stub.currentDateTime = DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0);
+
+        stub.errorSettingsOrgDefaults = new Error_Settings__c(
+            Async_Error_Check_Last_Run__c = null
+        );
+
+        stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>();
+
+        stub.execute(null);
+
+        System.assertEquals(
+            DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0),
+            stub.upsertedErrorSettings.Async_Error_Check_Last_Run__c
+        );
+    }
+
+    @isTest
+    private static void testInsertsErrors() {
+        /*
+         * Given the following AsyncApexJobWrapper objects are returned from query:
+         *   | JobType       | ApexClassName | ApexClassNamespacePrefix | MethodName | CompletedDate       | ExtendedStatus  |
+         *   | Future        | TestFuture    | npsp                     | callFuture | 2016-08-29 07:00:00 | Future Error    |
+         *   | ScheduledApex | TestScheduled | npsp                     |            | 2016-08-29 07:00:00 | Scheduled Error |
+         *   | BatchApex     | TestBatch     | foo                      |            | 2016-08-29 07:00:00 | BatchApex Error |
+         *   | Queueable     | TestQueueable |                          |            | 2016-08-29 07:00:00 | Queueable Error |
+         * When I call execute()
+         * Then the following Error__c objects should be inserted:
+         *   | Error_Type__c        | Context_Type__c             | DateTime__c         | Full_Message__c |
+         *   | Future method error  | npsp__TestFuture.callFuture | 2016-08-29 07:00:00 | Future Error    |
+         *   | Scheduled Apex error | npsp__TestScheduled         | 2016-08-29 07:00:00 | Scheduled Error |
+         *   | Batch Apex error     | foo__TestBatch              | 2016-08-29 07:00:00 | BatchApex Error |
+         *   | Queueable job error  | TestQueueable               | 2016-08-29 07:00:00 | Queueable Error |
+         */
+        AsyncErrorsStub stub = new AsyncErrorsStub();
+
+        stub.currentDateTime = DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0);
+
+        stub.errorSettingsOrgDefaults = new Error_Settings__c(
+            Async_Error_Check_Last_Run__c = null
+        );
+
+        DateTime errorDateTime = DateTime.newInstanceGmt(2016, 8, 29, 7, 0, 0);
+        stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>{
+            new ERR_AsyncErrors.AsyncApexJobWrapper(
+                'Future', 'TestFuture', 'npsp', 'callFuture', errorDateTime, 'Future Error'
+            ),
+            new ERR_AsyncErrors.AsyncApexJobWrapper(
+                'ScheduledApex', 'TestScheduled', 'npsp', '', errorDateTime, 'Scheduled Error'
+            ),
+            new ERR_AsyncErrors.AsyncApexJobWrapper(
+                'BatchApex', 'TestBatch', 'foo', '', errorDateTime, 'BatchApex Error'
+            ),
+            new ERR_AsyncErrors.AsyncApexJobWrapper(
+                'Queueable', 'TestQueueable', '', '', errorDateTime, 'Queueable Error'
+            )
+        };
+
+        stub.execute(null);
+
+        Set<Error__c> expectedErrors = new Set<Error__c>{
+            new Error__c(
+                Error_Type__c = 'Future method error',
+                Context_Type__c = 'npsp__TestFuture.callFuture',
+                DateTime__c = errorDateTime,
+                Full_Message__c = 'Future Error'
+            ),
+            new Error__c(
+                Error_Type__c = 'Scheduled Apex error',
+                Context_Type__c = 'npsp__TestScheduled',
+                DateTime__c = errorDateTime,
+                Full_Message__c = 'Scheduled Error'
+            ),
+            new Error__c(
+                Error_Type__c = 'Batch Apex error',
+                Context_Type__c = 'foo__TestBatch',
+                DateTime__c = errorDateTime,
+                Full_Message__c = 'BatchApex Error'
+            ),
+            new Error__c(
+                Error_Type__c = 'Queueable job error',
+                Context_Type__c = 'TestQueueable',
+                DateTime__c = errorDateTime,
+                Full_Message__c = 'Queueable Error'
+            )
+        };
+
+        System.assertEquals(
+            expectedErrors,
+            new Set<Error__c>(stub.insertedErrors)
+        );
+    }
+
+    @isTest
+    private static void testSendsNotifications() {
+        /*
+         * Given at least one AsyncApexJob error exists
+         * When I call execute()
+         * Then error notifications should be sent via notifications util
+         */
+        AsyncErrorsStub stub = new AsyncErrorsStub();
+
+        stub.currentDateTime = DateTime.newInstanceGmt(2016, 8, 29, 8, 0, 0);
+
+        stub.errorSettingsOrgDefaults = new Error_Settings__c(
+            Async_Error_Check_Last_Run__c = null
+        );
+
+        DateTime errorDateTime = DateTime.newInstanceGmt(2016, 8, 29, 7, 0, 0);
+        stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>{
+            new ERR_AsyncErrors.AsyncApexJobWrapper(
+                'Future', 'TestFuture', 'npsp', 'callFuture', errorDateTime, 'Future Error'
+            )
+        };
+
+        stub.execute(null);
+
+        System.assert(stub.errorNotificationsSent);
+    }
+
+
+    /**
+     * @description This stub class overrides behavior of ERR_AsyncErrors that
+     * depends on the runtime environment.
+     */
+    private class AsyncErrorsStub extends ERR_AsyncErrors {
+        public DateTime currentDateTime;
+        public String currentNamespace;
+        public Error_Settings__c errorSettingsOrgDefaults;
+        public Error_Settings__c upsertedErrorSettings;
+        public List<Error__c> insertedErrors;
+        public Boolean errorNotificationsSent = false;
+        public DateTime pendingAsyncJobErrorsLastRun;
+        public String pendingAsyncJobErrorsNamespace;
+        public List<ERR_AsyncErrors.AsyncApexJobWrapper> pendingAsyncJobErrors;
+        private override DateTime getCurrentDateTime() {
+            return currentDateTime;
+        }
+        private override String getCurrentNamespace() {
+            return currentNamespace;
+        }
+        private override Error_Settings__c getErrorSettingsOrgDefaults() {
+            return errorSettingsOrgDefaults;
+        }
+        private override void upsertErrorSettings(Error_Settings__c errorSettings) {
+            upsertedErrorSettings = errorSettings;
+        }
+        private override void insertErrors(List<Error__c> errors) {
+            insertedErrors = errors;
+        }
+        private override void sendErrorNotifications() {
+            errorNotificationsSent = true;
+        }
+        private override List<ERR_AsyncErrors.AsyncApexJobWrapper> getPendingAsyncJobErrors(DateTime lastRun, String namespace) {
+            pendingAsyncJobErrorsLastRun = lastRun;
+            pendingAsyncJobErrorsNamespace = namespace;
+            return pendingAsyncJobErrors;
+        }
+    }
+
+}

--- a/src/classes/ERR_AsyncErrors_TEST.cls-meta.xml
+++ b/src/classes/ERR_AsyncErrors_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>3</minorNumber>
+        <minorNumber>4</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>5</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ERR_AsyncErrors_TEST.cls-meta.xml
+++ b/src/classes/ERR_AsyncErrors_TEST.cls-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>3</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>5</minorNumber>
+        <namespace>npo02</namespace>
+    </packageVersions>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ERR_Handler_CTRL_TEST.cls
+++ b/src/classes/ERR_Handler_CTRL_TEST.cls
@@ -36,25 +36,6 @@
 */
 public with sharing class ERR_Handler_CTRL_TEST {
     /*******************************************************************************************************
-    * @description test error handling without a save point
-    */
-    public pageReference withoutManualRollback() {     
-        
-        Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', Title = 'VP1');
-        insert contact1;
-        
-        //I think npe4__Contact__c is missing from the reciprocal relationship that gets automatically created.
-        npe4__Relationship__c[] relationships = new npe4__Relationship__c[]{
-            new npe4__Relationship__c(npe4__contact__c = contact1.id, npe4__Type__c='TestLookupType') };    
-        
-        insert relationships;
-        
-        //No try-catch necessary. The error is found in the processDML method of TDTM_TriggerHandler.
-        //The transaction is rolled back in that same method.
-        
-        return null;
-    }
-    /*******************************************************************************************************
     * @description test error handling with a save point
     */
     public pageReference withManualRollback() {

--- a/src/classes/ERR_Handler_TEST.cls
+++ b/src/classes/ERR_Handler_TEST.cls
@@ -82,53 +82,20 @@ public class ERR_Handler_TEST {
         UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(Error_Notifications_On__c = true, 
             Error_Notifications_To__c = user.Id, Store_Errors_On__c = true));
     }
-    /*******************************************************************************************************
-    * @description test and verify error notifications posted to chatter
-    * We need to use Database.insert because otherwise the code does not go passed the contacts insert operation
-    *     in the test itself. 
-    *     An error record gets inserted just because the name field for accounts was not retrieved. This happens in 
-    *     the second pass of the Database.insert
-    */
+
+    /**
+     * @description Trigger error notification processing by calling
+     * ERR_Handler.processError() and verify that the error was posted to
+     * Chatter.
+     */
     public testmethod static void errorsStoredInDbTdtmCustomConfigPostToChatter() {
     	if (strTestOnly != '*' && strTestOnly != 'errorsStoredInDbTdtmCustomConfigPostToChatter') return;
     	
     	setupWithChatterNotifications();
     	
-    	insert new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
-              Class__c = 'ERR_ParentAccountUpdater_TEST', Load_Order__c = 1, Object__c = 'Contact', 
-              Trigger_Action__c = 'BeforeInsert;');
-    	            
-    	//Create account
-    	Account acc1 = new Account(Name='test1');
-    	Account acc2 = new Account(Name='test2');
-    	Account acc3 = new Account(Name='test3');
-        insert new Account[] {acc1, acc2, acc3};
-        
-        //Create contact
-        Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', AccountId = acc1.Id, Title = 'VP1');
-        Contact contact2 = new Contact(FirstName = 'test', LastName = 'testerson2', AccountId = acc2.Id, Title = 'VP2');
-        Contact contact3 = new Contact(FirstName = 'test', LastName = 'testerson3', AccountId = acc3.Id, Title = 'VP3');
+        StringException testException = new StringException('Test Exception');
+        ERR_Handler.processError(testException, ERR_Handler_API.Context.TDTM);
 
-        //Delete the account to get ERR_ParentAccountUpdater_TEST code to throw an exception
-        delete acc2;
-        
-        Test.startTest();
-	    List<Contact> contacts = new Contact[]{contact1, contact2, contact3};
-	    LIST<database.SaveResult> results = Database.insert(contacts, false);
-        Test.stopTest();
-        
-        //Database.insert will roll everything back if there is an error, and then run again only with the records that
-        //don't produce exceptions
-        System.assertEquals(true, results[0].isSuccess());  
-        System.assertEquals(false, results[1].isSuccess()); 
-        System.assertEquals(true, results[2].isSuccess()); 
-
-        //Verify 2 contacts were properly inserted
-        list<Contact> insertedContacts = [select Id from Contact where Id in :contacts];
-        System.assertEquals(2, insertedContacts.size()); 
-        
-        //Verify error record was created - because the name field for accounts was not retrieved when we try to access
-        //it in line 40 of ERR_ParentAccountUpdater_TEST (in the second pass of the Database.insert operation)
         List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c, Posted_in_Chatter__c from Error__c];
         System.assertEquals(1, errors.size());
         UTIL_Debug.debug('****Errors: ' + JSON.serializePretty(errors));
@@ -144,53 +111,22 @@ public class ERR_Handler_TEST {
         }
     }
     
-    /*******************************************************************************************************
-    * @description test and verify error notifications were emailed
-    * We need to use Database.insert because otherwise the code does not go passed the contacts insert operation
-    *     in the test itself. 
-    *     An error record gets inserted just because the name field for accounts was not retrieved. This happens in 
-    *     the second pass of the Database.insert
-    */
+    /**
+     * @description Trigger error notification processing by calling
+     * ERR_Handler.processError() and verify that the error was emailed
+     */
     public testmethod static void errorsStoredInDbTdtmCustomConfigEmailErrors() {
         if (strTestOnly != '*' && strTestOnly != 'errorsStoredInDbTdtmCustomConfigEmailErrors') return;
         
         setupWithEmailNotifications();
-        
-        insert new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
-              Class__c = 'ERR_ParentAccountUpdater_TEST', Load_Order__c = 1, Object__c = 'Contact', 
-              Trigger_Action__c = 'BeforeInsert;');
-                    
-        //Create account
-        Account acc1 = new Account(Name='test1');
-        Account acc2 = new Account(Name='test2');
-        Account acc3 = new Account(Name='test3');
-        insert new Account[] {acc1, acc2, acc3};
-        
-        //Create contact
-        Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', AccountId = acc1.Id, Title = 'VP1');
-        Contact contact2 = new Contact(FirstName = 'test', LastName = 'testerson2', AccountId = acc2.Id, Title = 'VP2');
-        Contact contact3 = new Contact(FirstName = 'test', LastName = 'testerson3', AccountId = acc3.Id, Title = 'VP3');
 
-        //Delete the account to get ERR_ParentAccountUpdater_TEST code to throw an exception
-        delete acc2;
-        
         Test.startTest();
-        List<Contact> contacts = new Contact[]{contact1, contact2, contact3};
-        LIST<database.SaveResult> results = Database.insert(contacts, false);
-        Test.stopTest();
-        
-        //Database.insert will roll everything back if there is an error, and then run again only with the records that
-        //don't produce exceptions
-        System.assertEquals(true, results[0].isSuccess());  
-        System.assertEquals(false, results[1].isSuccess()); 
-        System.assertEquals(true, results[2].isSuccess()); 
 
-        //Verify 2 contacts were properly inserted
-        list<Contact> insertedContacts = [select Id from Contact where Id in :contacts];
-        System.assertEquals(2, insertedContacts.size()); 
-        
-        //Verify error record was created - because the name field for accounts was not retrieved when we try to access
-        //it in line 40 of ERR_ParentAccountUpdater_TEST (in the second pass of the Database.insert operation)
+        StringException testException = new StringException('Test Exception');
+        ERR_Handler.processError(testException, ERR_Handler_API.Context.TDTM);
+
+        Test.stopTest();
+
         List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c, Email_Sent__c from Error__c];
         System.assertEquals(1, errors.size());
         
@@ -199,155 +135,7 @@ public class ERR_Handler_TEST {
             System.assertEquals(true, error.Email_Sent__c);
         }
     }
-    
-    /*******************************************************************************************************
-    * @description Tests that an error record does not get created, and an error notification isn't sent
-    * when the "disable error handling" setting is on (even if the other two settings are on as well).
-    */
-    public testmethod static void errorHandlingDisabled() {
-        if (strTestOnly != '*' && strTestOnly != 'errorHandlingDisabled') return;
 
-        setupWithEmailNotifications();
-        //Disable error handling. Using the API class just to give it test coverage.
-        Error_Settings__c errorSettings = UTIL_CustomSettings_API.getErrorSettings();
-        errorSettings.Disable_Error_Handling__c = true;
-
-        insert new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
-              Class__c = 'ERR_ParentAccountUpdater_TEST', Load_Order__c = 1, Object__c = 'Contact', 
-              Trigger_Action__c = 'BeforeInsert;');
-                    
-        //Create account
-        Account acc1 = new Account(Name='test1');
-        Account acc2 = new Account(Name='test2');
-        Account acc3 = new Account(Name='test3');
-        insert new Account[] {acc1, acc2, acc3};
-
-        //Create contact
-        Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', AccountId = acc1.Id, Title = 'VP1');
-        Contact contact2 = new Contact(FirstName = 'test', LastName = 'testerson2', AccountId = acc2.Id, Title = 'VP2');
-        Contact contact3 = new Contact(FirstName = 'test', LastName = 'testerson3', AccountId = acc3.Id, Title = 'VP3');
-
-        //Delete the account to get ERR_ParentAccountUpdater_TEST code to throw an exception
-        delete acc2;
-
-        Test.startTest();
-        List<Contact> contacts = new Contact[]{contact1, contact2, contact3};
-        LIST<database.SaveResult> results = Database.insert(contacts, false);
-        Test.stopTest();
-
-        //All the records will be flagged as failure now, since an unhandled exception went out.
-        //(The platform rolls everything back in this case.)
-        System.assertEquals(false, results[0].isSuccess());  
-        System.assertEquals(false, results[1].isSuccess()); 
-        System.assertEquals(false, results[2].isSuccess()); 
-
-        //Verify 2 contacts were properly inserted
-        list<Contact> insertedContacts = [select Id from Contact where Id in :contacts];
-        System.assertEquals(0, insertedContacts.size()); 
-
-        //Verify no error record was created
-        List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c, Email_Sent__c from Error__c];
-        System.assertEquals(0, errors.size());
-
-        //Verify error was emailed
-        for(Error__c error : errors) {
-            System.assertEquals(false, error.Email_Sent__c);
-        }
-    }
-    /*******************************************************************************************************
-    * @description Test to prove that there are different types of null pointer exceptions. In this case the
-    * account name is always available. The error does not get stored because the second time that 
-    * Database.insert runs there are no errors.
-    */
-    public testmethod static void errorsStoredInDbTdtmCustomConfig2() {
-        if (strTestOnly != '*' && strTestOnly != 'errorsStoredInDbTdtmCustomConfig') return;
-        
-        setupWithChatterNotifications();
-        
-        insert new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
-              Class__c = 'ERR_ParentAccountUpdater2_TEST', Load_Order__c = 1, Object__c = 'Contact', 
-              Trigger_Action__c = 'BeforeInsert;');
-                    
-        //Create account
-        Account acc1 = new Account(Name='test1');
-        Account acc2 = new Account(Name='test2');
-        Account acc3 = new Account(Name='test3');
-        insert new Account[] {acc1, acc2, acc3};
-        
-        //Create contact
-        Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', AccountId = acc1.Id, Title = 'VP1');
-        Contact contact2 = new Contact(FirstName = 'test', LastName = 'testerson2', AccountId = acc2.Id, Title = 'VP2');
-        Contact contact3 = new Contact(FirstName = 'test', LastName = 'testerson3', AccountId = acc3.Id, Title = 'VP3');
-
-        //Delete the account to get ERR_ParentAccountUpdater_TEST code to throw an exception
-        delete acc2;
-        
-        Test.startTest();
-        List<Contact> contacts = new Contact[]{contact1, contact2, contact3};
-        LIST<database.SaveResult> results = Database.insert(contacts, false);
-        Test.stopTest();
-        
-        //Database.insert will roll everything back if there is an error, and then run again only with the records that
-        //don't produce exceptions
-        System.assertEquals(true, results[0].isSuccess());  
-        System.assertEquals(false, results[1].isSuccess()); 
-        System.assertEquals(true, results[2].isSuccess());
-
-        //Verify 2 contacts were properly inserted
-        list<Contact> insertedContacts = [select Id from Contact where Id in :contacts];
-        System.assertEquals(2, insertedContacts.size()); 
-        
-        //Verify no error record was created
-        List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c from Error__c];
-        System.assertEquals(0, errors.size()); 
-    }
-    /*******************************************************************************************************
-    * @description Test using the default configuration of classes that implement TDTM_Runnable
-    */
-    public testmethod static void errorStoredInDbTdtmStandardConfig() {
-    	if (strTestOnly != '*' && strTestOnly != 'errorStoredInDbTdtmStandardConfig') return;
-    
-        setupWithChatterNotifications();
-        
-        UTIL_CustomSettingsFacade.getAffiliationsSettingsForTests(
-            new npe5__Affiliations_Settings__c(npe5__Automatic_Affiliation_Creation_Turned_On__c = true));
-                    
-        //Create account
-        Account acc1 = new Account(Name='test1');
-        Account acc2 = new Account(Name='test2');
-        Account acc3 = new Account(Name='test3');
-        insert new Account[] {acc1, acc2, acc3};
-        
-        //Create contact
-        Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', AccountId = acc1.Id, Title = 'VP1');
-        Contact contact2 = new Contact(FirstName = 'test', LastName = 'testerson2', AccountId = acc2.Id, Title = 'VP2');
-        Contact contact3 = new Contact(FirstName = 'test', LastName = 'testerson3', AccountId = acc3.Id, Title = 'VP3');
-
-        //Delete the account to get the affiliations code to throw an exception
-        delete acc2;
-        
-        Test.startTest();
-        List<Contact> contacts = new Contact[]{contact1, contact2, contact3};
-        LIST<database.SaveResult> results = Database.insert(contacts, false);
-        Test.stopTest();
-        
-        //Database.insert will roll everything back if there is an error, and then run again only with the records that
-        //don't produce exceptions
-        System.assertEquals(true, results[0].isSuccess());  
-        System.assertEquals(false, results[1].isSuccess()); 
-        System.assertEquals(true, results[2].isSuccess()); 
-
-        //Verify 2 contacts were properly inserted
-        list<Contact> insertedContacts = [select Id from Contact where Id in :contacts];
-        System.assertEquals(2, insertedContacts.size()); 
-        
-        //Verify error record was created -> Nope. Since we are using Database insert the operation
-        //gets rolled back and then run again only with records that succeed. No error is saved.
-        //**Note that we have not created a Trigger_Handler__c record with the test class that would throw an exception**
-        List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c from Error__c];
-        UTIL_Debug.debug('****ERROR: ' + JSON.serializePretty(errors));
-        System.assertEquals(0, errors.size());                                    
-    }
     /*******************************************************************************************************
     * @description This is the same test called testErrorRecordCreation in the REL_Relationships_TEST class,
     * but using simple insert instead of Database.insert
@@ -420,42 +208,13 @@ public class ERR_Handler_TEST {
         UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(Error_Notifications_On__c = true, 
             Error_Notifications_To__c = u.Id, Store_Errors_On__c = true));
  
-        insert new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
-              Class__c = 'ERR_ParentAccountUpdater_TEST', Load_Order__c = 1, Object__c = 'Contact', 
-              Trigger_Action__c = 'BeforeInsert;');
-
-        //Create account
-        Account acc1 = new Account(Name='test1');
-        Account acc2 = new Account(Name='test2');
-        Account acc3 = new Account(Name='test3');
-        insert new Account[] {acc1, acc2, acc3};
-
-        //Create contact
-        Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', AccountId = acc1.Id, Title = 'VP1');
-        Contact contact2 = new Contact(FirstName = 'test', LastName = 'testerson2', AccountId = acc2.Id, Title = 'VP2');
-        Contact contact3 = new Contact(FirstName = 'test', LastName = 'testerson3', AccountId = acc3.Id, Title = 'VP3');
-
-        //Delete the account to get ERR_ParentAccountUpdater_TEST code to throw an exception
-        delete acc2;
-
         Test.startTest();
-        TDTM_TriggerHandler.suppressDebugAssertAfterErrorLogging = true;        
-        List<Contact> contacts = new Contact[]{contact1, contact2, contact3};
-        LIST<database.SaveResult> results = Database.insert(contacts, false);
+
+        StringException testException = new StringException('Test Exception');
+        ERR_Handler.processError(testException, ERR_Handler_API.Context.TDTM);
+
         Test.stopTest();
 
-        //Database.insert will roll everything back if there is an error, and then run again only with the records that
-        //don't produce exceptions
-        System.assertEquals(true, results[0].isSuccess());  
-        System.assertEquals(false, results[1].isSuccess()); 
-        System.assertEquals(true, results[2].isSuccess()); 
-
-        //Verify 2 contacts were properly inserted
-        list<Contact> insertedContacts = [select Id from Contact where Id in :contacts];
-        System.assertEquals(2, insertedContacts.size()); 
-
-        //Verify error record was created - because the name field for accounts was not retrieved when we try to access
-        //it in line 40 of ERR_ParentAccountUpdater_TEST (in the second pass of the Database.insert operation)
         List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c, Email_Sent__c from Error__c];
         System.assertEquals(1, errors.size());
 

--- a/src/classes/ERR_Handler_TEST.cls
+++ b/src/classes/ERR_Handler_TEST.cls
@@ -382,31 +382,7 @@ public class ERR_Handler_TEST {
         //assert no additional error record was created on update
         system.assertEquals(1, [select count() from Error__c]);
     }
-    
-    /*******************************************************************************************************
-    * @description Testing that DML that occurs before an exception is thrown and caught does not get 
-    * automatically rolled back 
-    */
-    static testMethod void controllerWithoutManualRollback() {
-        if (strTestOnly != '*' && strTestOnly != 'controllerWithoutManualRollback') return;
-        
-        setupWithChatterNotifications();
-        
-        ERR_Handler_CTRL_TEST controller = new ERR_Handler_CTRL_TEST();
-        
-        Test.startTest();
-        controller.withoutManualRollback();
-        Test.stopTest();
-        
-        //assert contact record creation was not automatically rolled back
-         system.assertEquals(1, [select count() from Contact]);
-        
-        //assert relationship record was stored (but the additional relationship was not created)
-         system.assertEquals(1, [select count() from npe4__Relationship__c]);
-         
-        //assert an error record was created - Required fields are missing: [npe4__Contact__c]
-        system.assertEquals(1, [select count() from Error__c]);  
-    }
+
     /*******************************************************************************************************
     * @description Testing that DML changes are properly rolled back in a controller that adheres to our
     * error-handling design, and that the error is properly stored.

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -52,13 +52,8 @@ public without sharing class HH_HouseholdNaming {
         //this is b/c of the public visibility
         HH_HouseholdNaming hn = new HH_HouseholdNaming();
 
-        Savepoint sp = Database.setSavepoint();
-        try {
-            hn.UpdateNames(hhids);
-        } catch(Exception e) {
-        	Database.rollback(sp);
-        	ERR_Handler.processError(e, ERR_Handler_API.Context.HH);
-        }      
+        hn.UpdateNames(hhids);
+
         HH_ProcessControl.inFutureContext = false;    
     }
 

--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -149,14 +149,8 @@ public class RD_RecurringDonations {
     */ 
     @future
     public static void updateRecurringDonationOnOppChangeFuture(set<id> RDids){
-        Savepoint sp = Database.setSavepoint();
-        try {
-            updateRecurringDonationOnOppChange(RDids, null);
-        } catch(Exception e) {
-        	Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.RD);
-        }
-    } 
+        updateRecurringDonationOnOppChange(RDids, null);
+    }
     
     /*******************************************************************************************************
     * @description Updates the specified RD's by querying their Opps so it can update the RD's 
@@ -306,16 +300,10 @@ public class RD_RecurringDonations {
     */ 
     @future
     public static void insertOppsOnRecurringDonationInsertFuture(set<id> recids) {
-        Savepoint sp = Database.setSavepoint();
-        try {
-	        delete [select id from Opportunity where isClosed = false and npe03__Recurring_Donation__r.id IN :recids];
-	
-	        list<npe03__Recurring_Donation__c> reclist = requeryListRD(recids);
-	        insertOppsOnRecurringDonationInsert(reclist);
-        } catch(Exception e) {
-        	Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.RD);
-        }
+        delete [select id from Opportunity where isClosed = false and npe03__Recurring_Donation__r.id IN :recids];
+
+        list<npe03__Recurring_Donation__c> reclist = requeryListRD(recids);
+        insertOppsOnRecurringDonationInsert(reclist);
     }
     
     /*******************************************************************************************************
@@ -638,13 +626,7 @@ public class RD_RecurringDonations {
     */ 
     @future 
     public static void oppContactRolesFuture(set<id> oppIds){
-    	Savepoint sp = Database.setSavepoint();
-    	try {
-    	   oppContactRoles(oppIds);
-    	} catch(Exception e) {
-    	   Database.rollback(sp);
-           ERR_Handler.processError(e, ERR_Handler_API.Context.RD);
-        }
+       oppContactRoles(oppIds);
     }
     
     /*******************************************************************************************************
@@ -706,13 +688,7 @@ public class RD_RecurringDonations {
     */ 
     @future
     public static void updateExistingOppsFuture(set<id>recIDs){
-    	Savepoint sp = Database.setSavepoint();
-    	try {
-    	   updateExistingOpps(recIDs, null);
-    	} catch(Exception e) {
-    	   Database.rollback(sp);
-           ERR_Handler.processError(e, ERR_Handler_API.Context.RD);
-        }
+       updateExistingOpps(recIDs, null);
     }
     
     /*******************************************************************************************************

--- a/src/classes/RD_RecurringDonations_BATCH.cls
+++ b/src/classes/RD_RecurringDonations_BATCH.cls
@@ -33,7 +33,7 @@
 * @group Recurring Donations
 * @description Class provides a batchable wrapper for open ended recurring donations
 */
-public without sharing class RD_RecurringDonations_BATCH implements Database.Batchable<sObject>, Database.Stateful, 
+public without sharing class RD_RecurringDonations_BATCH implements Database.Batchable<sObject>, Database.Stateful,
 UTIL_MasterSchedulableHelper.UTIL_IRecurring {
 	
     /*******************************************************************************************************
@@ -78,6 +78,9 @@ UTIL_MasterSchedulableHelper.UTIL_IRecurring {
     * @return database.Querylocator  
     */
     public database.Querylocator start(Database.BatchableContext bc) {
+        // this must return a QueryLocator, or else uncaught exceptions in the
+        // execute() method will not properly update the processed/failure
+        // counts (see W-2443023).
         return Database.getQueryLocator(query);      
     }
     
@@ -88,15 +91,9 @@ UTIL_MasterSchedulableHelper.UTIL_IRecurring {
     * @return void  
     */
     public void execute(Database.BatchableContext bc, Sobject[] result) {
-    	Savepoint sp = Database.setSavepoint();
-        try {
-	        RD_ProcessControl.batchButton = true;
-	        recCount += result.size();
-	        failuresCount = RD_RecurringDonations.evaluateRecurringDonationsForNewOppInsert(result);
-	    } catch(Exception e) {
-            Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.RD);
-        }    
+        RD_ProcessControl.batchButton = true;
+        recCount += result.size();
+        failuresCount = RD_RecurringDonations.evaluateRecurringDonationsForNewOppInsert(result);
     }
 
     /*******************************************************************************************************
@@ -115,9 +112,6 @@ UTIL_MasterSchedulableHelper.UTIL_IRecurring {
         rds.npe03__Number_of_Failures__c = failuresCount;
         if (!Test.isRunningTest())
             upsert rds;                            
-        
-        //if needed, send error notifications
-        ERR_Notifier.sendErrorNotifications(ERR_Handler_API.Context.RD.name());        
     }
     
     

--- a/src/classes/REL_Utils.cls
+++ b/src/classes/REL_Utils.cls
@@ -85,11 +85,7 @@ public with sharing class REL_Utils {
         // we are not attempting to handle fields with a newline inside of them
         // so, split on newline to get the spreadsheet rows
         List<String> lines = new List<String>();
-        try {
-            lines = contents.split('\n');
-        } catch (System.ListException e) {
-            UTIL_Debug.debug('Limits exceeded?' + e.getMessage());
-        }
+        lines = contents.split('\n');
         Integer num = 0;
         for(String line : lines) {
             // check for blank CSV lines (only commas)

--- a/src/classes/RLLP_OppRollup.cls
+++ b/src/classes/RLLP_OppRollup.cls
@@ -118,13 +118,7 @@ public without sharing class RLLP_OppRollup {
     ********************************************************************************************************/
     @future 
     public static void rollupContactsandHouseholdsForTriggerFuture(set<id> OppIds) {
-    	Savepoint sp = Database.setSavepoint();
-        try {
-            rollupContactsandHouseholdsForTrigger(OppIds);
-        } catch(Exception e) {
-            Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.RLLP);
-        }
+        rollupContactsandHouseholdsForTrigger(OppIds);
     }
 
     /*******************************************************************************************************
@@ -166,22 +160,15 @@ public without sharing class RLLP_OppRollup {
     ********************************************************************************************************/
     @future 
     public static void rollupAccountsFuture( set<id> acctIds ) {
-        Savepoint sp = Database.setSavepoint();
-        try {
-	        if (acctIds != null && !acctIds.isEmpty()) {
-	        	RLLP_OppRollup_UTIL oppRollupUtil = new RLLP_OppRollup_UTIL();
-	            map<id, Account> amap = new map<id, account>((list<Account>)Database.query(oppRollupUtil.buildAccountQuery() + 
-	                                                           ' where id IN :acctIds')); 
-	            RLLP_OppRollup rg = new RLLP_OppRollup();
-	            rg.rollupAccounts(amap);
-	           
-	        }
-        } catch(Exception e) {
-            Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.RLLP);
+        if (acctIds != null && !acctIds.isEmpty()) {
+            RLLP_OppRollup_UTIL oppRollupUtil = new RLLP_OppRollup_UTIL();
+            map<id, Account> amap = new map<id, account>((list<Account>)Database.query(oppRollupUtil.buildAccountQuery() + 
+                                                           ' where id IN :acctIds')); 
+            RLLP_OppRollup rg = new RLLP_OppRollup();
+            rg.rollupAccounts(amap);
         }
     }
-    
+
     /*******************************************************************************************************
     * @description Future wrapper method for updating contact rollups from a set of contact IDs.
     * @param acctIds A set of contact ids.
@@ -189,19 +176,13 @@ public without sharing class RLLP_OppRollup {
     ********************************************************************************************************/
     @future
     public static void rollupContactsFuture (set<id> conIDs){
-        Savepoint sp = Database.setSavepoint();
-        try {
-	        if (conIds != null && !conIDs.isEmpty()){
-	        	RLLP_OppRollup_UTIL oppRollupUtil = new RLLP_OppRollup_UTIL();
-	            map<id, Contact> cmap = new map<id, Contact>((list<Contact>)Database.query(oppRollupUtil.buildContactQuery() +
-	                                                          ' where id IN :conIds'));
-	            RLLP_OppRollup rg = new RLLP_OppRollup();
-	            rg.rollupContacts(cmap);
-	        }
-	    } catch(Exception e) {
-            Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.RLLP);
-        }     
+        if (conIds != null && !conIDs.isEmpty()){
+            RLLP_OppRollup_UTIL oppRollupUtil = new RLLP_OppRollup_UTIL();
+            map<id, Contact> cmap = new map<id, Contact>((list<Contact>)Database.query(oppRollupUtil.buildContactQuery() +
+                                                          ' where id IN :conIds'));
+            RLLP_OppRollup rg = new RLLP_OppRollup();
+            rg.rollupContacts(cmap);
+        }
     }
 
     /*******************************************************************************************************
@@ -211,20 +192,14 @@ public without sharing class RLLP_OppRollup {
     ********************************************************************************************************/
     @future
     public static void rollupHouseholdsFuture (set<id> hhIDs){
-    	Savepoint sp = Database.setSavepoint();
-        try {
-	        if (hhIds != null && !hhIds.isEmpty()){
-	        	RLLP_OppRollup_UTIL oppRollupUtil = new RLLP_OppRollup_UTIL();
-	            map<id, npo02__Household__c> hhmap = new map<id, npo02__Household__c>((list<npo02__Household__c>)Database.query(oppRollupUtil.buildHouseholdQuery() +
-	                                                                            ' where id IN :hhIDs'));
-	            RLLP_OppRollup rg = new RLLP_OppRollup();
-	            rg.rollupHouseholds(hhmap);                                                                         
-	        }
-	    } catch(Exception e) {
-            Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.RLLP);
-        }       
-    } 
+        if (hhIds != null && !hhIds.isEmpty()){
+            RLLP_OppRollup_UTIL oppRollupUtil = new RLLP_OppRollup_UTIL();
+            map<id, npo02__Household__c> hhmap = new map<id, npo02__Household__c>((list<npo02__Household__c>)Database.query(oppRollupUtil.buildHouseholdQuery() +
+                                                                            ' where id IN :hhIDs'));
+            RLLP_OppRollup rg = new RLLP_OppRollup();
+            rg.rollupHouseholds(hhmap);
+        }
+    }
 
     /*******************************************************************************************************
     * @description Runs opportunity rollups for accounts.

--- a/src/classes/STG_Panel.cls
+++ b/src/classes/STG_Panel.cls
@@ -386,9 +386,9 @@ public with sharing virtual class STG_Panel {
         for (String recordTypeIdString : recordTypeIdStrings) {
             Id recordTypeId;
 
-            try {
+            if (recordTypeIdString instanceof Id) {
                 recordTypeId = (Id) recordTypeIdString;
-            } catch (Exception e) {
+            } else {
                 continue;
             }
 

--- a/src/classes/STG_PanelADDRVerification_CTRL.cls
+++ b/src/classes/STG_PanelADDRVerification_CTRL.cls
@@ -204,12 +204,18 @@ public with sharing class STG_PanelADDRVerification_CTRL extends STG_Panel {
                         servicesURLMap.put(((ADDR_IValidator)classInstance).getServiceName(), ((ADDR_IValidator)classInstance).getDefaultURL());
                     }
                 } catch(exception ex) {
-                    // just ignore this class and continue.
+                    ApexPages.addMessage(new ApexPages.Message(
+                        ApexPages.Severity.ERROR,
+                        String.format(
+                            Label.Addr_Verification_Cant_Load_Class,
+                            new List<String>{classType.getName()}
+                        )
+                    ));
                 }
             }
-        }         
+        }
     }
-    
+
     /*******************************************************************************************************
     * @description Saves the address verification settings.
     * @return PageReference The page to redirect to. None, in this case.

--- a/src/classes/STG_PanelRDCustomFieldMapping_CTRL.cls
+++ b/src/classes/STG_PanelRDCustomFieldMapping_CTRL.cls
@@ -186,13 +186,13 @@ public with sharing class STG_PanelRDCustomFieldMapping_CTRL extends STG_Panel {
     * @return string
     */
     private string getFieldLabel(string strObj, string strField) {
-        try {
-            return UTIL_Describe.getFieldLabel(strObj, strField);                   
-        } catch (Exception e) {
+        if (UTIL_Describe.isValidField(strObj, strField)) {
+            return UTIL_Describe.getFieldLabel(strObj, strField);
+        } else {
             return strField;
-        }       
+        }
     }
-        
+
     /*********************************************************************************************************
     * @description Set of invalid fields for opp mappings
     */

--- a/src/classes/STG_PanelRel_CTRL.cls
+++ b/src/classes/STG_PanelRel_CTRL.cls
@@ -80,11 +80,11 @@ public with sharing class STG_PanelRel_CTRL extends STG_Panel {
     * @return string
     */
     private string getFieldLabel(string strObj, string strField) {
-        try {
-            return UTIL_Describe.getFieldLabel(strObj, strField);                   
-        } catch (Exception e) {
+        if (UTIL_Describe.isValidField(strObj, strField)) {
+            return UTIL_Describe.getFieldLabel(strObj, strField);
+        } else {
             return strField;
-        }       
+        }
     }
         
     

--- a/src/classes/TDTM_TriggerHandler.cls
+++ b/src/classes/TDTM_TriggerHandler.cls
@@ -67,80 +67,52 @@ public class TDTM_TriggerHandler {
            return;
         }
 
-        if(newList != null)
-    	   UTIL_Debug.debug(LoggingLevel.WARN, '****Trigger.new size: ' + newList.size());
-    	// This solves the problem of not being able to save error records if everything gets rolled back. 
-        // TDTM_TriggerHandler is taking care of saving error records if there is any error when performing 
-        // DML operations. It also takes care of rolling everything back in that case, just so there are no 
-        // issues (side effects) with re-entrant flags.
-    	Savepoint sp = Database.setSavepoint();
-    	
-    	try {
-    		TDTM_Runnable.Action thisAction = TDTM_TriggerActionHelper.determineTriggerAction(isBefore, 
-    		                                              isAfter, isInsert, isUpdate, isDelete, isUnDelete);
-            UTIL_Debug.debugWithInfo('****ACTION: ' + thisAction + ' on ' + describeObj.getLabel());
-        
-	        TDTM_Runnable.DmlWrapper dmlWrapper = new TDTM_Runnable.DmlWrapper();
-	        
-	        // If there are no records, insert the defaults.
-	        if(!defaultRecordsInserted && dao.isEmpty()) {
-	        	List<Trigger_Handler__c> defaultConfig = TDTM_DefaultConfig.getDefaultRecords();
-	        	insert defaultConfig;
-	        	defaultRecordsInserted = true;
-	        }
-	        
-	        // Get the classes to run. Note that we are using the local object name, so it works for objects 
-	        // from Cumulus both in the package and unmanaged dev orgs.
-	        List<SObject> classesToCall = dao.getclassesToCallForObject(describeObj.getLocalName(), thisAction);
-	        UTIL_Debug.debug(LoggingLevel.WARN, '****Classes To Call for ' + describeObj.getLocalName() + ': ' + JSON.serializePretty(classesToCall));
-	        
-	        if(classesToCall != null && classesToCall.size() > 0) {
-	            //Run the relevant classes
-	            for (SObject classToCall : classesToCall) {
-	                TDTM_Runnable.DmlWrapper dmlWrapperLocal = new TDTM_Runnable.DmlWrapper();
-	                dmlWrapperLocal = runClass(classToCall, newList, OldList, thisAction, describeObj);
-	                if(dmlWrapperLocal != null) {
-	                	if(dmlWrapperLocal.objectsToInsert != null && !dmlWrapperLocal.objectsToInsert.isEmpty())
-	                        dmlWrapper.objectsToInsert.addAll(dmlWrapperLocal.objectsToInsert);
-	                    if(dmlWrapperLocal.objectsToUpdate != null && !dmlWrapperLocal.objectsToUpdate.isEmpty())
-	                        dmlWrapper.objectsToUpdate.addAll(dmlWrapperLocal.objectsToUpdate);
-	                    if(dmlWrapperLocal.objectsToDelete != null && !dmlWrapperLocal.objectsToDelete.isEmpty())
-	                        dmlWrapper.objectsToDelete.addAll(dmlWrapperLocal.objectsToDelete);
-	                    if(dmlWrapperLocal.objectsToUndelete != null && !dmlWrapperLocal.objectsToUndelete.isEmpty())
-	                        dmlWrapper.objectsToUndelete.addAll(dmlWrapperLocal.objectsToUndelete);
-	                }          
-                    UTIL_Debug.debugWithInfo('****Finished executing: ' + classToCall.get('Class__c'));
-	            }
-	                         
-	            //Process the result
-	            if(dmlWrapper != null)
-	               processDML(dmlWrapper);
-	        }
-	    } catch(Exception e) {
-	    	UTIL_Debug.debug(LoggingLevel.WARN, '****Exception caught in run method of TDTM_TriggerHandler: ' + e.getMessage());
-            UTIL_Debug.debug(LoggingLevel.WARN, '\n****Stack Trace:\n' + e.getStackTraceString() + '\n');
-            if(!UTIL_CustomSettingsFacade.getErrorSettings().Disable_Error_Handling__c) {
-                Database.rollback(sp);
-                //Store error record and send error email notification
-                ERR_Handler.processError(e, ERR_Handler_API.Context.TDTM);
-            } else { // re-throwing exception if error handling is disabled 
-            	throw e;
+        if(newList != null) {
+           UTIL_Debug.debug(LoggingLevel.WARN, '****Trigger.new size: ' + newList.size());
+        }
+
+        TDTM_Runnable.Action thisAction = TDTM_TriggerActionHelper.determineTriggerAction(isBefore,
+                                                      isAfter, isInsert, isUpdate, isDelete, isUnDelete);
+        UTIL_Debug.debugWithInfo('****ACTION: ' + thisAction + ' on ' + describeObj.getLabel());
+
+        TDTM_Runnable.DmlWrapper dmlWrapper = new TDTM_Runnable.DmlWrapper();
+
+        // If there are no records, insert the defaults.
+        if(!defaultRecordsInserted && dao.isEmpty()) {
+            List<Trigger_Handler__c> defaultConfig = TDTM_DefaultConfig.getDefaultRecords();
+            insert defaultConfig;
+            defaultRecordsInserted = true;
+        }
+
+        // Get the classes to run. Note that we are using the local object name, so it works for objects
+        // from Cumulus both in the package and unmanaged dev orgs.
+        List<SObject> classesToCall = dao.getclassesToCallForObject(describeObj.getLocalName(), thisAction);
+        UTIL_Debug.debug(LoggingLevel.WARN, '****Classes To Call for ' + describeObj.getLocalName() + ': ' + JSON.serializePretty(classesToCall));
+
+        if(classesToCall != null && classesToCall.size() > 0) {
+            //Run the relevant classes
+            for (SObject classToCall : classesToCall) {
+                TDTM_Runnable.DmlWrapper dmlWrapperLocal = new TDTM_Runnable.DmlWrapper();
+                dmlWrapperLocal = runClass(classToCall, newList, OldList, thisAction, describeObj);
+                if(dmlWrapperLocal != null) {
+                    if(dmlWrapperLocal.objectsToInsert != null && !dmlWrapperLocal.objectsToInsert.isEmpty())
+                        dmlWrapper.objectsToInsert.addAll(dmlWrapperLocal.objectsToInsert);
+                    if(dmlWrapperLocal.objectsToUpdate != null && !dmlWrapperLocal.objectsToUpdate.isEmpty())
+                        dmlWrapper.objectsToUpdate.addAll(dmlWrapperLocal.objectsToUpdate);
+                    if(dmlWrapperLocal.objectsToDelete != null && !dmlWrapperLocal.objectsToDelete.isEmpty())
+                        dmlWrapper.objectsToDelete.addAll(dmlWrapperLocal.objectsToDelete);
+                    if(dmlWrapperLocal.objectsToUndelete != null && !dmlWrapperLocal.objectsToUndelete.isEmpty())
+                        dmlWrapper.objectsToUndelete.addAll(dmlWrapperLocal.objectsToUndelete);
+                }
+                UTIL_Debug.debugWithInfo('****Finished executing: ' + classToCall.get('Class__c'));
             }
-            // We don't need to mark the record(s) with an error (with addError) because the application does it automatically 
-            // for us (IF they are part of the DML performed in our processDML method). If we mark it with an error the transaction 
-            // will be rolled back by the platform, and our error record won't be saved or error notifications sent.
-                        
-            // but we do want our tests to fail if they encountered this error!
-            // we do need to allow some specific tests that are testing our error handling
-            // to avoid the assert, because by allowing it to throw an exception within our catch, it
-            // changes system behavior.
-            if (Test.isRunningTest() && !suppressDebugAssertAfterErrorLogging) {
-                UTIL_Debug.debug('****Stack trace: ' + e.getStackTraceString());
-                system.assertEquals(null, e.getMessage(), e.getStackTraceString()); 
-            }
+
+            //Process the result
+            if(dmlWrapper != null)
+               processDML(dmlWrapper);
         }
     }
-    
+
     private TDTM_Runnable.DmlWrapper runClass(SObject classToRunRecord, List<Sobject> newList, List<Sobject> oldList, 
     TDTM_Runnable.Action thisAction, Schema.DescribeSobjectResult describeObj) {
     	        

--- a/src/classes/UTIL_JobProgress_CTRL.cls
+++ b/src/classes/UTIL_JobProgress_CTRL.cls
@@ -151,26 +151,22 @@ public with sharing class UTIL_JobProgress_CTRL {
         List<AsyncApexJob> jobs = new List<AsyncApexJob>();
         List<BatchJobStatus> jobsStatus = new List<BatchJobStatus>();
 
-        try {
-            jobs = [
-                SELECT
-                ApexClass.Name,
-                CreatedBy.Name,
-                CreatedDate,
-                Status,
-                ExtendedStatus,
-                CompletedDate,
-                JobItemsProcessed,
-                TotalJobItems,
-                NumberOfErrors
-                FROM AsyncApexJob
-                WHERE JobType = 'BatchApex'
-                ORDER BY CreatedDate DESC
-                LIMIT :numberOfJobs
-            ];
-        } catch (QueryException e) {
-            // could not query jobs or no jobs found
-        }
+        jobs = [
+            SELECT
+            ApexClass.Name,
+            CreatedBy.Name,
+            CreatedDate,
+            Status,
+            ExtendedStatus,
+            CompletedDate,
+            JobItemsProcessed,
+            TotalJobItems,
+            NumberOfErrors
+            FROM AsyncApexJob
+            WHERE JobType = 'BatchApex'
+            ORDER BY CreatedDate DESC
+            LIMIT :numberOfJobs
+        ];
 
         for (AsyncApexJob job : jobs) {
             jobsStatus.add(new BatchJobStatus(job));

--- a/src/classes/UTIL_MasterSchedulableHelper.cls
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls
@@ -100,17 +100,12 @@ public without sharing class UTIL_MasterSchedulableHelper {
             if(classType != null && shouldRun) {     
                Object instance = classType.newInstance(); 
                if(instance instanceof UTIL_IRecurring) {
-                   try {
-                       UTIL_Debug.debug(LoggingLevel.WARN, '****Running ' + instance);
-                       Boolean wasRun = ((UTIL_IRecurring)instance).executeReturnStatus();
-                       //Update last time run
-                       if(wasRun) {
-                           job.Last_Time_Run__c = System.now();
-                           jobsToUpdate.add(job);
-                       }
-                   } catch (Exception e) {
-                       //The class itself should handle any errors. We don't want to have a reference to ERR_Handler
-                       //here because then we won't be able to push updates that modify it if the job is scheduled
+                   UTIL_Debug.debug(LoggingLevel.WARN, '****Running ' + instance);
+                   Boolean wasRun = ((UTIL_IRecurring)instance).executeReturnStatus();
+                   //Update last time run
+                   if(wasRun) {
+                       job.Last_Time_Run__c = System.now();
+                       jobsToUpdate.add(job);
                    }
                }
             }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -179,6 +179,14 @@
         <value>Mass Verify Existing Addresses</value>
     </labels>
     <labels>
+        <fullName>Addr_Verification_Cant_Load_Class</fullName>
+        <categories>address</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Unable to load verification class when visiting settings page</shortDescription>
+        <value>There was an error loading the validator class {0}</value>
+    </labels>
+    <labels>
         <fullName>Addr_Verification_Required</fullName>
         <categories>address</categories>
         <language>en_US</language>

--- a/src/objects/Error_Settings__c.object
+++ b/src/objects/Error_Settings__c.object
@@ -4,6 +4,15 @@
     <description>Settings that control your error management configuration.</description>
     <enableFeeds>false</enableFeeds>
     <fields>
+        <fullName>Async_Error_Check_Last_Run__c</fullName>
+        <description>If checked, NPSP&apos;s error handling framework is disabled.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Used to keep track of the most recent execution of the Async job error logger</inlineHelpText>
+        <label>Async Error Check Last Run</label>
+        <trackTrending>false</trackTrending>
+        <type>DateTime</type>
+    </fields>
+    <fields>
         <fullName>Disable_Error_Handling__c</fullName>
         <defaultValue>false</defaultValue>
         <description>If checked, NPSP&apos;s error handling framework is disabled.</description>

--- a/src/package.xml
+++ b/src/package.xml
@@ -86,6 +86,8 @@
         <members>EP_TaskRollup_TEST</members>
         <members>EP_Task_UTIL</members>
         <members>ERR_AddError_TEST</members>
+        <members>ERR_AsyncErrors</members>
+        <members>ERR_AsyncErrors_TEST</members>
         <members>ERR_Handler</members>
         <members>ERR_Handler_API</members>
         <members>ERR_Handler_CTRL_TEST</members>
@@ -635,6 +637,7 @@
         <members>Engagement_Plan__c.Status__c</members>
         <members>Engagement_Plan__c.Total_EP_Tasks__c</members>
         <members>Engagement_Plan__c.Total_Tasks__c</members>
+        <members>Error_Settings__c.Async_Error_Check_Last_Run__c</members>
         <members>Error_Settings__c.Disable_Error_Handling__c</members>
         <members>Error_Settings__c.Enable_Debug__c</members>
         <members>Error_Settings__c.Error_Notifications_On__c</members>
@@ -792,6 +795,7 @@
         <members>Addr_Verification_Batch_SmartyStreets_Message</members>
         <members>Addr_Verification_Batch_Status</members>
         <members>Addr_Verification_Batch_Title</members>
+        <members>Addr_Verification_Cant_Load_Class</members>
         <members>Addr_Verification_Required</members>
         <members>Addr_Verification_Undefined_Class</members>
         <members>Addr_Verification_Wrong_Class</members>


### PR DESCRIPTION
Removing instances where exceptions were being caught and ignored or otherwise hidden from the user.  Now, where an exception is caught, if there is a user available to see the error, then the error will be surfaced to the user.  In cases where there is no user (future methods, batch classes, schedulables, etc.) then the exception is uncaught and bubbles up to the platform level handler.

Add new class that will periodically scan the AsyncApexJob table for jobs that had uncaught exceptions, and will log/notify user about these errors.  New field added to Error_Settings__c object to support this feature.

Some exceptions are made for cases where the error message was being surfaced to the user in slightly different ways than via ApexPages (batch data import, address verification, etc.)

Several tests in ERR_Handler_TEST were attempting to test the functionality of ERR_Handler and ERR_Notifier by triggering errors within a trigger handler.  This made these tests dependent on error handling in TDTM.

However, after error handling was removed from TDTM, these tests began to fail because the TDTM transactions were being rolled back due to uncaught exceptions, and error log records were not being saved.

This adjusts these tests to remove dependency on TDTM error handling, but still testing behavior of ERR_Handler and ERR_Notifier classes.

The ERR_Handler_TEST.errorsStoredInDbTdtmCustomConfigPostToChatter(), ERR_Handler_TEST.errorsStoredInDbTdtmCustomConfigEmailErrors(), and ERR_Handler_TEST.testInactiveUserEmailBehavior() test methods were updated to remove DML intended to trigger TDTM execution, and to remove assertions that test TDTM error handling.  Instead, these tests now invoke ERR_Handler.processError() directly with a constructed exception.

Removed ERR_Handler_TEST.errorHandlingDisabled(), ERR_Handler_TEST.errorsStoredInDbTdtmCustomConfig2(), and ERR_Handler_TEST.errorStoredInDbTdtmStandardConfig() methods, because these tests are strictly dependent on TDTM error handling, or are otherwise redundant now that TDTM error handling has been removed.

# Critical Changes

# Changes

# Issues Closed