### PR TITLE
Only consider active RecordTypes

### DIFF
--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -539,7 +539,7 @@ public without sharing class UTIL_CustomSettingsFacade {
             rds.npe03__Opportunity_Forecast_Months__c = 12;
             rds.npe03__Update_Check_Interval__c = 90;
             rds.npe03__Open_Opportunity_Behavior__c = RD_RecurringDonations.RecurringDonationCloseOptions.Mark_Opportunities_Closed_Lost.name();
-            List<RecordType> oppRecordTypes = [select id from RecordType where sobjecttype = 'Opportunity'];
+            List<RecordType> oppRecordTypes = [select id from RecordType where sobjecttype = 'Opportunity' and IsActive = true];
             if(oppRecordTypes.size() > 0)
                 rds.npe03__Record_Type__c = oppRecordTypes[0].id;
         }   


### PR DESCRIPTION
Hi all...

I recently added some inactive record types to assist a migration from one org to another, and I found that my tests now fail. I traced it to this line, where an inactive record type is being used. Setting the record types to active solves the problem.

Please note that I haven't actually tested this, I don't even know how. I'm not actually proposing this change, I just want to start a conversation with someone more knowledgeable than myself.

Thanks!