### PR TITLE
Switch to running feature builds on CircleCI & scratch orgs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,29 @@
+# If you need to handle concurrency greater than 1, uncomment the following and deploy an instance of https://github.com/SalesforceFoundation/circleci-github-trigger to trigger your builds
+#general:
+#  branches:
+#    ignore:
+#      - /feature\/.*/
+machine:
+  python:
+    version: 2.7.12
+  environment:
+    CUMULUSCI_KEY: FIXME
+    CUMULUSCI_KEYCHAIN_CLASS: cumulusci.core.keychain.EnvironmentProjectKeychain
+dependencies:
+  override:
+    #- 'pip install --upgrade cumulusci'
+    - 'mkdir ~/.appcloud'
+    - 'echo $SFDX_CONFIG > ~/.appcloud/workspace-config.json'
+    - 'echo $SFDX_HUB_ORG > ~/.appcloud/hubOrg.json'
+    - 'heroku plugins:install salesforce-alm@preview'
+    - 'heroku force --help'
+    - 'git clone git@github.com:SalesforceFoundation/CumulusCI'
+    - 'cd CumulusCI; git checkout feature/2.0; pip install -r requirements_dev.txt'
+test:
+  override:
+    - 'if [[ $CIRCLE_BRANCH == feature/* ]]; then cumulusci2 flow run ci_feature --org feature --delete-org; fi'
+  post:
+    - 'mkdir -p $CIRCLE_TEST_REPORTS/junit/'
+    - 'cp test_results.xml $CIRCLE_TEST_REPORTS/junit/'
+    - 'if [[ $CIRCLE_BRANCH != "master" ]]; then cp test_results.json $CIRCLE_ARTIFACTS; fi'
+    #- 'if [[ $CIRCLE_BRANCH != "master" ]]; then cumulusci2 task run apextestsdb_upload; fi'

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     - 'cd CumulusCI; git checkout feature/2.0; pip install -r requirements_dev.txt'
 test:
   override:
-    - 'if [[ $CIRCLE_BRANCH == feature/* ]]; then cumulusci2 flow run ci_feature --org feature --delete-org; fi'
+    - 'if [[ $CIRCLE_BRANCH == feature/* ]]; then cumulusci2 flow run ci_feature_temp --org feature --delete-org; fi'
   post:
     - 'mkdir -p $CIRCLE_TEST_REPORTS/junit/'
     - 'cp test_results.xml $CIRCLE_TEST_REPORTS/junit/'

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -31,6 +31,5 @@ flows:
             - task: update_dependencies
             - task: deploy_pre
             - task: deploy
-            - task: uninstall_packaged_incremental
             - task: deploy_post
             - task: run_tests

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -22,3 +22,15 @@ project:
           version: 3.3
         - namespace: npe5
           version: 3.3
+
+flows:
+    ci_feature_temp:
+        description: Deploys the unmanaged package metadata and all dependencies to the target org and runs tests without collecting debug logs
+        tasks:
+            - task: create_package
+            - task: update_dependencies
+            - task: deploy_pre
+            - task: deploy
+            - task: uninstall_packaged_incremental
+            - task: deploy_post
+            - task: run_tests


### PR DESCRIPTION
This PR adds the config files for CircleCI to use CumulusCI 2.0 + Salesforce DX scratch orgs to allow us to run feature builds concurrently in a fresh org.