### PR TITLE
2521: Manage Allocations bug with commas and other symbols in the numeric field

### DIFF
--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -269,7 +269,7 @@ public with sharing class ALLO_ManageAllocations_CTRL {
     public static Double sumAmountFields(List<String> amts, List<String> pcts, Decimal parentAmount) {
         Double rtnValue = 0;
         if (amts != null) {
-            Boolean commaSeparator = (1.5).format().contains(',');
+            Boolean commaSeparator = (1.5).format().contains(','); // is this a comma separator for the decimal point?
             for (Integer i=0; i<amts.size(); i++) {
                 String a = amts[i];
                 if (commaSeparator) {
@@ -280,7 +280,7 @@ public with sharing class ALLO_ManageAllocations_CTRL {
                         // it out.
                         if (a.right(3).startsWith('.')) {
                             // If there is a decimal point in the 3rd position from the
-                            // right, then let's assume this is in US format.
+                            // right, then let's assume this is in US format (many other countries use this too)
                             // In that case, change the period to a comma so that
                             // it can be converted to a number below.
                             a = a.replaceAll('.',',');

--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -255,12 +255,56 @@ public with sharing class ALLO_ManageAllocations_CTRL {
         return source;
     }
 
-    /** @description Returns a dummy Allocation__c record with the amount field set to 1000 to use a way of
-      * retrieving a formatted currency value with the users current locale setting. This is needed to 
-      * determine the thousands separator in the page javascript 
-      * @return SObject with the Amount__c field set to 1000.
+    /** @description Used to handle properly converting and summing the amount fields on the page 
+      * taking into account the users current locale setting. Found that this could not be done
+      * reliably in JS, thus the need to handle via VF Remoting. Passing in the array of percents
+      * and the parent amount as well to handle the scenario where a) the user types in a percent
+      * on the screen and the amount is formatted using JS, but not in a way that exactly matches
+      * the locale Salesforce in Salesforce. In that case, have to reformat the % value to
+      * something that matches the current local; b) the amount value is "NaN" and has to be
+      * recalculated using the passed % value.
+      * @return Double value sum of the entere values (multiplied by 100)
      */
-    public Allocation__c getDummyAllocForFormatting() {
-        return new Allocation__c(Amount__c = 1000); 
+    @remoteAction
+    public static Double sumAmountFields(List<String> amts, List<String> pcts, Decimal parentAmount) {
+        Double rtnValue = 0;
+        if (amts != null) {
+            Boolean commaSeparator = (1.5).format().contains(',');
+            for (Integer i=0; i<amts.size(); i++) {
+                String a = amts[i];
+                if (commaSeparator) {
+                    if (!String.IsEmpty(pcts[i])) {
+                        // If there is a percentage on this line, then it's likely that
+                        // the amount field is formatted in standard US format (####.##).
+                        // This isn't always the case though, so have to try to figure 
+                        // it out.
+                        if (a.right(3).startsWith('.')) {
+                            // If there is a decimal point in the 3rd position from the
+                            // right, then let's assume this is in US format.
+                            // In that case, change the period to a comma so that
+                            // it can be converted to a number below.
+                            a = a.replaceAll('.',',');
+                        } else if (a == 'NaN') {
+                            // if the string is "NaN" (not-a-number in JS) then recalcuate
+                            // the percentage here
+                            a = (Math.round( Integer.valueOf(pcts[i].replaceAll(',','.')) * (parentAmount*100)) / 100).format();
+                        }
+                    }
+                    a = a.replaceAll('[^,\\d]','').replaceAll(',','.'); // remove any non-numeric characters and convert the comma to a period
+                } else {
+                    a = a.replaceAll(',',''); // remove any commas
+                }
+                try {
+                    rtnValue += Double.valueOf(a)*100;
+                } catch (Exception ex) {
+                    // if this fails, then the string can't be converted to a number
+                    // in the new format. In that case, it's likely that the string
+                    // is formatted differently than the users locale. So
+                    // give it one more try without stripping out any characters
+                    rtnValue += Double.valueOf(amts[i])*100;
+                }
+            }
+        }
+        return rtnValue;
     }
 }

--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -255,56 +255,14 @@ public with sharing class ALLO_ManageAllocations_CTRL {
         return source;
     }
 
-    /** @description Used to handle properly converting and summing the amount fields on the page 
-      * taking into account the users current locale setting. Found that this could not be done
-      * reliably in JS, thus the need to handle via VF Remoting. Passing in the array of percents
-      * and the parent amount as well to handle the scenario where a) the user types in a percent
-      * on the screen and the amount is formatted using JS, but not in a way that exactly matches
-      * the locale Salesforce in Salesforce. In that case, have to reformat the % value to
-      * something that matches the current local; b) the amount value is "NaN" and has to be
-      * recalculated using the passed % value.
-      * @return Double value sum of the entere values (multiplied by 100)
-     */
-    @remoteAction
-    public static Double sumAmountFields(List<String> amts, List<String> pcts, Decimal parentAmount) {
-        Double rtnValue = 0;
-        if (amts != null) {
-            Boolean commaSeparator = (1.5).format().contains(','); // is this a comma separator for the decimal point?
-            for (Integer i=0; i<amts.size(); i++) {
-                String a = amts[i];
-                if (commaSeparator) {
-                    if (!String.IsEmpty(pcts[i])) {
-                        // If there is a percentage on this line, then it's likely that
-                        // the amount field is formatted in standard US format (####.##).
-                        // This isn't always the case though, so have to try to figure 
-                        // it out.
-                        if (a.right(3).startsWith('.')) {
-                            // If there is a decimal point in the 3rd position from the
-                            // right, then let's assume this is in US format (many other countries use this too)
-                            // In that case, change the period to a comma so that
-                            // it can be converted to a number below.
-                            a = a.replaceAll('.',',');
-                        } else if (a == 'NaN') {
-                            // if the string is "NaN" (not-a-number in JS) then recalcuate
-                            // the percentage here
-                            a = (Math.round( Integer.valueOf(pcts[i].replaceAll(',','.')) * (parentAmount*100)) / 100).format();
-                        }
-                    }
-                    a = a.replaceAll('[^,\\d]','').replaceAll(',','.'); // remove any non-numeric characters and convert the comma to a period
-                } else {
-                    a = a.replaceAll(',',''); // remove any commas
-                }
-                try {
-                    rtnValue += Double.valueOf(a)*100;
-                } catch (Exception ex) {
-                    // if this fails, then the string can't be converted to a number
-                    // in the new format. In that case, it's likely that the string
-                    // is formatted differently than the users locale. So
-                    // give it one more try without stripping out any characters
-                    rtnValue += Double.valueOf(amts[i])*100;
-                }
-            }
-        }
-        return rtnValue;
+    /** @description Returns the decimal separator character in use for the Users current Locale setting */
+    public String getDecimalSeparator() {
+        return (1.5).format().subString(1,2);
     }
+
+    /** @description Returns the thousands separator character in use for the Users current Locale setting */
+    public String getThousandsSeparator() {
+        return (1000).format().subString(1,2);
+    }
+
 }

--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -254,4 +254,13 @@ public with sharing class ALLO_ManageAllocations_CTRL {
         pageReference source = new pageReference('/'+parentId);
         return source;
     }
+
+    /** @description Returns a dummy Allocation__c record with the amount field set to 1000 to use a way of
+      * retrieving a formatted currency value with the users current locale setting. This is needed to 
+      * determine the thousands separator in the page javascript 
+      * @return SObject with the Amount__c field set to 1000.
+     */
+    public Allocation__c getDummyAllocForFormatting() {
+        return new Allocation__c(Amount__c = 1000); 
+    }
 }

--- a/src/classes/ALLO_ManageAllocations_TEST.cls
+++ b/src/classes/ALLO_ManageAllocations_TEST.cls
@@ -251,11 +251,11 @@ private class ALLO_ManageAllocations_TEST {
         );
     }
 
-    /** @description test the VF remoting method */
+    /** @description test the methods to retreive the currency separator characters */
     @isTest
-    private static void testRemoteAction() {
-        Double amt = 1000.23;
-        Double rtn = ALLO_ManageAllocations_CTRL.sumAmountFields(new List<String>{ '1,000.23' }, new List<String>{ '' }, amt);
-        System.AssertEquals(amt, rtn/100, 'The sum of the amount should return ' + (amt*100).format() + ' not ' + rtn.format());
+    private static void testGetSeparators() {
+        ALLO_ManageAllocations_CTRL controller = new ALLO_ManageAllocations_CTRL();
+        system.AssertNotEquals(null, controller.getDecimalSeparator());
+        system.AssertNotEquals(null, controller.getThousandsSeparator());
     }
 }

--- a/src/classes/ALLO_ManageAllocations_TEST.cls
+++ b/src/classes/ALLO_ManageAllocations_TEST.cls
@@ -250,4 +250,12 @@ private class ALLO_ManageAllocations_TEST {
             controller.getCurrencySymbol()
         );
     }
+
+    /** @description test the VF remoting method */
+    @isTest
+    private static void testRemoteAction() {
+        Double amt = 1000.23;
+        Double rtn = ALLO_ManageAllocations_CTRL.sumAmountFields(new List<String>{ '1,000.23' }, new List<String>{ '' }, amt);
+        System.AssertEquals(amt, rtn/100, 'The sum of the amount should return ' + (amt*100).format() + ' not ' + rtn.format());
+    }
 }

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -10,6 +10,8 @@
         var sumAmount;
         
         var parentAmount = {!parentAmount};
+        var decimalSeparator = "{!decimalSeparator}";
+        var thousandsSeparator = "{!thousandsSeparator}";
         var defaultEnabled = {!Settings.Default_Allocations_Enabled__c};
 
         function isLightningExperienceOrSalesforce1() {
@@ -26,8 +28,7 @@
 
         //adds all amount fields together
         var calcAmount = function() {
-            var amts = [];
-            var pcts = [];
+            sumAmount = 0;
             $('.alloAmount').each(function(i,o){
                 var thisRowAmount = $('.amount'+i);
                 var thisRowPercent = $('.percent'+i);
@@ -45,39 +46,38 @@
                     if (isBlankOrEmpty(thisRowPercent)) {
                         thisRowPercent.prop('disabled', true);
                     }
-                    amts.push(thisRowAmount.val());
-                    pcts.push(thisRowPercent.val());
                 }
+
+                // create a regex expression to remove the thousands separator from the string
+                var re = new RegExp("\\"+thousandsSeparator,"g");
+                // remove all currency symbols, whitespace characters and thousands separators from the string
+                // before attempting to convert it to a numeric value
+                var cleanedAmt = amt=thisRowAmount.val().replace(/[\$£€]/g, '').replace(/\s/g,'').replace(re,'');
+                if (decimalSeparator !== ".") {
+                    // JS does not recognize decimal separators other than a period
+                    re = new RegExp("\\"+decimalSeparator,"g");
+                    cleanedAmt = cleanedAmt.replace(re,'');
+                }
+                if (!isNaN(cleanedAmt)) {
+                    sumAmount += Math.round(cleanedAmt*100);
+                }
+
             });
 
-            // Use VF remoting to handle summing the amount field values to ensure that the amount
-            // input string values are properly converted to a number using the current user's
-            // locale setting in Salesforce.
-            if (amts.length > 0) {
-                Visualforce.remoting.Manager.invokeAction(
-                    '{!$RemoteAction.ALLO_ManageAllocations_CTRL.sumAmountFields}', amts, pcts, parentAmount,
-                    function (result, event) {
-                        sumAmount = result;
-                        //write total amount. if we have a parent amount, include the unallocated remainder. 
-                        //if we're over the parent amount, make it red.
-                        if (parentAmount > 0) {
-                            var unallocated = (Math.round((parentAmount*100) - sumAmount)/100).toFixed(2);
-                            $('#totalAmount').text(unallocated);
-                            if (unallocated < 0) {
-                                $('#totalAmount').css({ "color": "red", "font-weight": "bold" });
-                                $('[id$="saveCloseBTN"]').attr('disabled','disabled');
-                            } else {
-                                $('#totalAmount').css({ "color": "black", "font-weight": "normal" });
-                                $('[id$="saveCloseBTN"]').removeAttr('disabled');
-                            }
-                        } else {
-                            $('#totalAmount').text((Math.round(sumAmount)/100).toFixed(2));
-                        }
-                    }
-                );
+            //write total amount. if we have a parent amount, include the unallocated remainder. 
+            //if we're over the parent amount, make it red.
+            if (parentAmount > 0) {
+                var unallocated = (Math.round((parentAmount*100) - sumAmount)/100).toFixed(2);
+                $('#totalAmount').text(unallocated);
+                if (unallocated < 0) {
+                    $('#totalAmount').css({ "color": "red", "font-weight": "bold" });
+                    $('[id$="saveCloseBTN"]').attr('disabled','disabled');
+                } else {
+                    $('#totalAmount').css({ "color": "black", "font-weight": "normal" });
+                    $('[id$="saveCloseBTN"]').removeAttr('disabled');
+                }
             } else {
-                $('#totalAmount').text(Math.round((parentAmount*100)/100).toFixed(2));
-                $('[id$="saveCloseBTN"]').attr('disabled','disabled');
+                $('#totalAmount').text((Math.round(sumAmount)/100).toFixed(2));
             }
             
         }
@@ -97,10 +97,14 @@
                     thisRowAmount.prop('disabled', true);
                     //if we have a parent amount, set the calculated amount based on the percent
                     if (parentAmount > 0) {
+                        var pct = thisRowPercent.val();
                         // if the users locale uses commas as the decimal separator, replace
                         // those with a period so it works with js. don't have to worry about
                         // the thousands separator for percentages.
-                        var pct = thisRowPercent.val().replace(/\s/g,'').replace(/,/g,'.');
+                        if (decimalSeparator !== ".") {
+                            var re = new RegExp("\\"+decimalSeparator,"g");
+                            pct = pct.replace(/\s/g,'').replace(re,'.');
+                        }
                         var amt = (Math.round(pct * parentAmount)/100).toFixed(2);
                         if (amt !== 'NaN') {
                             thisRowAmount.val(amt);

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -26,7 +26,8 @@
 
         //adds all amount fields together
         var calcAmount = function() {
-            sumAmount = 0;
+            var amts = [];
+            var pcts = [];
             $('.alloAmount').each(function(i,o){
                 var thisRowAmount = $('.amount'+i);
                 var thisRowPercent = $('.percent'+i);
@@ -44,33 +45,39 @@
                     if (isBlankOrEmpty(thisRowPercent)) {
                         thisRowPercent.prop('disabled', true);
                     }
-                }
-                // determine the User's current thousands separator to strip out of the string
-                var thousandsSeparator = whatSeparator();
-                // create a regex expression to remove the thousands separator from the string
-                var re = new RegExp("\\"+thousandsSeparator,"g");
-                // remove all currency symbols, whitespace characters and thousands separators from the string
-                // before attempting to convert it to a numeric value
-                var cleanedAmt = amt=$(o).val().replace(/[\$£€]/g, '').replace(/\s/g,'').replace(re,'');
-                if (!isNaN(cleanedAmt)) {
-                    sumAmount += Math.round(cleanedAmt*100);
+                    amts.push(thisRowAmount.val());
+                    pcts.push(thisRowPercent.val());
                 }
             });
 
-            //write total amount. if we have a parent amount, include the unallocated remainder. 
-            //if we're over the parent amount, make it red.
-            if (parentAmount > 0) {
-                var unallocated = (Math.round((parentAmount*100) - sumAmount)/100).toFixed(2);
-                $('#totalAmount').text(unallocated);
-                if (unallocated < 0) {
-                    $('#totalAmount').css({ "color": "red", "font-weight": "bold" });
-                    $('[id$="saveCloseBTN"]').attr('disabled','disabled');
-                } else {
-                    $('#totalAmount').css({ "color": "black", "font-weight": "normal" });
-                    $('[id$="saveCloseBTN"]').removeAttr('disabled');
-                }
+            // Use VF remoting to handle summing the amount field values to ensure that the amount
+            // input string values are properly converted to a number using the current user's
+            // locale setting in Salesforce.
+            if (amts.length > 0) {
+                Visualforce.remoting.Manager.invokeAction(
+                    '{!$RemoteAction.ALLO_ManageAllocations_CTRL.sumAmountFields}', amts, pcts, parentAmount,
+                    function (result, event) {
+                        sumAmount = result;
+                        //write total amount. if we have a parent amount, include the unallocated remainder. 
+                        //if we're over the parent amount, make it red.
+                        if (parentAmount > 0) {
+                            var unallocated = (Math.round((parentAmount*100) - sumAmount)/100).toFixed(2);
+                            $('#totalAmount').text(unallocated);
+                            if (unallocated < 0) {
+                                $('#totalAmount').css({ "color": "red", "font-weight": "bold" });
+                                $('[id$="saveCloseBTN"]').attr('disabled','disabled');
+                            } else {
+                                $('#totalAmount').css({ "color": "black", "font-weight": "normal" });
+                                $('[id$="saveCloseBTN"]').removeAttr('disabled');
+                            }
+                        } else {
+                            $('#totalAmount').text((Math.round(sumAmount)/100).toFixed(2));
+                        }
+                    }
+                );
             } else {
-                $('#totalAmount').text((Math.round(sumAmount)/100).toFixed(2));
+                $('#totalAmount').text(Math.round((parentAmount*100)/100).toFixed(2));
+                $('[id$="saveCloseBTN"]').attr('disabled','disabled');
             }
             
         }
@@ -89,8 +96,12 @@
                 } else {
                     thisRowAmount.prop('disabled', true);
                     //if we have a parent amount, set the calculated amount based on the percent
-                    if (parentAmount > 0)
-                        thisRowAmount.val((Math.round(thisRowPercent.val() * parentAmount)/100).toFixed(2));
+                    if (parentAmount > 0) {
+                        var amt = (Math.round(thisRowPercent.val() * parentAmount)/100).toFixed(2);
+                        if (amt !== 'NaN') {
+                            thisRowAmount.val(amt);
+                        }
+                    }
                 }
             });
             
@@ -112,18 +123,6 @@
         var initOrReload = function() {
             calcPercent();
             calcAmount();
-        }
-
-        // determine the thousands separator by using Salesforce's currency locale settings format an 
-        // sobject field into a hidden div and then retrieve and parse that string out here.
-        var whatSeparator = function() {
-            var formattedNumber = $("#dummyFormattedCurrency").text().trim().replace(/\s/g,'');
-            if (formattedNumber) {
-                var oneIsAt = formattedNumber.indexOf("1");
-                return formattedNumber.substring(oneIsAt+1, oneIsAt+2);
-            } else {
-                return ","; // default value
-            }
         }
 
         //bind functions to window that are needed in the page
@@ -251,7 +250,4 @@
             </div>
         </div>
     </apex:form>
-    <div style="display:none" id="dummyFormattedCurrency">
-        <apex:outputField value="{!dummyAllocForFormatting.Amount__c}" />
-    </div>
 </apex:page>

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -56,7 +56,7 @@
                 if (decimalSeparator !== ".") {
                     // JS does not recognize decimal separators other than a period
                     re = new RegExp("\\"+decimalSeparator,"g");
-                    cleanedAmt = cleanedAmt.replace(re,'');
+                    cleanedAmt = cleanedAmt.replace(re,'.');
                 }
                 if (!isNaN(cleanedAmt)) {
                     sumAmount += Math.round(cleanedAmt*100);

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -114,11 +114,16 @@
             calcAmount();
         }
 
-        //determine the thousands separator by using the machine/browswer current locale setting        
+        // determine the thousands separator by using Salesforce's currency locale settings format an 
+        // sobject field into a hidden div and then retrieve and parse that string out here.
         var whatSeparator = function() {
-            var n = 1000.1;
-            n = n.toLocaleString().substring(1, 2);
-            return n;
+            var formattedNumber = $("#dummyFormattedCurrency").text().trim().replace(/\s/g,'');
+            if (formattedNumber) {
+                var oneIsAt = formattedNumber.indexOf("1");
+                return formattedNumber.substring(oneIsAt+1, oneIsAt+2);
+            } else {
+                return ","; // default value
+            }
         }
 
         //bind functions to window that are needed in the page
@@ -246,4 +251,7 @@
             </div>
         </div>
     </apex:form>
+    <div style="display:none" id="dummyFormattedCurrency">
+        <apex:outputField value="{!dummyAllocForFormatting.Amount__c}" />
+    </div>
 </apex:page>

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -68,7 +68,7 @@
             //if we're over the parent amount, make it red.
             if (parentAmount > 0) {
                 var unallocated = (Math.round((parentAmount*100) - sumAmount)/100).toFixed(2);
-                $('#totalAmount').text(unallocated);
+                $('#totalAmount').text(reformatCurrency(unallocated));
                 if (unallocated < 0) {
                     $('#totalAmount').css({ "color": "red", "font-weight": "bold" });
                     $('[id$="saveCloseBTN"]').attr('disabled','disabled');
@@ -77,7 +77,7 @@
                     $('[id$="saveCloseBTN"]').removeAttr('disabled');
                 }
             } else {
-                $('#totalAmount').text((Math.round(sumAmount)/100).toFixed(2));
+                $('#totalAmount').text(reformatCurrency((Math.round(sumAmount)/100).toFixed(2)));
             }
             
         }
@@ -107,7 +107,7 @@
                         }
                         var amt = (Math.round(pct * parentAmount)/100).toFixed(2);
                         if (amt !== 'NaN') {
-                            thisRowAmount.val(amt);
+                            thisRowAmount.val(reformatCurrency(amt));
                         }
                     }
                 }
