### PR TITLE
Display unexpected exception message for Delete Data Import buttons

### DIFF
--- a/src/classes/BDI_DataImportDeleteBTN_CTRL.cls
+++ b/src/classes/BDI_DataImportDeleteBTN_CTRL.cls
@@ -1,0 +1,104 @@
+/*
+    Copyright (c) 2017 Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @date 2017
+ * @group Batch Data Import
+ * @group-content ../../ApexDocContent/BatchDataImport.htm
+ * @description Controller for the Batch Data Import: Delete Data Import Records buttons' Visualforce page 
+ */
+
+public with sharing class BDI_DataImportDeleteBTN_CTRL {
+    /** @description Action type specified to delete imported Data Import records */
+    public static final String ACTION_DELETE_IMPORTED = 'deleteImported';
+
+    /** @description Action type specified to delete all Data Import records */
+    public static final String ACTION_DELETE_ALL = 'deleteAll';
+    
+    /** @description Controller constructor */
+    public BDI_DataImportDeleteBTN_CTRL() {}
+
+    /** 
+     * @description Delete all or imported only Data Import records based on the
+     * action provided in the Visualforce page 'action' parameter.
+     * @return PageReference Page specified in 'retURL' parameter or Home page
+     */
+    public PageReference buttonClick() {        
+        String actionType = ApexPages.currentPage().getParameters().get('action');
+
+        if (actionType == ACTION_DELETE_IMPORTED) {
+            return deleteDIRecords(false);    
+
+        } else if (actionType == ACTION_DELETE_ALL) {
+            return deleteDIRecords(true);    
+        }
+
+        String errMsg = String.isBlank(actionType)
+            ? 'Please specify an action type'
+            : actionType + ' is not a valid action type'; 
+
+        ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, errMsg)); 
+        return null;
+    }
+
+    /** 
+     * @description Delete Data Import records
+     * @param isDeleteAll If true, delete all Data Import records, otherwise delete imported records only
+     * @return PageReference Page specified in the 'retURL' parameter or Home page
+     */
+    PageReference deleteDIRecords(Boolean isDeleteAll) {
+        try {
+            if (isDeleteAll) {
+                delete [SELECT Id FROM DataImport__c LIMIT 10000];
+            } else {
+                delete [SELECT Id FROM DataImport__c WHERE Status__c = :label.bdiImported LIMIT 10000];
+            }
+
+            return close(); 
+
+        } catch (Exception e) {
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, e.getMessage())); 
+            return null; 
+        }
+    }
+
+    /** 
+     * @description Return either page specified in the 'retURL' parameter or Home page
+     * @return PageReference 
+     */
+    public PageReference close() {
+        String retUrl = ApexPages.currentPage().getParameters().get('retURL');
+        if (String.isBlank(retUrl)) retUrl = '/home/home.jsp';
+
+        PageReference p = new PageReference(retUrl);
+        p.setRedirect(true);
+        return p;
+    }
+}

