### PR TITLE
Default address not resetting on Seasonal End Dates #2358

### DIFF
--- a/src/aura/HH_Container/HH_ContainerHelper.js
+++ b/src/aura/HH_Container/HH_ContainerHelper.js
@@ -822,12 +822,15 @@
     },
 
     /*******************************************************************************************************
-     * @description adds or removes namespace prefix from the object's custom fields
+     * @description adds or removes namespace prefix from the object's custom fields.  for non-namespaced
+     * fields, it will replace __c with __nons on add, and switch it back on subtract.  this way we don't
+     * assume on add, that no namespace means it should get our namespace!
      */
     processPrefixObjectFields: function(namespacePrefix, object, isAdd) {
         if (namespacePrefix && namespacePrefix.length > 0) {
 
             var obj = {}; //create object
+            var fld2;
 
             // process namespace prefix from each custom field
             for (var fld in object) {
@@ -840,16 +843,24 @@
                 if (isAdd) {
                     // see if custom field has no namespace prefix
                     if (fld.length > 3 && fld.lastIndexOf('__c') === (fld.length - 3) && fld.indexOf('__') === fld.lastIndexOf('__')) {
-                        var fld2 = namespacePrefix + fld;
+                        fld2 = namespacePrefix + fld;
                         obj[fld2] = object[fld];
+                    // see if it's marked with our non-namespaced custom field tag
+                    } else if (fld.lastIndexOf('__nons') === (fld.length - 6)) {
+                        fld2 = fld.replace('__nons', '__c');
+                        obj[fld2] = object[fld];                        
                     } else {
                         obj[fld] = object[fld];
                     }
                 } else {
                     // see if custom field starts with our namespace prefix
                     if (fld.length > 3 && fld.lastIndexOf('__c') === (fld.length - 3) && fld.indexOf(namespacePrefix) === 0) {
-                        var fld3 = fld.replace(namespacePrefix, '');
-                        obj[fld3] = object[fld];
+                        fld2 = fld.replace(namespacePrefix, '');
+                        obj[fld2] = object[fld];
+                    // see if it is a non-namespaced custom field
+                    } else if (fld.length > 3 && fld.lastIndexOf('__c') === (fld.length - 3) && fld.indexOf('__') === fld.lastIndexOf('__')) {
+                        fld2 = fld.replace('__c', '__nons');
+                        obj[fld2] = object[fld];                                            
                     } else {
                         obj[fld] = object[fld];
                     }

--- a/src/classes/ADDR_Addresses_TDTM.cls
+++ b/src/classes/ADDR_Addresses_TDTM.cls
@@ -718,16 +718,42 @@ public class ADDR_Addresses_TDTM extends TDTM_Runnable {
     }
     
     /*******************************************************************************************************
-    * @description routine the scheduled batch job calls to update households with the specified Seasonal addresses
-    * @param listAddr a list of Addresses to update
+    * @description routine the scheduled batch job calls to update households with Seasonal addresses
+    * @param listAcc a list of Accounts to see if their address needs to be updated
     * @return void
     */ 
-    public static void batchSeasonalUpdate(list<Address__c> listAddr) {
-        if (listAddr == null || listAddr.size() == 0) return;
+    public static void batchSeasonalUpdate(list<Account> listAcc) {
+        if (listAcc == null || listAcc.size() == 0) 
+            return;
         
         map<Id, Address__c> mapAccIdAddr = new map<Id, Address__c>();
-        for (Address__c addr : listAddr) 
-            mapAccIdAddr.put(addr.Household_Account__c, addr);
+        for (Account acc : listAcc) 
+            mapAccIdAddr.put(acc.Id, null);
+        
+        // get the default and seasonal address for each HH
+        map<Id, ADDR_Addresses_TDTM.HHInfo> mapAccIdHHInfo = ADDR_Addresses_TDTM.refreshCurrentHHAddress(mapAccIdAddr, null, true);
+        
+        // now see which accounts actually had their address change, so we only update them.
+        for (Account acc : listAcc) {
+            ADDR_Addresses_TDTM.HHInfo hhinfo = mapAccIdHHInfo.get(acc.Id);
+            if (hhinfo != null) {
+                Address__c addr = hhinfo.addrSeasonal;
+                if (addr == null)
+                    addr = hhinfo.addrDefault;
+                if (addr != null) {
+                    Address__c addrCurrent = new Address__c();
+                    ADDR_Addresses_TDTM.copyAddressStdSObjAddr(acc, 'Billing', addrCurrent, null);
+                    // now see if the address has changed, and if not, we don't need to process it anymore
+                    if (!isAddressChanged(addr, addrCurrent, false)) {
+                        mapAccIdAddr.remove(acc.Id);
+                    }
+                    
+                }
+            }
+        }
+        
+        // now mapAccIdAddr only contains those Accounts (and Contacts) who need updating.
+        // we'll go thru refreshCurrentHHAddress() again, this time allowing it to do the updates    
         
         // must manually set our semaphore, so when we update contacts and households, they don't try to create additional addresses
         hasRunAddrTrigger = true;       

--- a/src/classes/ADDR_Addresses_TEST2.cls
+++ b/src/classes/ADDR_Addresses_TEST2.cls
@@ -47,7 +47,7 @@ public with sharing class ADDR_Addresses_TEST2 {
     */
     static integer cHH = 2;
 
-    /*******************************    **************************************************************************
+    /*********************************************************************************************************
     * @description Holds the number of Contacts per Household to create in tests.
     */
     static integer cCon = 2;    
@@ -509,6 +509,86 @@ public with sharing class ADDR_Addresses_TEST2 {
             system.assertEquals(true, ADDR_Addresses_TEST.isMatchAddressAccCon(acc, con));
             system.assert(con.MailingStreet.contains('New Seasonal Street'));
             system.assert(con.MailingCity.contains('New Seasonal City'));
+            system.assertEquals(false, con.is_Address_Override__c);
+            system.assertNotEquals(null, con.Current_Address__c);
+        }
+        
+        // verify the previous addresses still are Default
+        list<Address__c> listAddr = [select Id, Default_Address__c, MailingStreet__c, Household_Account__c, Latest_Start_Date__c, Latest_End_Date__c from Address__c];
+        system.assertEquals(cHH * 2, listAddr.size());
+        for (Address__c addr : listAddr) {
+            boolean fSeasonal = (addr.MailingStreet__c.contains('New Seasonal Street'));
+            system.assertEquals(!fSeasonal, addr.Default_Address__c);
+        }        
+    }
+
+    /*********************************************************************************************************
+    @description
+        reset a seasonal address thru the scheduler 
+    verify:
+        contact's && hh address matches new seasonal
+        old default addresses still marked default
+    **********************************************************************************************************/            
+    static testMethod void scheduleSeasonalAddrReset() {
+        if (strTestOnly != '*' && strTestOnly != 'scheduleSeasonalAddrReset') return;
+        
+        // this creates a default Address for each HH
+        createHHTestData(cHH, cCon);
+        
+        // create additional addresses
+        initTestAddr(cHH);
+        for (integer i = 0; i < cHH; i++) {
+            listAddrT[i].Household_Account__c = listAccT[i].Id;
+            listAddrT[i].Default_Address__c = false;
+            listAddrT[i].Seasonal_Start_Month__c = string.valueOf(system.today().addMonths(-2).month());
+            listAddrT[i].Seasonal_Start_Day__c = '1';
+            listAddrT[i].Seasonal_End_Month__c = string.valueOf(system.today().addMonths(1).month());
+            listAddrT[i].Seasonal_End_Day__c = '1';
+            listAddrT[i].MailingStreet__c = 'New Seasonal Street' + i;
+            listAddrT[i].MailingCity__c = 'New Seasonal City' + i;
+        }
+        
+        // this should update the hh and contacts to the seasonal addresses
+        insert listAddrT;
+        
+        // verify that the HH and Contacts share the same address and it's new!
+        map<Id, Account> mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry, BillingLatitude, BillingLongitude from Account]);
+        list<Contact> listCon = [select Id, Name, AccountId, is_Address_Override__c, Current_Address__c, MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry, MailingLatitude, MailingLongitude from Contact];
+        system.assertEquals(cHH * cCon, listCon.size());
+        
+        for (Contact con : listCon) {
+            Account acc = mapAccIdAcc.get(con.AccountId);
+            system.assertEquals(true, ADDR_Addresses_TEST.isMatchAddressAccCon(acc, con));
+            system.assert(con.MailingStreet.contains('New Seasonal Street'));
+            system.assert(con.MailingCity.contains('New Seasonal City'));
+            system.assertEquals(false, con.is_Address_Override__c);
+            system.assertNotEquals(null, con.Current_Address__c);
+        }
+
+        // now let's update the seasonal addresses to no longer be active, but disable triggers for now
+        // this way we can test the scheduled job!
+        for (Address__c addr : listAddrT) {
+            addr.Seasonal_End_Month__c = string.valueOf(system.today().addMonths(-1).month());
+        }
+        ADDR_Addresses_TDTM.hasRunAddrTrigger = true;
+        update listAddrT;
+        ADDR_Addresses_TDTM.hasRunAddrTrigger = false;
+
+        // run the scheduled batch directly
+        Test.startTest();
+        Database.executeBatch(new ADDR_Seasonal_SCHED(), 10);
+        Test.stopTest();
+        
+        // verify that the HH and Contacts share the same address and it's the old default!
+        mapAccIdAcc = new map<Id, Account>([select Id, Name, BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry, BillingLatitude, BillingLongitude from Account]);
+        listCon = [select Id, Name, AccountId, is_Address_Override__c, Current_Address__c, MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry, MailingLatitude, MailingLongitude from Contact];
+        system.assertEquals(cHH * cCon, listCon.size());
+        
+        for (Contact con : listCon) {
+            Account acc = mapAccIdAcc.get(con.AccountId);
+            system.assertEquals(true, ADDR_Addresses_TEST.isMatchAddressAccCon(acc, con));
+            system.assert(con.MailingStreet.startsWith('Street'));
+            system.assert(con.MailingCity.startsWith('City'));
             system.assertEquals(false, con.is_Address_Override__c);
             system.assertNotEquals(null, con.Current_Address__c);
         }

--- a/src/classes/ADDR_Seasonal_SCHED.cls
+++ b/src/classes/ADDR_Seasonal_SCHED.cls
@@ -39,6 +39,7 @@ public class ADDR_Seasonal_SCHED implements Database.Batchable<SObject>, Schedul
     * @description Schedulable execute method executes this batch job.
     ********************************************************************************************************/
     public void execute(SchedulableContext context) {
+        //call the batch job, processing 10 at a time
         Id batchInstanceId = Database.executeBatch(new ADDR_Seasonal_SCHED(), 10);
     }
 
@@ -47,27 +48,34 @@ public class ADDR_Seasonal_SCHED implements Database.Batchable<SObject>, Schedul
     * @param bc the BatchableContext
     * @return database.Querylocator  
     ********************************************************************************************************/
-    public database.Querylocator start(Database.BatchableContext bc){       
-        //call the batch job, processing 10 at a time
-        integer iMonth = system.today().month();
-        integer iDay = system.today().day();
-        
-        String strQuery = 'select Id, Household_Account__c, Default_Address__c ' +
-            ' from Address__c ' +
-            ' where Seasonal_Start_Month__c = \'' + string.valueOf(iMonth) + '\'' +
-            ' and Seasonal_Start_Day__c = \'' + string.valueOf(iDay) + '\'';
-
-        return Database.getQueryLocator(strQuery);      
+    public database.Querylocator start(Database.BatchableContext bc) {       
+            
+        // find all seasonal addresses, so we can see which accounts might need updating
+        list<Address__c> listAddr = [select Id, Household_Account__c from Address__c where Seasonal_Start_Month__c != null];
+        list<ID> listAccId = new list<ID>();
+        for (Address__c addr : listAddr) {
+            listAccId.add(addr.Household_Account__c);
+        }
+            
+        // find all Accounts who have any Seasonal Address, since it may need to now
+        // become current or inactive, and we don't want to assume the last time this ran.
+        // make sure to include all Billing Address fields, that we will need to look at
+        string strSoql = 'select Id, BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry, BillingLongitude, BillingLatitude';
+        if (ADDR_Addresses_TDTM.isStateCountryPicklistsEnabled) {
+            strSoql += ', BillingStateCode, BillingCountryCode';
+        }
+        strSoql += ' from Account where Id in :listAccId';
+        return Database.getQueryLocator(strSoql);      
     }
     
     /*******************************************************************************************************
     * @description execute Method for the Database.Batchable interface
     * @param bc the BatchableContext
-    * @param listSobj the list of Address objects to process
+    * @param listSobj the list of Account objects to process
     * @return void  
     ********************************************************************************************************/
     public void execute(Database.BatchableContext bc, Sobject[] listSobj) {
-        ADDR_Addresses_TDTM.batchSeasonalUpdate((list<Address__c>) listSobj);        
+        ADDR_Addresses_TDTM.batchSeasonalUpdate((list<Account>) listSobj);        
     }
 
     /*******************************************************************************************************


### PR DESCRIPTION
I've redesigned how we do the scheduled batch job for seasonal addresses.  previously, it just looked for seasonal addresses that became active on the current day.  That's flawed for two reasons; if the job doesn't run one day, the change would not happen, and we never detected when seasonal addresses no longer should be used.

the new strategy finds all accounts who have any seasonal addresses associated with them, then calls existing logic to find each accounts current default and potential seasonal.  it then sees if the appropriate address matches what's in the account or not.  If not, it then calls existing logic to update the HH and Contacts with the appropriate address.  

# Critical Changes

# Changes

# Issues Closed
Fixes #2358 