@@ -122,6 +122,13 @@
                 thisRowAmount.val('');
             }
             initOrReload();
+        }
+
+        var reformatCurrency = function(amt) {
+            if (decimalSeparator !== ".") {
+                amt = amt.replace(".",decimalSeparator);
+            }
+            return amt;
         }
 
         var isBlankOrEmpty = function (selector){

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -45,12 +45,16 @@
                         thisRowPercent.prop('disabled', true);
                     }
                 }
-                var amt=$(o).val();
-                // due to how chrome handle's the global replace, have to
-                // first remove the currency symbols first and then strip out all commas.
-                if (!isNaN(amt.replace(/[\$£€]/g, '').replace(/,/g, '')))
-                    sumAmount += Math.round(amt.replace(/[\$£€]/g, '').replace(/,/g, '')*100);
-
+                // determine the User's current thousands separator to strip out of the string
+                var thousandsSeparator = whatSeparator();
+                // create a regex expression to remove the thousands separator from the string
+                var re = new RegExp("\\"+thousandsSeparator,"g");
+                // remove all currency symbols, whitespace characters and thousands separators from the string
+                // before attempting to convert it to a numeric value
+                var cleanedAmt = amt=$(o).val().replace(/[\$£€]/g, '').replace(/\s/g,'').replace(re,'');
+                if (!isNaN(cleanedAmt)) {
+                    sumAmount += Math.round(cleanedAmt*100);
+                }
             });
 
             //write total amount. if we have a parent amount, include the unallocated remainder. 