--- a/src/classes/BDI_DataImportDeleteBTN_CTRL.cls-meta.xml
+++ b/src/classes/BDI_DataImportDeleteBTN_CTRL.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_DataImportDeleteBTN_CTRL.cls-meta.xml
+++ b/src/classes/BDI_DataImportDeleteBTN_CTRL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>39.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDI_DataImportDeleteBTN_TEST.cls
+++ b/src/classes/BDI_DataImportDeleteBTN_TEST.cls
@@ -280,9 +280,7 @@ class BDI_DataImportDeleteBTN_TEST {
      * @return PageReference
      */
     static PageReference clickButton(String actionType) {
-        if (String.isNotBlank(actionType)) {
-            ApexPages.currentPage().getParameters().put('action', actionType);
-        }
+        ApexPages.currentPage().getParameters().put('action', actionType);
 
         BDI_DataImportDeleteBTN_CTRL ctrl = new BDI_DataImportDeleteBTN_CTRL();
 

--- a/src/classes/BDI_DataImportDeleteBTN_TEST.cls
+++ b/src/classes/BDI_DataImportDeleteBTN_TEST.cls
@@ -1,0 +1,343 @@
+/*
+    Copyright (c) 2017 Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @date 2017
+ * @group Batch Data Import
+ * @group-content ../../ApexDocContent/BatchDataImport.htm
+ * @description Tests specific to the Delete Data Import Records buttons' user interface and error handling
+ */
+
+@isTest
+class BDI_DataImportDeleteBTN_TEST {
+
+    /**
+     * @description Specify '*' to run all tests, 
+     * otherwise, specify a test name to execute the specified test only
+     */
+    static String strTestOnly = '*';
+
+    /** @description Error message returned when user does not have Delete permission on the SObject */
+    static String INSUFFICIENT_ACCESS_ERROR_MSG = 'INSUFFICIENT_ACCESS_OR_READONLY';
+
+    /** @description Static method executed before each test method is run */
+    static {
+        Test.setCurrentPage(Page.BDI_DataImportDeleteBTN); 
+    }
+    
+    /**
+     * @description operation: 
+     *    Test an error message is displayed when a button is clicked and
+     *    the action type page parameter is not provided or is empty
+     * verify: 
+     *    - the error is displayed on the page
+     *    - no record is deleted
+     */
+    @isTest
+    static void TestErrorMessageDisplayWhenPageActionParameterIsNotProvided() {
+        if (isNotRunnable('TestErrorMessageDisplayWhenPageActionParameterIsNotProvided')) return;
+        
+        PageReference returnPage;
+        DataImport__c[] records = setUpData();
+        
+        Test.startTest();
+        
+        for (String actionType : new String[] { null, '', ' ' }) {
+            returnPage = clickButton(actionType);
+            
+            System.assertEquals(null, returnPage);
+            
+            UTIL_UnitTestData_TEST.assertPageHasError('Please specify an action type');
+            
+            assertExpectedRecordSize(records.size());
+        }
+        
+        Test.stopTest();
+    }
+    
+    /**
+     * @description operation: 
+     *    Test an error message is displayed when a button is clicked and
+     *    the action type page parameter is not valid
+     * verify: 
+     *    - the error is displayed on the page
+     *    - no record is deleted
+     */
+    @isTest
+    static void TestErrorMessageDisplayWhenPageActionParameterIsInvalid() {
+        if (isNotRunnable('TestErrorMessageDisplayWhenPageActionParameterIsInvalid')) return;
+        
+        String actionType = 'TestInvalidAction';
+        DataImport__c[] records = setUpData();
+        
+        Test.startTest();
+        PageReference returnPage = clickButton(actionType);
+        Test.stopTest();
+
+        System.assertEquals(null, returnPage);
+
+        UTIL_UnitTestData_TEST.assertPageHasError(actionType + ' is not a valid action type');
+
+        assertExpectedRecordSize(records.size());
+    }
+
+    /**
+     * @description operation: 
+     *    Test Delete All Data Import Records button 
+     * verify: 
+     *    All records are deleted
+     */
+    @isTest
+    static void TestDeleteAllDataImportRecordsBtn() {
+        if (isNotRunnable('TestDeleteAllDataImportRecordsBtn')) return;
+            
+        DataImport__c[] records = setUpData();
+        
+        Test.startTest();
+        PageReference returnPage = clickButton(BDI_DataImportDeleteBTN_CTRL.ACTION_DELETE_ALL);
+        Test.stopTest();
+
+        System.assertNotEquals(null, returnPage);
+
+        assertExpectedRecordSize(0);
+    }
+
+    /**
+     * @description operation: 
+     *    Test Delete All Data Import Records button action
+     *    adds an error message to the page when an exception is raised.
+     * verify: 
+     *    - the error is displayed on the page
+     *    - no record is deleted
+     */
+    @isTest
+    static void TestDeleteAllDataImportRecordsBtnExceptionMessageDisplay() {
+        testPageErrorMessageDisplayOnDeleteActionException(
+            'TestDeleteAllDataImportRecordsBtnExceptionMessageDisplay',
+            BDI_DataImportDeleteBTN_CTRL.ACTION_DELETE_ALL,
+            INSUFFICIENT_ACCESS_ERROR_MSG
+        );
+    }
+
+   /**
+    * @description operation: 
+    *    Test Delete Imported Data Import Records button 
+    * verify: 
+    *    All imported records are deleted
+    */
+    @isTest
+    static void TestDeleteImportedDataImportRecordsBtn() {
+        if (isNotRunnable('TestDeleteImportedDataImportRecordsBtn')) return;
+            
+        DataImport__c[] records = setUpData();
+        records[3].Status__c = label.bdiImported;
+        update records;
+        
+        Test.startTest();
+        PageReference returnPage = clickButton(BDI_DataImportDeleteBTN_CTRL.ACTION_DELETE_IMPORTED);
+        Test.stopTest();
+
+        System.assertNotEquals(null, returnPage);
+
+        records = [SELECT Id, Status__c FROM DataImport__c ORDER BY Status__c];
+        System.assertEquals(2, records.size());
+        System.assertEquals(null, records[0].Status__c);
+        System.assertEquals(label.bdiFailed, records[1].Status__c);
+    }
+
+    /**
+     * @description operation: 
+     *    Test Delete Imported Data Import Records button action
+     *    adds an error message to the page when an exception is raised.
+     * verify: 
+     *    - the error is displayed on the page
+     *    - no record is deleted
+     */
+    @isTest
+    static void TestDeleteImportedDataImportRecordsBtnExceptionMessageDisplay() {
+        testPageErrorMessageDisplayOnDeleteActionException(
+            'TestDeleteImportedDataImportRecordsBtnExceptionMessageDisplay',
+            BDI_DataImportDeleteBTN_CTRL.ACTION_DELETE_IMPORTED,
+            INSUFFICIENT_ACCESS_ERROR_MSG
+        );
+    }
+
+    /**
+     * @description operation: 
+     *    Test close() method when page parameter retURL is blank
+     * verify: 
+     *    Home page is returned
+     */
+    @isTest
+    static void TestCloseWhenRetUrlIsBlank() {
+        if (isNotRunnable('TestCloseWhenRetUrlIsBlank')) return;
+
+        for (String retURL : new String[] { null, '', ' ' }) {
+            ApexPages.currentPage().getParameters().put('retURL', retURL);
+
+            assertHomePage(new BDI_DataImportDeleteBTN_CTRL().close());
+        }
+    }
+
+    /**
+     * @description operation: 
+     *    Test close() method when page parameter retURL is not provided
+     * verify: 
+     *    Home page is returned
+     */
+    @isTest
+    static void TestCloseWhenRetUrlIsNotProvided() {
+        if (isNotRunnable('TestCloseWhenRetUrlIsNotProvided')) return;
+
+        assertHomePage(new BDI_DataImportDeleteBTN_CTRL().close());
+    }
+
+    /**
+     * @description operation: 
+     *    Test close() method when page parameter retURL is provided
+     * verify: 
+     *    retURL page is returned
+     */
+    @isTest
+    static void TestCloseWhenRetUrlIsProvided() {
+        if (isNotRunnable('TestCloseWhenRetUrlIsProvided')) return;
+
+        String retURL = '/testpage.jsp';
+        ApexPages.currentPage().getParameters().put('retURL', retURL);
+
+        assertPage(retURL, new BDI_DataImportDeleteBTN_CTRL().close());
+    }
+
+    // Helpers
+    ////////////
+
+    /**
+     * @description Create Data Import records with various status values
+     * @return DataImport__c[] Data Import records
+     */
+    static DataImport__c[] setUpData() {
+        DataImport__c[] records = new DataImport__c[] {
+            BDI_DataImport_TEST.newDI('c1', 'C1', 'c2', 'C2'),
+            BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'),
+            BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'),
+            BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4')
+        };
+        records[0].Status__c = label.bdiImported;
+        records[1].Status__c = label.bdiFailed;
+
+        insert records;
+        return records;
+    }
+
+    /**
+     * @description Check if the specified test should not be executed
+     * @param testMethodName Name of the test method
+     * @return Boolean true if the test should not be executed, otherwise false
+     */
+    static Boolean isNotRunnable(String testMethodName) {
+        return strTestOnly != '*' && strTestOnly != testMethodName;
+    }
+
+    /**
+     * @description Assert that actual and expected number of Data Import records is the same
+     * @param expectedSize Expected number of Data Import records
+     * @return void
+     */
+    static void assertExpectedRecordSize(Integer expectedSize) {
+        System.assertEquals(expectedSize, [SELECT COUNT() FROM DataImport__c]);
+    }
+
+    /**
+     * @description Set up page and test specified delete action type
+     * @param actionType Specific action type to delete all or imported Data Import records
+     * @return PageReference
+     */
+    static PageReference clickButton(String actionType) {
+        if (String.isNotBlank(actionType)) {
+            ApexPages.currentPage().getParameters().put('action', actionType);
+        }
+
+        BDI_DataImportDeleteBTN_CTRL ctrl = new BDI_DataImportDeleteBTN_CTRL();
+
+        return ctrl.buttonClick();
+    }
+
+    /**
+     * @description Apply delete action as a user with Standard User profile.
+     * Assert the exception message is displayed on the Visualforce page.
+     * @return void
+     */
+    static void testPageErrorMessageDisplayOnDeleteActionException(
+        String testMethodName,
+        String actionType,
+        String expectedMsg
+    ) {
+        if (isNotRunnable(testMethodName)) return;
+
+        PageReference returnPage;
+        DataImport__c[] records = setUpData();
+        
+        Test.startTest();
+
+        System.runAs(UTIL_UnitTestData_TEST.createStandardProfileUser()) {
+            returnPage = clickButton(actionType);
+        }
+
+        Test.stopTest();
+
+        System.assertEquals(null, returnPage);
+
+        UTIL_UnitTestData_TEST.assertPageHasError(expectedMsg);
+
+        assertExpectedRecordSize(records.size());
+    }
+
+    /**
+     * @description Assert Home page URL and redirect values
+     * @param actual Page to verify
+     * @return void
+     */
+    static void assertHomePage(PageReference actual) {
+        assertPage('/home/home.jsp', actual);
+    }
+
+    /**
+     * @description Assert page URL and redirect values
+     * @param expectedUrl Expected URL
+     * @param actual Page to verify
+     * @return void
+     */
+    static void assertPage(String expectedUrl, PageReference actual) {
+        System.assertNotEquals(null, actual);
+        System.assert(actual.getRedirect());
+        System.assertEquals(expectedUrl, actual.getUrl());
+    }
+	
+}

--- a/src/classes/BDI_DataImportDeleteBTN_TEST.cls-meta.xml
+++ b/src/classes/BDI_DataImportDeleteBTN_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_DataImportDeleteBTN_TEST.cls-meta.xml
+++ b/src/classes/BDI_DataImportDeleteBTN_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>39.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDI_DataImport_CTRL.cls
+++ b/src/classes/BDI_DataImport_CTRL.cls
@@ -36,6 +36,10 @@
 */
 
 public with sharing class BDI_DataImport_CTRL {
+    public Boolean batchRunning { get; set; }
+    private ID apexJobId;
+    private DateTime dtStart;
+
     public boolean userCanEditSettings {
         get {
             return Data_Import_Settings__c.SobjectType.getDescribe().isUpdateable();
@@ -48,15 +52,7 @@ public with sharing class BDI_DataImport_CTRL {
         dtStart = null;
     }
 
-    public PageReference actionImportOrDelete() {        
-        String strAction = ApexPages.currentPage().getParameters().get('action');
-        if (strAction == 'deleteImported') {
-            return deleteImportedDIRecords();    
-        } else if (strAction == 'deleteAll') {
-            return deleteAllDIRecords();    
-        }
-        // else we load up the DataImport page.  
-        
+    public PageReference preload() { 
         // force loading data import settings.
         // for some reason, just leaving the references to diSettings in the page
         // wasn't enough to get the settings initially saved (the upsert in the CustomSettingsFacade failed),
@@ -68,20 +64,6 @@ public with sharing class BDI_DataImport_CTRL {
         return null;
     }
     
-    public PageReference deleteImportedDIRecords() {
-        delete [select Id from DataImport__c where Status__c = :label.bdiImported limit 10000];
-        return (close());       
-    }
-    
-    public PageReference deleteAllDIRecords() {
-        delete [select Id from DataImport__c limit 10000];
-        return (close());
-    }
-    
-    public Boolean batchRunning { get; set; }
-    private ID apexJobId;
-    private DateTime dtStart;
-    
     public Data_Import_Settings__c diSettings {
         get {
             if (diSettings == null) {
@@ -91,12 +73,12 @@ public with sharing class BDI_DataImport_CTRL {
         }
         private set;
     }
-
-    // action method that user wants to close this page
+    
     public PageReference close() {
-        string strURL = ApexPages.currentPage().getParameters().get('retURL');
-        if (strURL == null || strURL == '') strURL = '/home/home.jsp';
-        PageReference p = new PageReference(strURL);
+        String retUrl = ApexPages.currentPage().getParameters().get('retURL');
+        if (String.isBlank(retUrl)) retUrl = '/home/home.jsp';
+
+        PageReference p = new PageReference(retUrl);
         p.setRedirect(true);
         return p;
     }

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -147,80 +147,7 @@ private with sharing class BDI_DataImport_TEST2 {
         
         Test.stopTest();
     }
-
-   /*********************************************************************************************************
-    * @description operation: 
-    *    test the Delete All Data Import Records button 
-    * verify: 
-    *    all records deleted
-    **********************************************************************************************************/            
-    static testMethod void TestDeleteAllDIRecordsBtn() {
-        if (strTestOnly != '*' && strTestOnly != 'TestDeleteAllDIRecordsBtn') return;
-            
-        list<DataImport__c> listDI = new list<DataImport__c>();
-        listDI.add(BDI_DataImport_TEST.newDI('c1', 'C1', 'c2', 'C2'));
-        listDI.add(BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'));
-        listDI.add(BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'));
-        listDI.add(BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'));
-        listDI[0].Status__c = label.bdiImported;
-        listDI[1].Status__c = label.bdiFailed;
-        insert listDI;
-        
-        Test.startTest();
-
-        // create the page 
-        Test.setCurrentPage(Page.BDI_DataImport); 
-
-        // instantiate the controller
-        BDI_DataImport_CTRL ctrl = new BDI_DataImport_CTRL();
-
-        // call the deleteAll method
-        ctrl.deleteAllDIRecords();
-        Test.stopTest();
-
-        // verify results
-        listDI = [select Id, Status__c from DataImport__c];
-        system.assertEquals(0, listDI.size());
-    }
-
-   /*********************************************************************************************************
-    * @description operation: 
-    *    test the Delete Imported Data Import Records button 
-    * verify: 
-    *    all records deleted
-    **********************************************************************************************************/            
-    static testMethod void TestDeleteImportedDIRecordsBtn() {
-        if (strTestOnly != '*' && strTestOnly != 'TestDeleteImportedDIRecordsBtn') return;
-            
-        list<DataImport__c> listDI = new list<DataImport__c>();
-        listDI.add(BDI_DataImport_TEST.newDI('c1', 'C1', 'c2', 'C2'));
-        listDI.add(BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'));
-        listDI.add(BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'));
-        listDI.add(BDI_DataImport_TEST.newDI('c3', 'C3', 'c4', 'C4'));
-        listDI[0].Status__c = label.bdiImported;
-        listDI[1].Status__c = label.bdiFailed;
-        listDI[3].Status__c = label.bdiImported;
-        insert listDI;
-        
-        Test.startTest();
-
-        // create the page 
-        Test.setCurrentPage(Page.BDI_DataImport); 
-
-        // instantiate the controller
-        BDI_DataImport_CTRL ctrl = new BDI_DataImport_CTRL();
-
-        // call the deleteAll method
-        ctrl.deleteImportedDIRecords();
-        Test.stopTest();
-
-        // verify results
-        listDI = [select Id, Status__c from DataImport__c order by Status__c];
-        system.assertEquals(2, listDI.size());
-        system.assertEquals(null, listDI[0].Status__c);
-        system.assertEquals(label.bdiFailed, listDI[1].Status__c);
-    }
-
+    
     /*********************************************************************************************************
     * @description operation: 
     *    import matching contacts within multiple di records in the same batch, using different email fields 
@@ -1711,4 +1638,5 @@ private with sharing class BDI_DataImport_TEST2 {
         system.assertEquals(null, BDI_DataImport_API.importData());
         Test.stopTest();
     }
+    
 }

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -36,6 +36,7 @@
 
 @isTest
 public class UTIL_UnitTestData_TEST { 
+    static final String PROFILE_STANDARD_USER = 'Standard User';
 
 // create data for use in unit tests
 // should not be referenced by production code
@@ -157,32 +158,6 @@ public class UTIL_UnitTestData_TEST {
         
         return ContactsToAdd;
     }
-    /*
-    public static List<Contact> CreateMultipleTestContactsInHouseholds (List<Contact> firstContactList) {
-        
-        List<contact> ContactsToAdd = New List<contact> ();
-        
-        for (integer i=0;i<firstContactList.size();i++) {
-            Contact newCon = New Contact (
-                FirstName= CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS + i,
-                LastName= CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,
-                npe01__Private__c=false,
-                npe01__WorkEmail__c = CAO_Constants.CONTACT_EMAIL_FOR_TESTS, 
-                npe01__Preferred_Email__c = CAO_Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
-                npe01__WorkPhone__c = CAO_Constants.CONTACT_PHONE_FOR_TESTS,
-                npe01__PreferredPhone__c = CAO_Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS,
-                OtherCity = 'Seattle',
-                Household__c = firstContactList[i].Household__c
-            );
-            ContactsToAdd.add (newCon);
-        }
-        
-        // testing doing the insert in the calling code - will maybe reinstate this
-        //insert ContactsToAdd;
-        
-        return ContactsToAdd;
-    }
-    */
 
     public static List<Opportunity> OppsForContactList (List<Contact> Cons, id CampId, string Stage, date Close, double Amt, string rectype, string oppType) {
         id rtid = UTIL_RecordTypes.GetRecordTypeId (Opportunity.sObjectType,rectype);
@@ -355,7 +330,7 @@ public class UTIL_UnitTestData_TEST {
         Profile p = [
             SELECT Id
             FROM Profile
-            WHERE Name='Standard User'
+            WHERE Name = :PROFILE_STANDARD_USER
         ];
 
         UserRole r;
@@ -395,6 +370,7 @@ public class UTIL_UnitTestData_TEST {
                 UserRoleId = r.Id,
                 Username = strUsername
             );
+
             insert u;
         }
         return u;
@@ -423,6 +399,89 @@ public class UTIL_UnitTestData_TEST {
         }
 
         return u;
+    }
+
+    /**
+     * @description Create a User having Standard User profile assigned
+     * @return User
+     */
+    public static User createStandardProfileUser() {
+        return createUser(PROFILE_STANDARD_USER);
+    }
+
+    /**
+     * @description Create a User having specified profile assigned
+     * @param profileName Profile Name
+     * @return User
+     */
+    public static User createUser(String profileName) {
+        User u = buildUser(buildUniqueLastName(), profileName);
+
+        //create the user
+        System.runAs(u) {}
+
+        return u;      
+    } 
+
+    /**
+     * @description Construct a unique last name to be assigned to a User
+     * @return String
+     */
+    static String buildUniqueLastName() {
+        return UserInfo.getOrganizationId() +
+            String.valueof(Datetime.now()).replace(' ','').replace(':','').replace('-','') +
+            Integer.valueOf(math.rint(math.random()*2000000));
+    }
+
+    /**
+     * @description Set new User fields
+     * @param lastName Last Name
+     * @param profileName Profile Name
+     * @return User
+     */
+    static User buildUser(String lastName, String profileName) {
+        Profile p = [SELECT Id FROM Profile WHERE name = :profileName];
+        String alias = lastName.replaceAll(' ', '').leftPad(8, '0').right(8);
+        String email = lastName.left(70) + '@email.com';
+
+        return new User(
+            LastName = lastName, 
+            Email = email, 
+            ProfileId = p.id,
+            UserName = email,
+            Alias = alias, 
+            TimeZoneSidKey = 'America/Los_Angeles',
+            LocaleSidKey = 'en_US', 
+            LanguageLocaleKey = 'en_US',
+            EmailEncodingKey = 'ISO-8859-1'
+        );
+    }
+
+    /**
+     * @description Assert a Visualforce page has an error message displayed
+     * @param expectedMsg Expected error message
+     * @return void
+     */
+    public static void assertPageHasError(String expectedMsg) {
+        ApexPages.Message[] msgs = ApexPages.getMessages();
+
+        System.assert(
+            ApexPages.hasMessages(ApexPages.Severity.ERROR), 
+            'Expected page to contain at least one error message. Messages: ' + msgs
+        );
+ 
+        for (ApexPages.Message msg : msgs) {
+            if (msg.getSummary().contains(expectedMsg) && msg.getSeverity() == ApexPages.Severity.ERROR) {
+                return;       
+            }
+        }
+
+        System.assert(false, 
+            String.format(
+                'Cannot find "{0}" in the page messages: ' + msgs,
+                new String[] { expectedMsg }
+            )
+        );
     }
 
     public static list<Account> listAccT;
@@ -514,47 +573,4 @@ public class UTIL_UnitTestData_TEST {
         System.assertEquals(false, queriedUser.IsActive);
     }
 
-/*
-        public static List<Opportunity> OppsForAccountList (List<Account> Accts, id CampId, string Stage, date Close, double Amt, string rectype) {
-    
-        // given a List of accounts,
-        // add one Opp per acct w/ the specified data
-    
-        List<Opportunity> OppsToAdd = new List<Opportunity> ();
-        
-        // look up the id for the specified rectype
-        id rtid = UTIL_RecordTypes.GetRecordTypeId ('Opportunity',rectype);
-        
-        for ( Account thisAcct : Accts) {
-            Opportunity newOpp = New Opportunity (
-                AccountId = thisAcct.id,
-                Name = 'Test Opp ' + thisAcct.Name,
-                Amount = Amt,
-                CloseDate = Close,
-                StageName = Stage,
-                CampaignId = CampId,
-                RecordTypeId = rtid
-            );  
-            OppsToAdd.add (newOpp);
-        }
-        
-        return OppsToAdd;
-        
-    }
-    */
-    
-    
-  /*  
-    public Static CampaignMember CreateCampaignMember (id CampId, id ConId, string CMStatus) {
-    
-        CampaignMember newCM = new CampaignMember (
-            CampaignId = CampId,
-            ContactId = ConId,
-            Status = CMStatus
-        );
-        
-        insert newCM;
-        return newCm;           
-    }
-*/
 }

--- a/src/components/UTIL_NavigateBack.component
+++ b/src/components/UTIL_NavigateBack.component
@@ -15,7 +15,7 @@
         if (redirect) {
             if ((typeof sforce != 'undefined') && sforce && (!!sforce.one)) {
                 // Manage navigation in Lightning Experience & Salesforce1
-                    sforce.one.back(true);
+                sforce.one.back(true);
             }
             else {
                 var recordId = '{!recordId}';

--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -1105,7 +1105,7 @@
         <openType>sidebar</openType>
         <protected>false</protected>
         <requireRowSelection>false</requireRowSelection>
-        <url>/apex/npsp__BDI_DataImport?action=deleteAll&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
+        <url>/apex/npsp__BDI_DataImportDeleteBTN?action=deleteAll&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
     </webLinks>
     <webLinks>
         <fullName>Delete_Imported_Data_Import_Records</fullName>
@@ -1118,7 +1118,7 @@
         <openType>sidebar</openType>
         <protected>false</protected>
         <requireRowSelection>false</requireRowSelection>
-        <url>/apex/npsp__BDI_DataImport?action=deleteImported&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
+        <url>/apex/npsp__BDI_DataImportDeleteBTN?action=deleteImported&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
     </webLinks>
     <webLinks>
         <fullName>Process_Data_Import</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -57,6 +57,8 @@
         <members>BDI_DataImport_CTRL</members>
         <members>BDI_DataImport_TEST</members>
         <members>BDI_DataImport_TEST2</members>
+        <members>BDI_DataImportDeleteBTN_CTRL</members>
+        <members>BDI_DataImportDeleteBTN_TEST</members>
         <members>BDI_Donations</members>
         <members>CAM_CascadeDeleteLookups_TDTM</members>
         <members>CAM_CascadeDeleteLookups_TEST</members>
@@ -306,6 +308,7 @@
         <members>ALLO_RollupBTN</members>
         <members>BDE_BatchEntry</members>
         <members>BDI_DataImport</members>
+        <members>BDI_DataImportDeleteBTN</members>
         <members>CONV_Account_Conversion</members>
         <members>CON_ContactMerge</members>
         <members>CON_DeleteContactOverride</members>

--- a/src/pages/BDI_DataImport.page
+++ b/src/pages/BDI_DataImport.page
@@ -3,7 +3,7 @@
     tabStyle="DataImport__c"
     showHeader="true"
     sidebar="false"
-    action="{!actionImportOrDelete}"
+    action="{!preload}"
     docType="html-5.0"
     standardStylesheets="false">
 

--- a/src/pages/BDI_DataImportDeleteBTN.page
+++ b/src/pages/BDI_DataImportDeleteBTN.page
@@ -1,0 +1,30 @@
+<apex:page controller="BDI_DataImportDeleteBTN_CTRL"
+    title="NPSP Data Import Delete"
+    tabStyle="DataImport__c"
+    showHeader="true"
+    sidebar="false"
+    action="{!buttonClick}"
+    docType="html-5.0"
+    standardStylesheets="false">
+
+    <apex:stylesheet value="{!URLFOR($Resource.CumulusStaticResources, '/npsp-slds/npsp-common.css')}" />
+    <apex:stylesheet value="{!URLFOR($Resource.SLDS, '/0_12_2/assets/styles/salesforce-lightning-design-system-vf.min.css')}"/>
+
+    <div class="slds slds-p-bottom--x-large">
+        <apex:form id="idForm" styleClass="slds-p-bottom--x-large">
+    
+        <c:UTIL_PageMessages />
+
+        <div class="slds-card__header slds-grid">
+            <div class="slds-no-flex">
+                <apex:commandButton value="{!$Label.bdiBtnClose}" 
+                    action="{!close}" 
+                    immediate="true" 
+                    styleClass="slds-button slds-button--neutral" />
+            </div>
+        </div>
+
+        </apex:form>
+    </div>
+                                    
+</apex:page>

--- a/src/pages/BDI_DataImportDeleteBTN.page-meta.xml
+++ b/src/pages/BDI_DataImportDeleteBTN.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>39.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>BDI_DataImportDeleteBTN</label>

--- a/src/pages/BDI_DataImportDeleteBTN.page-meta.xml
+++ b/src/pages/BDI_DataImportDeleteBTN.page-meta.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>BDI_DataImportDeleteBTN</label>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>6</minorNumber>
+        <namespace>npe01</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>9</minorNumber>
+        <namespace>npe03</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>5</minorNumber>
+        <namespace>npe4</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>5</minorNumber>
+        <namespace>npe5</namespace>
+    </packageVersions>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>8</minorNumber>
+        <namespace>npo02</namespace>
+    </packageVersions>
+</ApexPage>


### PR DESCRIPTION
# Critical Changes
- In order to enable allowed users to execute "Delete All Data Import Records" and "Delete Imported Data Import Records" operations, it is required to add selected profiles into "Enabled Profiles" at "Security" page for the new "BDI_DataImportDeleteBTN" Visualforce page.

# Changes

# Issues Closed
Fixes #1955