### PR TITLE
Prevent exception when legacy accounts have >50k contacts

### DIFF
--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -63,19 +63,26 @@ public with sharing class CON_DeleteContactOverride_CTRL {
     public pageReference processDelete() {
         Contact queryContact = [SELECT Id, AccountId, Account.npe01__SYSTEMIsIndividual__c FROM Contact WHERE Id = :conId];
         string accId = queryContact.AccountId;
-        list<AggregateResult> contactsInHousehold = [SELECT COUNT(id) ct FROM Contact WHERE AccountId = :accId GROUP BY AccountId HAVING COUNT(id) = 1];
+        boolean shouldDeleteContactAlone = true;
 
-        //This contact is alone in a system account, delete the system account and allow the cascading
-        //delete to remove the contact
-        if (contactsInHousehold.size() == 1 && contactsInHousehold[0].get('ct') == 1 && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
-            Account accForDelete = new Account(id=accId);
-            delete accForDelete;
+        if (queryContact.AccountId != null && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
+            list<AggregateResult> contactsInHousehold = [SELECT COUNT(id) ct FROM Contact WHERE AccountId = :accId GROUP BY AccountId HAVING COUNT(id) = 1];
 
-            //if we were returning to the account we just deleted, go back to contacts home
-            if (retURL.contains(accId.substring(0,15))) {
-                retURL = '/003/o';
+            //This contact is alone in a system account, delete the system account and allow the cascading
+            //delete to remove the contact
+            if (contactsInHousehold.size() == 1 && contactsInHousehold[0].get('ct') == 1) {
+                shouldDeleteContactAlone = false;
+                Account accForDelete = new Account(id=accId);
+                delete accForDelete;
+
+                //if we were returning to the account we just deleted, go back to contacts home
+                if (retURL.contains(accId.substring(0,15))) {
+                    retURL = '/003/o';
+                }
             }
-        } else {
+        }
+
+        if (shouldDeleteContactAlone) {
             delete queryContact;
         }
 

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -63,11 +63,11 @@ public with sharing class CON_DeleteContactOverride_CTRL {
     public pageReference processDelete() {
         Contact queryContact = [SELECT Id, AccountId, Account.npe01__SYSTEMIsIndividual__c FROM Contact WHERE Id = :conId];
         string accId = queryContact.AccountId;
-        list<Contact> contactsInHousehold = [SELECT id FROM Contact WHERE AccountId = :accId];
+        list<AggregateResult> contactsInHousehold = [SELECT COUNT(id) ct FROM Contact WHERE AccountId = :accId GROUP BY AccountId HAVING COUNT(id) = 1];
 
         //This contact is alone in a system account, delete the system account and allow the cascading
         //delete to remove the contact
-        if (contactsInHousehold.size()==1 && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
+        if (agg.size() == 1 && agg[0].get('ct') == 1 && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
             Account accForDelete = new Account(id=accId);
             delete accForDelete;
 

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -67,7 +67,7 @@ public with sharing class CON_DeleteContactOverride_CTRL {
 
         //This contact is alone in a system account, delete the system account and allow the cascading
         //delete to remove the contact
-        if (agg.size() == 1 && agg[0].get('ct') == 1 && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
+        if (contactsInHousehold.size() == 1 && contactsInHousehold[0].get('ct') == 1 && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
             Account accForDelete = new Account(id=accId);
             delete accForDelete;
 


### PR DESCRIPTION
I have several legacy accounts with huge numbers of contacts.  When users try to delete those contacts using `CON_DeleteContactOverride`, they get an exception in the form:

> npsp:Too many query rows: 50001
> Error is in expression '{!processDelete}' in component <apex:page> in page npsp:con_deletecontactoverride: (npsp)

This patch aggregates the results instead of querying the 50k+ contacts that will never be used.

It's likely that `&& contactsInHousehold[0].get('ct') == 1` is redundant.

# Critical Changes

Fixes bug that can be duplicated as follows:

## Reproduce
1. Create an Account
1. Create 60k contacts all in that account.
1. Click delete on one of those contacts.

## Expected result:
Contact is deleted.

## Actual result:

> npsp:Too many query rows: 50001
> Error is in expression '{!processDelete}' in component <apex:page> in page npsp:con_deletecontactoverride: (npsp)

# Changes

# Issues Closed

#2425: **Cannot delete Contact in Account with >50k Contacts**