### PR TITLE
Prevent exception when legacy accounts have >50k contacts. Issue #2436

### DIFF
--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -38,7 +38,7 @@
 public with sharing class CON_DeleteContactOverride_CTRL {
 
     /** @description The contact id of the record to delete. */
-	private final string conId;
+    private final string conId;
     private string retURL;
 
     /*******************************************************************************************************
@@ -63,19 +63,26 @@ public with sharing class CON_DeleteContactOverride_CTRL {
     public pageReference processDelete() {
         Contact queryContact = [SELECT Id, AccountId, Account.npe01__SYSTEMIsIndividual__c FROM Contact WHERE Id = :conId];
         string accId = queryContact.AccountId;
-        list<Contact> contactsInHousehold = [SELECT id FROM Contact WHERE AccountId = :accId];
+        boolean shouldDeleteContactAlone = true;
 
-        //This contact is alone in a system account, delete the system account and allow the cascading
-        //delete to remove the contact
-        if (contactsInHousehold.size()==1 && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
-            Account accForDelete = new Account(id=accId);
-            delete accForDelete;
+        if (queryContact.AccountId != null && queryContact.Account.npe01__SYSTEMIsIndividual__c) {
+            list<AggregateResult> contactsInHousehold = [SELECT COUNT(id) ct FROM Contact WHERE AccountId = :accId GROUP BY AccountId HAVING COUNT(id) = 1];
 
-            //if we were returning to the account we just deleted, go back to contacts home
-            if (retURL.contains(accId.substring(0,15))) {
-                retURL = '/003/o';
+            //This contact is alone in a system account, delete the system account and allow the cascading
+            //delete to remove the contact
+            if (contactsInHousehold.size() == 1 && contactsInHousehold[0].get('ct') == 1) {
+                shouldDeleteContactAlone = false;
+                Account accForDelete = new Account(id=accId);
+                delete accForDelete;
+
+                //if we were returning to the account we just deleted, go back to contacts home
+                if (retURL.contains(accId.substring(0,15))) {
+                    retURL = '/003/o';
+                }
             }
-        } else {
+        }
+
+        if (shouldDeleteContactAlone) {
             delete queryContact;
         }
 


### PR DESCRIPTION
# Critical Changes

# Changes
- Charles Koppelman has contributed an NPSP fix to handle deleting Contacts from an Account with over 50,000 contacts in it.  Thank you Charles!

# Issues Closed
Fixes #2436 