@@ -109,7 +113,14 @@
             calcPercent();
             calcAmount();
         }
-        
+
+        //determine the thousands separator by using the machine/browswer current locale setting        
+        var whatSeparator = function() {
+            var n = 1000.1;
+            n = n.toLocaleString().substring(1, 2);
+            return n;
+        }
+
         //bind functions to window that are needed in the page
         window.initOrReload = initOrReload;
         window.changePercent = changePercent;

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -97,7 +97,11 @@
                     thisRowAmount.prop('disabled', true);
                     //if we have a parent amount, set the calculated amount based on the percent
                     if (parentAmount > 0) {
-                        var amt = (Math.round(thisRowPercent.val() * parentAmount)/100).toFixed(2);
+                        // if the users locale uses commas as the decimal separator, replace
+                        // those with a period so it works with js. don't have to worry about
+                        // the thousands separator for percentages.
+                        var pct = thisRowPercent.val().replace(/\s/g,'').replace(/,/g,'.');
+                        var amt = (Math.round(pct * parentAmount)/100).toFixed(2);
                         if (amt !== 'NaN') {
                             thisRowAmount.val(amt);
                         }

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -45,9 +45,12 @@
                         thisRowPercent.prop('disabled', true);
                     }
                 }
-                if (!isNaN($(o).val()))
-                    sumAmount += Math.round($(o).val()*100);
-               
+                var amt=$(o).val();
+                // due to how chrome handle's the global replace, have to
+                // first remove the currency symbols first and then strip out all commas.
+                if (!isNaN(amt.replace(/[\$£€]/g, '').replace(/,/g, '')))
+                    sumAmount += Math.round(amt.replace(/[\$£€]/g, '').replace(/,/g, '')*100);
+
             });
 
             //write total amount. if we have a parent amount, include the unallocated remainder. 


### PR DESCRIPTION
 Update the JS that calculates the amount values to strip out leading currency symbols and all commas from the string value

# Critical Changes

# Changes

# Issues Closed
Fixed #2521 