### PR TITLE
Updating handling of Cicero API, fixes #2439 and #2508

### DIFF
--- a/src/classes/ADDR_Cicero_TEST.cls
+++ b/src/classes/ADDR_Cicero_TEST.cls
@@ -48,142 +48,242 @@ public with sharing class ADDR_Cicero_TEST {
     * @description a fake http response from Cicero for test code
     */
     private static string strResponseTest = 
-		'{'+
-		'"response" : {'+
-		'"messages" : [ ],'+
-		'"results" : {'+
-		'"candidates" : [ {'+
-		'"x" : -122.162791,'+
-		'"y" : 47.63411,'+
-		'"match_addr" : "2623 134th Ave NE, Bellevue, Washington, 98005",'+
-		'"locator_type" : "PointAddress",'+
-		'"score" : 100,'+
-		'"districts" : [ {'+
-		'"valid_to" : null,'+
-		'"last_update_date" : "2012-03-18 07:46:32",'+
-		'"district_type" : "NATIONAL_EXEC",'+
-		'"subtype" : "NATION",'+
-		'"id" : 19,'+
-		'"country" : "US",'+
-		'"city" : "",'+
-		'"label" : "United States",'+
-		'"district_id" : "UNITED STATES",'+
-		'"state" : "",'+
-		'"data" : { },'+
-		'"valid_from" : "0001-01-01 04:56:02",'+
-		'"sk" : 19'+
-		'}, {'+
-		'"valid_to" : null,'+
-		'"last_update_date" : "2012-03-18 07:46:32",'+
-		'"district_type" : "NATIONAL_UPPER",'+
-		'"subtype" : "UPPER",'+
-		'"id" : 74,'+
-		'"country" : "US",'+
-		'"city" : "",'+
-		'"label" : "Washington",'+
-		'"district_id" : "WA",'+
-		'"state" : "WA",'+
-		'"data" : { },'+
-		'"valid_from" : "1977-05-18 00:00:00",'+
-		'"sk" : 74'+
-		'}, {'+
-		'"valid_to" : null,'+
-		'"last_update_date" : "2012-03-18 07:46:32",'+
-		'"district_type" : "STATE_EXEC",'+
-		'"subtype" : "STATE",'+
-		'"id" : 1009,'+
-		'"country" : "US",'+
-		'"city" : "",'+
-		'"label" : "Washington",'+
-		'"district_id" : "WA",'+
-		'"state" : "WA",'+
-		'"data" : { },'+
-		'"valid_from" : "0001-01-01 04:56:02",'+
-		'"sk" : 1009'+
-		'}, {'+
-		'"valid_to" : null,'+
-		'"last_update_date" : "2012-03-18 07:46:31",'+
-		'"district_type" : "LOCAL",'+
-		'"subtype" : "COUNTY",'+
-		'"id" : 2908,'+
-		'"country" : "US",'+
-		'"city" : "King",'+
-		'"label" : "",'+
-		'"district_id" : "6",'+
-		'"state" : "WA",'+
-		'"data" : { },'+
-		'"valid_from" : "0001-01-01 04:56:02",'+
-		'"sk" : 2908'+
-		'}, {'+
-		'"valid_to" : null,'+
-		'"last_update_date" : "2012-03-18 07:46:31",'+
-		'"district_type" : "LOCAL",'+
-		'"subtype" : "COUNTY",'+
-		'"id" : 2916,'+
-		'"country" : "US",'+
-		'"city" : "King",'+
-		'"label" : "",'+
-		'"district_id" : "AT LARGE",'+
-		'"state" : "WA",'+
-		'"data" : { },'+
-		'"valid_from" : "0001-01-01 04:56:02",'+
-		'"sk" : 2916'+
-		'}, {'+
-		'"valid_to" : "2023-01-09 00:00:00",'+
-		'"last_update_date" : "2012-11-20 00:00:00",'+
-		'"district_type" : "STATE_UPPER",'+
-		'"subtype" : "UPPER",'+
-		'"id" : 756663,'+
-		'"country" : "US",'+
-		'"city" : "",'+
-		'"label" : "Washington State Senate district 48",'+
-		'"district_id" : "48",'+
-		'"state" : "WA",'+
-		'"data" : { },'+
-		'"valid_from" : "2013-01-14 00:00:00",'+
-		'"sk" : 756663'+
-		'}, {'+
-		'"valid_to" : "2023-01-09 00:00:00",'+
-		'"last_update_date" : "2012-11-20 00:00:00",'+
-		'"district_type" : "STATE_LOWER",'+
-		'"subtype" : "LOWER",'+
-		'"id" : 756712,'+
-		'"country" : "US",'+
-		'"city" : "",'+
-		'"label" : "Washington House of Representatives district 48",'+
-		'"district_id" : "48",'+
-		'"state" : "WA",'+
-		'"data" : { },'+
-		'"valid_from" : "2013-01-14 00:00:00",'+
-		'"sk" : 756712'+
-		'}, {'+
-		'"valid_to" : "2023-01-03 00:00:00",'+
-		'"last_update_date" : "2012-11-30 00:00:00",'+
-		'"district_type" : "NATIONAL_LOWER",'+
-		'"subtype" : "LOWER",'+
-		'"id" : 757403,'+
-		'"country" : "US",'+
-		'"city" : "",'+
-		'"label" : "Washington\'s 9th congressional district",'+
-		'"district_id" : "9",'+
-		'"state" : "WA",'+
-		'"data" : { },'+
-		'"valid_from" : "2013-01-03 00:00:00",'+
-		'"sk" : 757403'+
-		'} ],'+
-		'"geoservice" : "EsriWGS",'+
-		'"wkid" : 4326,'+
-		'"count" : {'+
-		'"from" : 0,'+
-		'"total" : 8,'+
-		'"to" : 7'+
-		'},'+
-		'"locator" : "rooftop"'+
-		'} ]'+
-		'},'+
-		'"errors" : [ ]'+
-		'}'+
-		'}';
+'{'+
+'  "response" : {'+
+'    "results" : {'+
+'      "candidates" : [ {'+
+'        "geoservice" : "Google",'+
+'        "match_subregion" : "San Francisco County",'+
+'        "x" : -122.3948366,'+
+'        "y" : 37.7938462,'+
+'        "match_addr" : "1 Market St #300, San Francisco, CA 94105, USA",'+
+'        "match_city" : "San Francisco",'+
+'        "match_region" : "CA",'+
+'        "score" : 0,'+
+'        "locator" : "rooftop",'+
+'        "districts" : [ {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca",'+
+'          "data" : { },'+
+'          "id" : 5,'+
+'          "last_update_date" : "2012-03-18 07:46:32",'+
+'          "num_officials" : 2,'+
+'          "state" : "CA",'+
+'          "subtype" : "UPPER",'+
+'          "sk" : 5,'+
+'          "label" : "California",'+
+'          "valid_to" : null,'+
+'          "district_id" : "CA",'+
+'          "country" : "US",'+
+'          "valid_from" : "1977-05-18 00:00:00",'+
+'          "city" : "",'+
+'          "district_type" : "NATIONAL_UPPER"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us",'+
+'          "data" : { },'+
+'          "id" : 19,'+
+'          "last_update_date" : "2012-03-18 07:46:32",'+
+'          "num_officials" : 2,'+
+'          "state" : "",'+
+'          "subtype" : "NATION",'+
+'          "sk" : 19,'+
+'          "label" : "United States",'+
+'          "valid_to" : null,'+
+'          "district_id" : "UNITED STATES",'+
+'          "country" : "US",'+
+'          "valid_from" : "0001-01-01 04:56:02",'+
+'          "city" : "",'+
+'          "district_type" : "NATIONAL_EXEC"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca",'+
+'          "data" : { },'+
+'          "id" : 87,'+
+'          "last_update_date" : "2012-03-18 07:46:32",'+
+'          "num_officials" : 2,'+
+'          "state" : "CA",'+
+'          "subtype" : "STATE",'+
+'          "sk" : 87,'+
+'          "label" : "California",'+
+'          "valid_to" : null,'+
+'          "district_id" : "CA",'+
+'          "country" : "US",'+
+'          "valid_from" : "0001-01-01 04:56:02",'+
+'          "city" : "",'+
+'          "district_type" : "STATE_EXEC"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca/place:san_francisco",'+
+'          "data" : { },'+
+'          "id" : 279,'+
+'          "last_update_date" : "2012-03-18 07:46:32",'+
+'          "num_officials" : 1,'+
+'          "state" : "CA",'+
+'          "subtype" : "CITY",'+
+'          "sk" : 279,'+
+'          "label" : "San Francisco city",'+
+'          "valid_to" : "9999-12-31 00:00:00",'+
+'          "district_id" : "SAN FRANCISCO",'+
+'          "country" : "US",'+
+'          "valid_from" : "0001-01-01 04:56:02",'+
+'          "city" : "San Francisco",'+
+'          "district_type" : "LOCAL_EXEC"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca/county:san_francisco/council_district:6",'+
+'          "data" : { },'+
+'          "id" : 1691,'+
+'          "last_update_date" : "2012-03-18 07:46:31",'+
+'          "num_officials" : 1,'+
+'          "state" : "CA",'+
+'          "subtype" : "COUNTY",'+
+'          "sk" : 1691,'+
+'          "label" : "San Francisco City Council district 6",'+
+'          "valid_to" : "9999-12-31 00:00:00",'+
+'          "district_id" : "6",'+
+'          "country" : "US",'+
+'          "valid_from" : "0001-01-01 04:56:02",'+
+'          "city" : "San Francisco",'+
+'          "district_type" : "LOCAL"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca/county:san francisco",'+
+'          "data" : { },'+
+'          "id" : 2253,'+
+'          "last_update_date" : "2012-03-18 07:46:31",'+
+'          "num_officials" : 0,'+
+'          "state" : "CA",'+
+'          "subtype" : "COUNTY",'+
+'          "sk" : 2253,'+
+'          "label" : "San Francisco city",'+
+'          "valid_to" : null,'+
+'          "district_id" : "AT LARGE",'+
+'          "country" : "US",'+
+'          "valid_from" : "0001-01-01 04:56:02",'+
+'          "city" : "San Francisco",'+
+'          "district_type" : "LOCAL"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca11",'+
+'          "data" : { },'+
+'          "id" : 383744,'+
+'          "last_update_date" : "2012-03-23 15:06:30",'+
+'          "num_officials" : 0,'+
+'          "state" : "CA",'+
+'          "subtype" : "UPPER",'+
+'          "sk" : 383744,'+
+'          "label" : "",'+
+'          "valid_to" : null,'+
+'          "district_id" : "11",'+
+'          "country" : "US",'+
+'          "valid_from" : "2012-03-26 21:14:08.201488",'+
+'          "city" : "",'+
+'          "district_type" : "STATE_UPPER_REDISTRICTED"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca17",'+
+'          "data" : { },'+
+'          "id" : 385724,'+
+'          "last_update_date" : "2012-03-22 15:22:42",'+
+'          "num_officials" : 0,'+
+'          "state" : "CA",'+
+'          "subtype" : "LOWER",'+
+'          "sk" : 385724,'+
+'          "label" : "",'+
+'          "valid_to" : null,'+
+'          "district_id" : "17",'+
+'          "country" : "US",'+
+'          "valid_from" : "2012-03-26 21:18:41.419987",'+
+'          "city" : "",'+
+'          "district_type" : "STATE_LOWER_REDISTRICTED"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca12",'+
+'          "data" : { },'+
+'          "id" : 388478,'+
+'          "last_update_date" : "2012-03-26 21:44:46",'+
+'          "num_officials" : 0,'+
+'          "state" : "CA",'+
+'          "subtype" : "LOWER",'+
+'          "sk" : 388478,'+
+'          "label" : "",'+
+'          "valid_to" : null,'+
+'          "district_id" : "12",'+
+'          "country" : "US",'+
+'          "valid_from" : "2012-03-26 21:56:48.256155",'+
+'          "city" : "",'+
+'          "district_type" : "NATIONAL_LOWER_REDISTRICTED"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca6",'+
+'          "data" : { },'+
+'          "id" : 393743,'+
+'          "last_update_date" : "2012-05-09 00:00:00",'+
+'          "num_officials" : 0,'+
+'          "state" : "CA",'+
+'          "subtype" : "CITY",'+
+'          "sk" : 393743,'+
+'          "label" : "",'+
+'          "valid_to" : null,'+
+'          "district_id" : "6",'+
+'          "country" : "US",'+
+'          "valid_from" : "2012-05-09 00:00:00",'+
+'          "city" : "SAN FRANCISCO",'+
+'          "district_type" : "LOCAL_REDISTRICTED"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca/sldl:17",'+
+'          "data" : { },'+
+'          "id" : 752693,'+
+'          "last_update_date" : "2012-11-12 00:00:00",'+
+'          "num_officials" : 1,'+
+'          "state" : "CA",'+
+'          "subtype" : "LOWER",'+
+'          "sk" : 752693,'+
+'          "label" : "California Assembly district 17",'+
+'          "valid_to" : "2022-12-05 00:00:00",'+
+'          "district_id" : "17",'+
+'          "country" : "US",'+
+'          "valid_from" : "2012-12-03 00:00:00",'+
+'          "city" : "",'+
+'          "district_type" : "STATE_LOWER"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca/sldu:11",'+
+'          "data" : { },'+
+'          "id" : 752749,'+
+'          "last_update_date" : "2012-11-12 00:00:00",'+
+'          "num_officials" : 1,'+
+'          "state" : "CA",'+
+'          "subtype" : "UPPER",'+
+'          "sk" : 752749,'+
+'          "label" : "California State Senate district 11",'+
+'          "valid_to" : "2022-12-05 00:00:00",'+
+'          "district_id" : "11",'+
+'          "country" : "US",'+
+'          "valid_from" : "2012-12-03 00:00:00",'+
+'          "city" : "",'+
+'          "district_type" : "STATE_UPPER"'+
+'        }, {'+
+'          "ocd_id" : "ocd-division/country:us/state:ca/cd:12",'+
+'          "data" : { },'+
+'          "id" : 757216,'+
+'          "last_update_date" : "2012-11-30 00:00:00",'+
+'          "num_officials" : 1,'+
+'          "state" : "CA",'+
+'          "subtype" : "LOWER",'+
+'          "sk" : 757216,'+
+'          "label" : "California\'s 12th congressional district",'+
+'          "valid_to" : "2023-01-03 00:00:00",'+
+'          "district_id" : "12",'+
+'          "country" : "US",'+
+'          "valid_from" : "2013-01-03 00:00:00",'+
+'          "city" : "",'+
+'          "district_type" : "NATIONAL_LOWER"'+
+'        } ],'+
+'        "match_country" : "US",'+
+'        "wkid" : 4326,'+
+'        "match_postal" : "94105",'+
+'        "count" : {'+
+'          "from" : 0,'+
+'          "total" : 13,'+
+'          "to" : 12'+
+'        }'+
+'      } ]'+
+'    },'+
+'    "messages" : [ ],'+
+'    "errors" : [ ]'+
+'  }'+
+'}';
     
     /*********************************************************************************************************
     * @description returns the HTTP Response from the HTTP Request for Cicero.
@@ -207,10 +307,10 @@ public with sharing class ADDR_Cicero_TEST {
 
         list<Address__c> listAddr = new list<Address__c>();
         Address__c addr = new Address__c();
-        addr.MailingStreet__c = '2623 134 ave ne, #2';
-        addr.MailingCity__c = 'bellevue';
-        addr.MailingState__c = 'wa';
-        addr.MailingPostalCode__c = '98005';
+        addr.MailingStreet__c = '1 market st #300';
+        addr.MailingCity__c = 'san francisco';
+        addr.MailingState__c = 'ca';
+        addr.MailingPostalCode__c = '94105-1234';
         listAddr.add(addr);
         
         ADDR_Cicero_Validator cicero = new ADDR_Cicero_Validator();
@@ -221,11 +321,12 @@ public with sharing class ADDR_Cicero_TEST {
         system.assertEquals(1, listAddrVerified.size());
         //system.assertNotEquals(null, listAddrVerified[0].Pre_Verification_Address__c);
         system.assertEquals(true, listAddrVerified[0].Verified__c);
-        system.assertEquals('2623 134th Ave NE, #2', listAddrVerified[0].MailingStreet__c);
-        system.assertEquals('Bellevue', listAddrVerified[0].MailingCity__c);
-        system.assertEquals('Washington', listAddrVerified[0].MailingState__c);
-        system.assertEquals('48', listAddrVerified[0].State_Lower_District__c);
-        system.assertEquals('48', listAddrVerified[0].State_Upper_District__c);
+        system.assertEquals('1 Market St #300', listAddrVerified[0].MailingStreet__c);
+        system.assertEquals('San Francisco', listAddrVerified[0].MailingCity__c);
+        system.assertEquals('CA', listAddrVerified[0].MailingState__c);
+        system.assertEquals('94105-1234', listAddrVerified[0].MailingPostalCode__c);
+        system.assertEquals('17', listAddrVerified[0].State_Lower_District__c);
+        system.assertEquals('11', listAddrVerified[0].State_Upper_District__c);
 
 	}
 

--- a/src/classes/ADDR_Cicero_Validator.cls
+++ b/src/classes/ADDR_Cicero_Validator.cls
@@ -180,6 +180,8 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
                     // more than one candidate means should mark as ambiguous
                     if (listCandidates.size() > 1) {
                         addr.Ambiguous__c = true;
+                    } else {
+                        addr.Ambiguous__c = false;
                     }
                     // find the congressional legislative district
                     if (listCandidates.size() == 1 || (listCandidates.size() > 1 && !settings.Reject_Ambiguous_Addresses__c)) {

--- a/src/classes/ADDR_Cicero_Validator.cls
+++ b/src/classes/ADDR_Cicero_Validator.cls
@@ -112,7 +112,7 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
     private Address__c verifyAddress(Address__c addr, Addr_Verification_Settings__c settings) {
     
         String strRequest = '?';
-        String subpremise = '';
+        String lastFourPostalDigits;
 
         //replacing formula with actual fields, as formula was null for tests
         String mailingAddress = '';
@@ -120,23 +120,21 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
             mailingAddress += addr.MailingStreet__c.trim();
         if (addr.MailingStreet2__c!=null)
             mailingAddress += ' ' + addr.MailingStreet2__c.trim();
-
-        if (mailingAddress!='') {
-            //if our address has a comma, split it off and append it after verification
-            if (mailingAddress.contains(',')) {
-                list<string> split = mailingAddress.split(',',2);
-                strRequest += 'search_address=' + EncodingUtil.urlEncode(split[0],'UTF-8') + '&';
-                subpremise = split[1];
-            } else {
-                strRequest += 'search_address=' + EncodingUtil.urlEncode(mailingAddress,'UTF-8') + '&';
-            }
-        }
+        if (mailingAddress!='')
+            strRequest += 'search_address=' + EncodingUtil.urlEncode(mailingAddress,'UTF-8') + '&';
         if (addr.MailingCity__c != null)
             strRequest += 'search_city=' + EncodingUtil.urlEncode(addr.MailingCity__c,'UTF-8') + '&';
         if (addr.MailingState__c != null)
             strRequest += 'search_state=' + EncodingUtil.urlEncode(addr.MailingState__c,'UTF-8') + '&';
-        if (addr.MailingPostalCode__c != null)
-            strRequest += 'search_postal=' + EncodingUtil.urlEncode(addr.MailingPostalCode__c,'UTF-8') + '&';
+        if (addr.MailingPostalCode__c != null) {
+            if (addr.MailingPostalCode__c.contains('-')) {
+                List<String> splitPostal = addr.MailingPostalCode__c.split('-');
+                lastFourPostalDigits = splitPostal[1];
+                strRequest += 'search_postal=' + EncodingUtil.urlEncode(splitPostal[0],'UTF-8') + '&';
+            } else {
+                strRequest += 'search_postal=' + EncodingUtil.urlEncode(addr.MailingPostalCode__c,'UTF-8') + '&';
+            }
+        }
         if (addr.MailingCountry__c != null)
             strRequest += 'search_country=' + EncodingUtil.urlEncode(addr.MailingCountry__c,'UTF-8') + '&';
 
@@ -200,22 +198,20 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
                                 addr.State_Lower_District__c = district.district_id;
                         }
                     
-                        // parse match_addr to get normalized form
-                        // we assume it looks like 'street, city, state, zip'
-                        list<string> listParts = candidate.match_addr.split(',');
-                        if (listParts.size() == 4) {
-                            addr.MailingStreet__c = listParts[0].trim();
-                            if (subpremise!='')
-                                addr.MailingStreet__c+=',' + subpremise;
-                            ADDR_Addresses_TDTM.handleMultilineStreet(addr);
-                            addr.MailingCity__c = listParts[1].trim();
-                            addr.MailingState__c = listParts[2].trim();
-                            addr.MailingPostalCode__c = listParts[3].trim();
+                        addr.MailingStreet__c = candidate.match_addr.split(',')[0].trim();
+                        addr.MailingCity__c = candidate.match_city;
+                        addr.MailingState__c = candidate.match_region;
+                        addr.MailingPostalCode__c = candidate.match_postal;
+                        if (!String.isBlank(lastFourPostalDigits)) {
+                            addr.MailingPostalCode__c += '-' + lastFourPostalDigits;
                         }
+                        addr.County_Name__c  = candidate.match_subregion;
+
+                        ADDR_Addresses_TDTM.handleMultilineStreet(addr);
                     
-                    // save location
-                    addr.Geolocation__Latitude__s = decimal.valueOf(candidate.y);
-                    addr.Geolocation__Longitude__s = decimal.valueOf(candidate.x);
+                        // save location
+                        addr.Geolocation__Latitude__s = decimal.valueOf(candidate.y);
+                        addr.Geolocation__Longitude__s = decimal.valueOf(candidate.x);
                     }
                 }   
                 addr.Verified__c = foundData;
@@ -280,7 +276,7 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
         /** @description county of the matched address -- the upstream geocoder is very spotty with populating this and it is not reliable; may be used more for addresses outside the U.S. */        
         public string match_subregion; 
 
-        /** @description state of the matched address - doesn't seem to be part of the response, even though I was told it would be. */
+        /** @description state of the matched address */
         public string match_region; 
         
         /** @description country of the matched address. seems to be UN 3 character code, so I left getting country 2 digit ISO code from district. */        


### PR DESCRIPTION
# Critical Changes
- An update to the Cicero API caused that address validation service to malfunction in NPSP. Cicero users should disable NPSP Address Verification until NPSP 3.92 is installed to avoid any issues.

# Changes

# Issues Closed
- Fixed #2439
- Fixed #2508