### PR TITLE
Feature/bdi unique id fix

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -12,6 +12,9 @@ project:
         default_branch: dev
         prefix_beta: uat/
         prefix_release: rel/
+    apexdoc:
+        homepage: ApexDocContent/homepage.htm
+        banner: ApexDocContent/projectheader.htm
     dependencies:
         - namespace: npo02
           version: 3.7

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -953,6 +953,9 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
         // we need the Contact CustomId key to always be checked second when matching
         string strUniqueId = '';
         if (isCustomIDInContactMatchRules && (strUniqueId = strNull(con.get(diSettings.Contact_Custom_Unique_ID__c))) != '') {
+            if (!isCustomIdInContactDatatypeString) {
+                strUniqueId = string.valueOf(double.valueOf(strUniqueId));
+            }
             listDiKey.add(strUniqueId);
         }
 
@@ -1071,6 +1074,9 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
 
         // we need the Contact CustomId key to always be checked second when matching
         if (isCustomIDInContactMatchRules && (strUniqueId = strNull(di.get(strDIContactCustomIDField(strCx)))) != '') {
+            if (!isCustomIdInContactDatatypeString) {
+                strUniqueId = string.valueOf(double.valueOf(strUniqueId));
+            }
             listDiKey.add(strUniqueId);
         }
                 
@@ -1354,6 +1360,9 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
         // we need the Account CustomId key to always be checked second when matching
         string strUniqueId = ''; 
         if (isCustomIDInAccountMatchRules && (strUniqueId = strNull(acc.get(diSettings.Account_Custom_Unique_ID__c))) != '') {
+            if (!isCustomIdInAccountDatatypeString) {
+                strUniqueId = string.valueOf(double.valueOf(strUniqueId));
+            }
             listDiKey.add(strUniqueId);
         }
 
@@ -1381,6 +1390,9 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
 
         // we need the Account CustomId key to always be checked second when matching
         if (isCustomIDInAccountMatchRules && (strUniqueId = strNull(di.get(strDIAccountCustomIDField(strAx)))) != '') {
+            if (!isCustomIdInAccountDatatypeString) {
+                strUniqueId = string.valueOf(double.valueOf(strUniqueId));
+            }
             listDiKey.add(strUniqueId);
         }
 


### PR DESCRIPTION
In Batch Data Import, the user can have us match by an external unique ID for contacts and accounts.  The datatype of this field can be either a string or a number.  Unfortunately, we had a bug where if it was a number, we were not consistently handling how we coerce them to strings for BDI key mapping.  So when we read the numeric field from an existing contact that had 1 stored in its numeric Unique ID, we'd get back 1 from the soql, and '1' is what was stored in the key.  But when we were reading from our DI record, even though the field was also numeric, it was coming back as 1.0, and '1.0' was stored in the key. So now we force always storing numbers as doubles, which causes them to consistently include the decimal and zero.  Exact same issue for Accounts.

Unfortunately, I cannot write tests to show this problem and prove the fix.  The current tests dealing with our external unique id matching has to use existing fields on contact and the DI record (and similarly Account and the Di record), since we can't create temporary fields in a test.  The DI record does not contain any numeric fields, only text ones. 

# Critical Changes

# Changes

# Issues Closed
fixed #2517 