### PR TITLE
2567: send-acknowledgment-btn-not-gracefully-handling-errors

### DIFF
--- a/src/classes/OPP_SendAcknowledgmentBTN_CTRL.cls
+++ b/src/classes/OPP_SendAcknowledgmentBTN_CTRL.cls
@@ -131,7 +131,6 @@ public with sharing class OPP_SendAcknowledgmentBTN_CTRL {
         for (Opportunity opp : listOpp) {
             opp.Acknowledgment_Status__c = label.sendAcknowledgmentFireStatus;
         }
-        cNotSent = listOpp.size();
 
         try {
             update listOpp;
@@ -168,6 +167,7 @@ public with sharing class OPP_SendAcknowledgmentBTN_CTRL {
             // Since none of the records were sent, update the listOppNotSent collection
             // to contain a list of all the records that would have been processed.
             listOppNotSent = [select Id, Name from Opportunity where id in :listOpp];
+            cNotSent = listOppNotSent.size();
 
             // Make the error look more readable on the page
             ERR_ExceptionHandler.beautifyExceptionMessage(ex);

--- a/src/classes/OPP_SendAcknowledgmentBTN_CTRL.cls
+++ b/src/classes/OPP_SendAcknowledgmentBTN_CTRL.cls
@@ -131,7 +131,8 @@ public with sharing class OPP_SendAcknowledgmentBTN_CTRL {
         for (Opportunity opp : listOpp) {
             opp.Acknowledgment_Status__c = label.sendAcknowledgmentFireStatus;
         }
-                
+        cNotSent = listOpp.size();
+
         try {
             update listOpp;
             
@@ -164,6 +165,16 @@ public with sharing class OPP_SendAcknowledgmentBTN_CTRL {
             
             return null;
         } catch (Exception ex) {
+            // Since none of the records were sent, update the listOppNotSent collection
+            // to contain a list of all the records that would have been processed.
+            listOppNotSent = [select Id, Name from Opportunity where 
+                id in :listOpp];
+            for (Opportunity opp : listOppNotSent) {
+                opp.Acknowledgment_Status__c = label.sendAcknowledgmentFireStatus;
+            }
+
+            // Make the error look more readable on the page
+            ERR_ExceptionHandler.beautifyExceptionMessage(ex);
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, ex.getMessage()));
             return null;
         }

--- a/src/classes/OPP_SendAcknowledgmentBTN_CTRL.cls
+++ b/src/classes/OPP_SendAcknowledgmentBTN_CTRL.cls
@@ -167,11 +167,7 @@ public with sharing class OPP_SendAcknowledgmentBTN_CTRL {
         } catch (Exception ex) {
             // Since none of the records were sent, update the listOppNotSent collection
             // to contain a list of all the records that would have been processed.
-            listOppNotSent = [select Id, Name from Opportunity where 
-                id in :listOpp];
-            for (Opportunity opp : listOppNotSent) {
-                opp.Acknowledgment_Status__c = label.sendAcknowledgmentFireStatus;
-            }
+            listOppNotSent = [select Id, Name from Opportunity where id in :listOpp];
 
             // Make the error look more readable on the page
             ERR_ExceptionHandler.beautifyExceptionMessage(ex);


### PR DESCRIPTION
Init the cNotSent var to avoid a null reference in VF; Modify the catch block to display a cleaner error and list the Opportunities not acknowledged.

# Critical Changes

# Changes

# Issues Closed

Fixed #2567 