### PR TITLE
Add back empty test class to prevent permanent deletion from package

### DIFF
--- a/src/classes/UTIL_CascadeDeleteLookups_TEST.cls
+++ b/src/classes/UTIL_CascadeDeleteLookups_TEST.cls
@@ -1,0 +1,37 @@
+/*
+    Copyright (c) 2009, Salesforce.com Foundation
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Salesforce.com Foundation nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.com Foundation
+*/
+@isTest
+private class UTIL_CascadeDeleteLookups_TEST {
+    static testmethod void test() {
+    }
+}

--- a/src/classes/UTIL_CascadeDeleteLookups_TEST.cls-meta.xml
+++ b/src/classes/UTIL_CascadeDeleteLookups_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -245,6 +245,7 @@
         <members>TDTM_iTableDataGateway</members>
         <members>UTIL_AbstractRollup_BATCH</members>
         <members>UTIL_CascadeDeleteLookups_TDTM</members>
+        <members>UTIL_CascadeDeleteLookups_TEST</members>
         <members>UTIL_Currency</members>
         <members>UTIL_Currency_TEST</members>
         <members>UTIL_CustomSettingsFacade</members>


### PR DESCRIPTION
The UTIL_CascadeDeleteLookups_TEST class was removed from the dev branch.  When I went to create a production release, I noticed that the class would be permanently deleted from the package meaning we couldn't create it again in the future.  This PR adds back an empty class that will prevent that deletion.