### PR TITLE
Matching donations by date range setting

### DIFF
--- a/src/classes/BDI_Donations.cls
+++ b/src/classes/BDI_Donations.cls
@@ -298,7 +298,10 @@ public class BDI_Donations {
         }
         else if (matchBehavior == BDI_DataImport_API.RequireNoMatch && di.DonationImported__c != null) {
             strError = label.bdiErrorDonationRequireNoMatch;
-        } 
+        }
+        else if (matchBehavior == BDI_DataImport_API.RequireExactMatch && di.Payment_Possible_Matches__c != null) {
+            strError = label.bdiErrorPaymentMultiMatch;
+        }
         else if (matchBehavior == BDI_DataImport_API.RequireExactMatch && di.Donation_Possible_Matches__c != null) {
             strError = label.bdiErrorDonationMultiMatch;
         } 
@@ -323,10 +326,13 @@ public class BDI_Donations {
             if (di.Donation_Possible_Matches__c == null) {
                 di.Donation_Possible_Matches__c = di.DonationImported__c;
             }
+            if (di.Payment_Possible_Matches__c == null) {
+                di.Payment_Possible_Matches__c = di.PaymentImported__c;
+            }
 
             di.DonationImported__c = null;
             di.PaymentImported__c = null;
-            di.PaymentImportStatus__c = null;
+            di.PaymentImportStatus__c = strError;
         }
 
         // invalid behavior

--- a/src/classes/BDI_Donations.cls
+++ b/src/classes/BDI_Donations.cls
@@ -283,7 +283,7 @@ public class BDI_Donations {
     */ 
     private boolean isValidMatchBehavior(DataImport__c di, string matchBehavior) {
         string strError;
-        
+
         // always allow matching by Id, regardless of specified behavior
         if (di.DonationImportStatus__c == label.bdiMatchedId) {
             return true;

--- a/src/classes/BDI_Donations_TEST.cls
+++ b/src/classes/BDI_Donations_TEST.cls
@@ -642,7 +642,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            0, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 0);
+            0, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -663,7 +663,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
                 UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            0, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 1);
+            0, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, label.bdiMatched, false, 1);
     }
 
     /*********************************************************************************************************
@@ -684,7 +684,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
                 UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true, 1);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorPaymentMultiMatch, label.bdiErrorPaymentMultiMatch, true, 1);
     }
 
     /*********************************************************************************************************
@@ -705,7 +705,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
                 UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            0, BDI_DataImport_API.RequireBestMatch, label.bdiMatchedBest, true, 1);
+            0, BDI_DataImport_API.RequireBestMatch, label.bdiMatchedBest, label.bdiMatchedBest, true, 1);
     }
 
     /*********************************************************************************************************
@@ -725,7 +725,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            4, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 0);
+            4, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -754,7 +754,7 @@ public with sharing class BDI_Donations_TEST {
             UTIL_Namespace.StrTokenNSPrefix('Donation_Record_Type_Name__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            3, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 0);
+            3, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -775,7 +775,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiErrorDonationMultiMatch, true, 0);
+            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiErrorDonationMultiMatch, label.bdiErrorDonationMultiMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -796,7 +796,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiCreated, false, 0);
+            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiCreated, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -816,7 +816,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -2, BDI_DataImport_API.BestMatchOrCreate, label.bdiMatchedBest, true, 0);
+            -2, BDI_DataImport_API.BestMatchOrCreate, label.bdiMatchedBest, label.bdiMatchedBest, true, 0);
     }
 
     /*********************************************************************************************************
@@ -837,7 +837,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.BestMatchOrCreate, label.bdiCreated, false, 0);
+            -1, BDI_DataImport_API.BestMatchOrCreate, label.bdiCreated, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -857,7 +857,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.DoNotMatch, label.bdiCreated, false, 0);
+            -1, BDI_DataImport_API.DoNotMatch, label.bdiCreated, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -878,7 +878,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireNoMatch, label.bdiErrorDonationRequireNoMatch, true, 0);
+            -1, BDI_DataImport_API.RequireNoMatch, label.bdiErrorDonationRequireNoMatch, label.bdiErrorDonationRequireNoMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -898,7 +898,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireNoMatch, label.bdiCreated, false, 0);
+            -1, BDI_DataImport_API.RequireNoMatch, label.bdiCreated, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -919,7 +919,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, false, 0);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, label.bdiErrorDonationNoMatch, false, 0);
     }
 
     /*********************************************************************************************************
@@ -940,7 +940,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true, 0);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorPaymentMultiMatch, label.bdiErrorPaymentMultiMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -961,7 +961,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -982,7 +982,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            2, BDI_DataImport_API.RequireBestMatch, label.bdiMatchedBest, true, 0);
+            2, BDI_DataImport_API.RequireBestMatch, label.bdiMatchedBest, label.bdiMatchedBest, true, 0);
     }
 
     /*********************************************************************************************************
@@ -1003,7 +1003,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireBestMatch, label.bdiErrorDonationNoMatch, false, 0);
+            -1, BDI_DataImport_API.RequireBestMatch, label.bdiErrorDonationNoMatch, label.bdiErrorDonationNoMatch, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1024,7 +1024,7 @@ public with sharing class BDI_Donations_TEST {
             
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Type__c'),
-            2, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            2, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1044,7 +1044,7 @@ public with sharing class BDI_Donations_TEST {
             
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c'),
-            4, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            4, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1066,7 +1066,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            7, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            7, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1088,7 +1088,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1112,7 +1112,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Payment_Check_Reference_Number__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1138,7 +1138,7 @@ public with sharing class BDI_Donations_TEST {
             UTIL_Namespace.StrTokenNSPrefix('Payment_Check_Reference_Number__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' + 
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, false, 0);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, label.bdiErrorDonationNoMatch, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1163,7 +1163,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            8, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            8, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
             
         DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c, 
             Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
@@ -1203,7 +1203,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Payment_Check_Reference_Number__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true, 0);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorPaymentMultiMatch, label.bdiErrorPaymentMultiMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -1226,7 +1226,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            10, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            10, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1250,7 +1250,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            11, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            11, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1275,7 +1275,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
                 UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            12, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+            12, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, label.bdiMatched, false, 0);
 
         DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c,
             Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
@@ -1315,12 +1315,12 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
                 UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            12, BDI_DataImport_API.RequireBestMatch, label.bdiMatched, false, 1);
+            12, BDI_DataImport_API.RequireBestMatch, label.bdiMatched, label.bdiMatchedBest, true, 1);
 
         DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c,
             Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
         system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
-        system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
+        system.assertEquals(label.bdiMatchedBest, di.PaymentImportStatus__c);
 
         Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
         npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c, npe01__Scheduled_Date__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
@@ -1356,12 +1356,12 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
                 UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            12, BDI_DataImport_API.RequireBestMatch, label.bdiMatched, false, 2);
+            12, BDI_DataImport_API.RequireBestMatch, label.bdiMatched, label.bdiMatchedBest, true, 2);
 
         DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c,
             Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
         system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
-        system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
+        system.assertEquals(label.bdiMatchedBest, di.PaymentImportStatus__c);
 
         Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
         npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c, npe01__Scheduled_Date__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
@@ -1376,6 +1376,28 @@ public with sharing class BDI_Donations_TEST {
     }
 
     /*********************************************************************************************************
+    * @description operation:
+    *    import donations using different matching rules: Amount, Date, where Opp has Multiple Payments,
+    *    and matches multiple of the payments under the opp, using a date range
+    * verify:
+    *    error, due to detection of multiple payments
+    **********************************************************************************************************/
+    static testMethod void donationMatchRules18d() {
+        if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18d') return;
+
+        insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
+            Donation_Amount__c=12,
+            Donation_Date__c=System.Today()+1,
+            Payment_Method__c = 'Check',
+            Donation_Donor__c='contact1');
+
+        donationMatchRules(
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorPaymentMultiMatch, label.bdiErrorPaymentMultiMatch, true, 2);
+    }
+
+    /*********************************************************************************************************
     * @description operation: 
     *    the shared routine to actually test the different donations different matching rules. 
     * verify: 
@@ -1384,10 +1406,11 @@ public with sharing class BDI_Donations_TEST {
     * @param strRule The matching rules to use in the test
     * @param imatch The existing Opp we expect to match against.  use -1 if no match expected.  use -2 if best match expected (which can be random)
     * @param expectedStatus The status value we expect to be set in DonationImportStatus__c
+    * @param expectedStatusPmt The status value we expect to be set in PaymentImportStatus__c
     * @param hasMultiMatches Whether we expect anything in Donation_Possible_Matches__c
     **********************************************************************************************************/            
     static void donationMatchRules(string strRule, integer imatch, string matchBehavior, 
-        string expectedStatus, boolean hasMultiMatches, integer dateRange) {
+        string expectedStatus, string expectedStatusPmt, boolean hasMultiMatches, integer dateRange) {
         
         // create opps to match against
         Contact con = new Contact(firstname='c0', lastname='c0', email='c0@c0.com');
@@ -1478,17 +1501,17 @@ public with sharing class BDI_Donations_TEST {
         Test.stopTest();
     
         list<DataImport__c> listDI = [select Status__c, DonationImported__c, DonationImportStatus__c, 
-            Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];        
+            Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c, Payment_Possible_Matches__c from DataImport__c];
         system.assertEquals(1, listDI.size());
         system.assertEquals(expectedStatus, listDI[0].DonationImportStatus__c);
-        system.assertEquals(hasMultiMatches, listDI[0].Donation_Possible_Matches__c != null);
+        system.assertEquals(hasMultiMatches, listDI[0].Donation_Possible_Matches__c != null || listDI[0].Payment_Possible_Matches__c != null);
         if (imatch >= 0) {                
             system.assertEquals(label.bdiImported, listDI[0].Status__c);
             system.assertEquals(listOpp[imatch].Id, listDI[0].DonationImported__c);
             if (imatch != 6 && imatch != 7) {
                 system.assertNotEquals(null, listDI[0].PaymentImported__c);
-                system.assertEquals(label.bdiMatched, listDI[0].PaymentImportStatus__c);
-                npe01__OppPayment__c pmt = [select Id, npe01__Payment_Method__c from npe01__OppPayment__c 
+                system.assertEquals(expectedStatusPmt, listDI[0].PaymentImportStatus__c);
+                npe01__OppPayment__c pmt = [select Id, npe01__Payment_Method__c from npe01__OppPayment__c
                     where Id = :listDI[0].PaymentImported__c];
                 system.assertEquals('Check', pmt.npe01__Payment_Method__c);
             }

--- a/src/classes/BDI_Donations_TEST.cls
+++ b/src/classes/BDI_Donations_TEST.cls
@@ -642,7 +642,70 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            0, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false);
+            0, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 0);
+    }
+
+    /*********************************************************************************************************
+    * @description operation:
+    *    import donations using different matching rules: Amount, Date.  avoid same amount, different day.
+    *    use date range for the match.
+    * verify:
+    *    correct donations matched
+    **********************************************************************************************************/
+    static testMethod void donationMatchRules1b() {
+        if (strTestOnly != '*' && strTestOnly != 'donationMatchRules1b') return;
+        insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
+            Donation_Amount__c=100,
+            Donation_Date__c=System.Today()+1,
+            Payment_Method__c = 'Check',
+            Donation_Donor__c='contact1');
+
+        donationMatchRules(
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
+            0, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 1);
+    }
+
+    /*********************************************************************************************************
+    * @description operation:
+    *    import donations using different matching rules: Amount, Date.  avoid same amount, different day.
+    *    use date range for the match.
+    * verify:
+    *    error, due to multiple matches
+    **********************************************************************************************************/
+    static testMethod void donationMatchRules1c() {
+        if (strTestOnly != '*' && strTestOnly != 'donationMatchRules1c') return;
+        insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
+            Donation_Amount__c=100,
+            Donation_Date__c=System.Today(),
+            Payment_Method__c = 'Check',
+            Donation_Donor__c='contact1');
+
+        donationMatchRules(
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true, 1);
+    }
+
+    /*********************************************************************************************************
+    * @description operation:
+    *    import donations using different matching rules: Amount, Date.  avoid same amount, different day.
+    *    use date range for the match.
+    * verify:
+    *    correct donations matched
+    **********************************************************************************************************/
+    static testMethod void donationMatchRules1d() {
+        if (strTestOnly != '*' && strTestOnly != 'donationMatchRules1d') return;
+        insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
+            Donation_Amount__c=100,
+            Donation_Date__c=System.Today(),
+            Payment_Method__c = 'Check',
+            Donation_Donor__c='contact1');
+
+        donationMatchRules(
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
+            0, BDI_DataImport_API.RequireBestMatch, label.bdiMatchedBest, true, 1);
     }
 
     /*********************************************************************************************************
@@ -662,7 +725,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            4, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false);
+            4, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -691,7 +754,7 @@ public with sharing class BDI_Donations_TEST {
             UTIL_Namespace.StrTokenNSPrefix('Donation_Record_Type_Name__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            3, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false);
+            3, BDI_DataImport_API.ExactMatchOrCreate, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -712,7 +775,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiErrorDonationMultiMatch, true);
+            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiErrorDonationMultiMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -733,7 +796,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiCreated, false);
+            -1, BDI_DataImport_API.ExactMatchOrCreate, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -753,7 +816,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -2, BDI_DataImport_API.BestMatchOrCreate, label.bdiMatchedBest, true);
+            -2, BDI_DataImport_API.BestMatchOrCreate, label.bdiMatchedBest, true, 0);
     }
 
     /*********************************************************************************************************
@@ -774,7 +837,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.BestMatchOrCreate, label.bdiCreated, false);
+            -1, BDI_DataImport_API.BestMatchOrCreate, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -794,7 +857,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.DoNotMatch, label.bdiCreated, false);
+            -1, BDI_DataImport_API.DoNotMatch, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -815,7 +878,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireNoMatch, label.bdiErrorDonationRequireNoMatch, true);
+            -1, BDI_DataImport_API.RequireNoMatch, label.bdiErrorDonationRequireNoMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -835,7 +898,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireNoMatch, label.bdiCreated, false);
+            -1, BDI_DataImport_API.RequireNoMatch, label.bdiCreated, false, 0);
     }
 
     /*********************************************************************************************************
@@ -856,7 +919,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, false);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, false, 0);
     }
 
     /*********************************************************************************************************
@@ -877,7 +940,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -898,7 +961,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -919,7 +982,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            2, BDI_DataImport_API.RequireBestMatch, label.bdiMatchedBest, true);
+            2, BDI_DataImport_API.RequireBestMatch, label.bdiMatchedBest, true, 0);
     }
 
     /*********************************************************************************************************
@@ -940,7 +1003,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireBestMatch, label.bdiErrorDonationNoMatch, false);
+            -1, BDI_DataImport_API.RequireBestMatch, label.bdiErrorDonationNoMatch, false, 0);
     }
 
     /*********************************************************************************************************
@@ -961,7 +1024,7 @@ public with sharing class BDI_Donations_TEST {
             
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Type__c'),
-            2, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            2, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -981,7 +1044,7 @@ public with sharing class BDI_Donations_TEST {
             
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c'),
-            4, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            4, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1003,7 +1066,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            7, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            7, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1025,7 +1088,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1049,7 +1112,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Payment_Check_Reference_Number__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            9, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1075,7 +1138,7 @@ public with sharing class BDI_Donations_TEST {
             UTIL_Namespace.StrTokenNSPrefix('Payment_Check_Reference_Number__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' + 
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, false);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationNoMatch, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1100,7 +1163,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            8, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            8, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
             
         DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c, 
             Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
@@ -1140,7 +1203,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Payment_Check_Reference_Number__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true);
+            -1, BDI_DataImport_API.RequireExactMatch, label.bdiErrorDonationMultiMatch, true, 0);
     }
 
     /*********************************************************************************************************
@@ -1163,7 +1226,7 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            10, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            10, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
     }
 
     /*********************************************************************************************************
@@ -1187,7 +1250,129 @@ public with sharing class BDI_Donations_TEST {
         donationMatchRules(
             UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
             UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
-            11, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false);
+            11, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+    }
+
+    /*********************************************************************************************************
+    * @description operation:
+    *    import donations using different matching rules: Amount, Date, where Opp has Multiple Payments,
+    *    and matches one of the payments under the opp
+    * verify:
+    *    no new donation created
+    *    existing opp matched, but left open
+    *    payment matched
+    *    opp remaining balance updated
+    **********************************************************************************************************/
+    static testMethod void donationMatchRules18a() {
+        if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18a') return;
+
+        insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
+            Donation_Amount__c=12,
+            Donation_Date__c=System.Today(),
+            Payment_Method__c = 'Check',
+            Donation_Donor__c='contact1');
+
+        donationMatchRules(
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
+            12, BDI_DataImport_API.RequireExactMatch, label.bdiMatched, false, 0);
+
+        DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c,
+            Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
+        system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
+        system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
+
+        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
+
+        system.assertEquals(false, opp.IsWon);
+        system.assertEquals(false, opp.IsClosed);
+        system.assertEquals(48, opp.Amount);
+        system.assertEquals(36, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(12, pmt.npe01__Payment_Amount__c);
+        system.assertEquals(true, pmt.npe01__Paid__c);
+    }
+
+    /*********************************************************************************************************
+    * @description operation:
+    *    import donations using different matching rules: Amount, Date, where Opp has Multiple Payments,
+    *    and matches multiple of the payments under the opp, using a date range
+    * verify:
+    *    no new donation created
+    *    existing opp matched, but left open
+    *    payment matched
+    *    opp remaining balance updated
+    **********************************************************************************************************/
+    static testMethod void donationMatchRules18b() {
+        if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18a') return;
+
+        insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
+            Donation_Amount__c=12,
+            Donation_Date__c=System.Today(),
+            Payment_Method__c = 'Check',
+            Donation_Donor__c='contact1');
+
+        donationMatchRules(
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
+            12, BDI_DataImport_API.RequireBestMatch, label.bdiMatched, false, 1);
+
+        DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c,
+            Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
+        system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
+        system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
+
+        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c, npe01__Scheduled_Date__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
+
+        system.assertEquals(false, opp.IsWon);
+        system.assertEquals(false, opp.IsClosed);
+        system.assertEquals(48, opp.Amount);
+        system.assertEquals(36, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(12, pmt.npe01__Payment_Amount__c);
+        system.assertEquals(true, pmt.npe01__Paid__c);
+        system.assertEquals(system.Today(), pmt.npe01__Scheduled_Date__c);
+    }
+
+    /*********************************************************************************************************
+    * @description operation:
+    *    import donations using different matching rules: Amount, Date, where Opp has Multiple Payments,
+    *    and matches multiple of the payments under the opp, using a date range
+    * verify:
+    *    no new donation created
+    *    existing opp matched, but left open
+    *    payment matched
+    *    opp remaining balance updated
+    **********************************************************************************************************/
+    static testMethod void donationMatchRules18c() {
+        if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18c') return;
+
+        insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
+            Donation_Amount__c=12,
+            Donation_Date__c=System.Today()+1,
+            Payment_Method__c = 'Check',
+            Donation_Donor__c='contact1');
+
+        donationMatchRules(
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c'),
+            12, BDI_DataImport_API.RequireBestMatch, label.bdiMatched, false, 2);
+
+        DataImport__c di = [select Status__c, DonationImported__c, DonationImportStatus__c,
+            Donation_Possible_Matches__c, PaymentImported__c, PaymentImportStatus__c from DataImport__c];
+        system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
+        system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
+
+        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c, npe01__Scheduled_Date__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
+
+        system.assertEquals(false, opp.IsWon);
+        system.assertEquals(false, opp.IsClosed);
+        system.assertEquals(48, opp.Amount);
+        system.assertEquals(36, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(12, pmt.npe01__Payment_Amount__c);
+        system.assertEquals(true, pmt.npe01__Paid__c);
+        system.assertEquals(system.Today()+1, pmt.npe01__Scheduled_Date__c);
     }
 
     /*********************************************************************************************************
@@ -1202,7 +1387,7 @@ public with sharing class BDI_Donations_TEST {
     * @param hasMultiMatches Whether we expect anything in Donation_Possible_Matches__c
     **********************************************************************************************************/            
     static void donationMatchRules(string strRule, integer imatch, string matchBehavior, 
-        string expectedStatus, boolean hasMultiMatches) { 
+        string expectedStatus, boolean hasMultiMatches, integer dateRange) {
         
         // create opps to match against
         Contact con = new Contact(firstname='c0', lastname='c0', email='c0@c0.com');
@@ -1244,9 +1429,13 @@ public with sharing class BDI_Donations_TEST {
         listOpp.add(new Opportunity(name='Opp11', Primary_Contact__c=con.Id, Amount=1100, CloseDate=System.Today(), 
             StageName=UTIL_unitTestData_TEST.getOpenStage(), npe01__Do_Not_Automatically_Create_Payment__c=true));
 
+        // Opp 12 will have multiple Payment records, different days, same amounts.
+        listOpp.add(new Opportunity(name='Opp11', Primary_Contact__c=con.Id, Amount=48, CloseDate=System.Today(),
+            StageName=UTIL_unitTestData_TEST.getOpenStage(), npe01__Do_Not_Automatically_Create_Payment__c=true));
+
         insert listOpp;
         
-        // create Opps 8-10's Payment records
+        // create Opps 8-11's Payment records
         list<npe01__OppPayment__c> listPmt = new list<npe01__OppPayment__c>();
         listPmt.add(new npe01__OppPayment__c(npe01__Opportunity__c=listOpp[8].Id, npe01__Payment_Amount__c=350, 
             npe01__Scheduled_Date__c=System.Today(), npe01__Check_Reference_Number__c='dupe'));
@@ -1266,12 +1455,21 @@ public with sharing class BDI_Donations_TEST {
         listPmt.add(new npe01__OppPayment__c(npe01__Opportunity__c=listOpp[11].Id, npe01__Payment_Amount__c=1100, 
             npe01__Scheduled_Date__c=System.Today(), npe01__Written_Off__c=true));
 
+        listPmt.add(new npe01__OppPayment__c(npe01__Opportunity__c=listOpp[12].Id, npe01__Payment_Amount__c=12,
+            npe01__Scheduled_Date__c=System.Today()));
+        listPmt.add(new npe01__OppPayment__c(npe01__Opportunity__c=listOpp[12].Id, npe01__Payment_Amount__c=12,
+            npe01__Scheduled_Date__c=System.Today()+1));
+        listPmt.add(new npe01__OppPayment__c(npe01__Opportunity__c=listOpp[12].Id, npe01__Payment_Amount__c=12,
+            npe01__Scheduled_Date__c=System.Today()+2));
+        listPmt.add(new npe01__OppPayment__c(npe01__Opportunity__c=listOpp[12].Id, npe01__Payment_Amount__c=12,
+            npe01__Scheduled_Date__c=System.Today()+3));
         insert listPmt;
         
         // set the specified settings
         Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
         diSettings.Donation_Matching_Rule__c = strRule;
         diSettings.Donation_Matching_Behavior__c = matchBehavior;
+        diSettings.Donation_Date_Range__c = dateRange;
  
         //run batch data import
         Test.StartTest();

--- a/src/classes/BDI_MatchDonations.cls
+++ b/src/classes/BDI_MatchDonations.cls
@@ -129,7 +129,6 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
 
                         for (npe01__OppPayment__c pmt : opp.npe01__OppPayment__r) {
                             matchInfo = getMatchInfoByPmtRules(di, pmt);
-                            system.debug('****DJH: pmt: ' + pmt + ' matchInfo: ' + matchInfo);
 
                             if (matchInfo.matchType == MATCHTYPE.ID_MATCH) {
                                 pmtBest = pmt;

--- a/src/classes/BDI_MatchDonations.cls
+++ b/src/classes/BDI_MatchDonations.cls
@@ -109,6 +109,7 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
             list<Opportunity> listCAOpps = mapConAccIdToOpps.get(id);
             list<Integer> listIMatches = new list<Integer>();
             map<ID, npe01__OppPayment__c> mapOppIdToPmt = new map<ID, npe01__OppPayment__c>();
+            list<ID> listPmtIdMatches = new list<ID>();
             
             boolean isMatchedByOppId = false;
             boolean isMatchedByPmtId = false;
@@ -133,8 +134,11 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
                             if (matchInfo.matchType == MATCHTYPE.ID_MATCH) {
                                 pmtBest = pmt;
                                 isMatchedByPmtId = true;
+                                // clear possible other matches
+                                listPmtIdMatches.clear();
                                 break;
                             } else if (matchInfo.matchType == MATCHTYPE.FIELD_MATCH) {
+                                listPmtIdMatches.add(pmt.Id);
                                 // we start with the first field match as possible best, and then look for closer matches
                                 if (pmtBest == null || matchInfo.dateVariance < dtVariancePmt) {
                                     pmtBest = pmt;
@@ -169,6 +173,7 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
                         listIMatches.add(i);
                         ioppBest = i;
                         isMatchedByOppId = true;
+                        listPmtIdMatches.clear();
                         break;
                     } else if (matchInfo.matchType == MATCHTYPE.FIELD_MATCH) {
                         listIMatches.add(i);
@@ -206,15 +211,31 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
                         if (i == 9)
                             break;
                     }
-                } 
+                }
                 
                 // also record the payment
                 npe01__OppPayment__c pmt = mapOppIdToPmt.get(opp.Id);
                 if (pmt != null) {
                     di.PaymentImported__c = pmt.Id;
-                    di.PaymentImportStatus__c = (isMatchedByPmtId ? label.bdiMatchedId : label.bdiMatched);
+                    di.PaymentImportStatus__c = (isMatchedByPmtId ? label.bdiMatchedId :
+                        (listPmtIdMatches.size() > 1 ? label.bdiMatchedBest : label.bdiMatched));
                     // put the existing pmt in our map for caller's use
                     mapDIIdToPmt.put(di.Id, pmt);
+
+                    // also record payment matches if any
+                    if (listPmtIdMatches.size() > 1) {
+                        for (integer i = 0; i < listPmtIdMatches.size(); i++) {
+                            ID idPmt = listPmtIdMatches[i];
+                            if (di.Payment_Possible_Matches__c == null) {
+                                di.Payment_Possible_Matches__c = idPmt;
+                            } else {
+                                di.Payment_Possible_Matches__c += ',' + idPmt;
+                            }
+                            // only take the first 10 matches to not blow our 255 char limit.
+                            if (i == 9)
+                                break;
+                        }
+                    }
                 }
             } else {
                 di.DonationImportStatus__c = label.bdiMatchedNone;

--- a/src/classes/BDI_MatchDonations.cls
+++ b/src/classes/BDI_MatchDonations.cls
@@ -112,67 +112,79 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
             
             boolean isMatchedByOppId = false;
             boolean isMatchedByPmtId = false;
+            integer ioppBest = null;
 
             if (listCAOpps != null) {
+                integer dtVarianceOpp = null;
+
                 // go thru each opp for this contact or account
                 for (integer i = 0; i < listCAOpps.size(); i++) {
                     Opportunity opp = listCAOpps[i];
-                    matchType mType = MATCHTYPE.NO_MATCH;
+                    MatchInfo matchInfo = new MatchInfo(MATCHTYPE.NO_MATCH, 0);
 
                     // if 1 or more payments, use Payment matching rules
                     if (opp.npe01__Number_of_Payments__c >= 1) {
                         npe01__OppPayment__c pmtBest = null;
+                        integer dtVariancePmt = null;
+
                         for (npe01__OppPayment__c pmt : opp.npe01__OppPayment__r) {
-                            mType = getMatchTypeByPmtRules(di, pmt);
-                            
-                            if (mType == MATCHTYPE.ID_MATCH) {
+                            matchInfo = getMatchInfoByPmtRules(di, pmt);
+                            system.debug('****DJH: pmt: ' + pmt + ' matchInfo: ' + matchInfo);
+
+                            if (matchInfo.matchType == MATCHTYPE.ID_MATCH) {
                                 pmtBest = pmt;
                                 isMatchedByPmtId = true;
                                 break;
-                            } else if (mType == MATCHTYPE.FIELD_MATCH) {
-                                // we take the first field match as possible best
-                                if (pmtBest == null) {
+                            } else if (matchInfo.matchType == MATCHTYPE.FIELD_MATCH) {
+                                // we start with the first field match as possible best, and then look for closer matches
+                                if (pmtBest == null || matchInfo.dateVariance < dtVariancePmt) {
                                     pmtBest = pmt;
+                                    dtVariancePmt = matchInfo.dateVariance;
                                 }
                             }
                         } // end looping thru payments
-                        
+
                         // save our best match
                         if (pmtBest != null) {
                             mapOppIdToPmt.put(opp.Id, pmtBest);
 
                             // treat a field match as Id match if the Opp was specified
                             if (opp.Id == di.DonationImported__c) {
-                                mType = MATCHTYPE.ID_MATCH;
+                                matchInfo.matchType = MATCHTYPE.ID_MATCH;
                             }
                             
-                            if (mType != MATCHTYPE.ID_MATCH) {
-                                mType = MATCHTYPE.FIELD_MATCH;
+                            if (matchInfo.matchType != MATCHTYPE.ID_MATCH) {
+                                matchInfo.matchType = MATCHTYPE.FIELD_MATCH;
                             }
                         }
                     } // end matching an opp with >= 1 payment
 
                     // if no payments, or we failed to match with a single payment, use Opp matching rules
-                    if (opp.npe01__Number_of_Payments__c <= 1 && mType == MATCHTYPE.NO_MATCH) {
-                        mType = getMatchTypeByOppRules(di, opp);
+                    if (opp.npe01__Number_of_Payments__c <= 1 && matchInfo.matchType == MATCHTYPE.NO_MATCH) {
+                        matchInfo = getMatchInfoByOppRules(di, opp);
                     }
 
-                    if (mType == MATCHTYPE.ID_MATCH) {
+                    if (matchInfo.matchType == MATCHTYPE.ID_MATCH) {
                         // if we matched by Id, then we don't even care about other matches by field.
                         listIMatches.clear();
                         listIMatches.add(i);
+                        ioppBest = i;
                         isMatchedByOppId = true;
                         break;
-                    } else if (mType == MATCHTYPE.FIELD_MATCH) {
+                    } else if (matchInfo.matchType == MATCHTYPE.FIELD_MATCH) {
                         listIMatches.add(i);
+                        // we start with the first field match as possible best, and then look for closer matches
+                        if (ioppBest == null || matchInfo.dateVariance < dtVarianceOpp) {
+                            ioppBest = i;
+                            dtVarianceOpp = matchInfo.dateVariance;
+                        }
                     }
                 } // end looping thru opps
             } 
             
             // if we have 1 or more matches, record the best one
             if (listIMatches.size() > 0) {
-                Integer iOpp = listIMatches[0];
-                Opportunity opp = listCAOpps[iOpp];
+                Opportunity opp = listCAOpps[ioppBest];
                 di.DonationImported__c = opp.Id;
                 // put the existing opp in our map for caller's use
                 mapDIIdToOpp.put(di.Id, opp);
@@ -180,7 +192,7 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
                 // if unique, remove this opp from the list to avoid matching it again.
                 if (listIMatches.size() == 1) {
                     di.DonationImportStatus__c = (isMatchedByOppId ? label.bdiMatchedId : label.bdiMatched);
-                    listCAOpps.remove(iOpp);
+                    listCAOpps.remove(ioppBest);
                 } else {
                     // we have multiple matches, we want to record them all, and fixup our status
                     di.DonationImportStatus__c = label.bdiMatchedBest;
@@ -212,76 +224,115 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
     }
 
     /*******************************************************************************************************
-    * @description describes the type of match returned from our matching routines.  we couldn't use declare
-    * an enum within an inner class, so we went with strings.
+    * @description describes the type of match returned from our matching routines.
     */
     private enum MATCHTYPE {ID_MATCH, FIELD_MATCH, NO_MATCH}
+
+    /*******************************************************************************************************
+    * @description describes the type of match returned from our matching routines
+    */
+    private class MatchInfo {
+        MATCHTYPE matchtype;
+        integer dateVariance;
+
+        MatchInfo(MATCHTYPE matchtype, integer dateVariance) {
+            this.matchtype = matchtype;
+            this.dateVariance = dateVariance;
+        }
+    }
 
     /*******************************************************************************************************
     * @description checks whether the specified opp is a match for this DI record
     * @param di The data import record we are trying to find an opp for
     * @param opp The opp to evaluate
-    * @return matchType
+    * @return MatchInfo
     */
-    private matchType getMatchTypeByOppRules(DataImport__c di, Opportunity opp) {
+    private MatchInfo getMatchInfoByOppRules(DataImport__c di, Opportunity opp) {
         // always match to an Opp we were given the Id to!
         if (di.DonationImported__c == opp.Id) {
-            return MATCHTYPE.ID_MATCH;
+            return new MatchInfo(MATCHTYPE.ID_MATCH, 0);
         }
 
         if (di.DonationImported__c == null) {
             // try match against all specified fields
             boolean isAllMatch = true;
+            integer dtVariance = 0;
+
             for (String strDIField : listMatchFields) {
                 Object val = di.get(strDIField);
+                string strOppField = mapDIFieldToOppField.get(strDIField);
+
+                // special case date matching
+                if (strDIField == UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c').toLowercase() && strOppField != null) {
+                    integer dtVarianceT = math.abs(date.valueOf(val).daysBetween(date.valueOf(opp.get(strOppField))));
+                    if (dtVarianceT <= integer.valueOf(bdi.diSettings.Donation_Date_Range__c)) {
+                        dtVariance = dtVarianceT;
+                        continue;
+                    }
+                }
+
                 // handle mapping a specified record type name to the Id we must compare with
                 if (strDIField == UTIL_Namespace.StrTokenNSPrefix('Donation_Record_Type_Name__c').toLowercase()) {
                     val = UTIL_RecordTypes.getRecordTypeId(Opportunity.sObjectType, string.valueOf(val));
                 }
+
                 // only test opp fields (failing match if payment fields specified)
-                string strOppField = mapDIFieldToOppField.get(strDIField);
                 if (strOppField == null || val != opp.get(strOppField)) {
                     isAllMatch = false;
                     break;
                 }
             }
             if (isAllMatch) {
-                return MATCHTYPE.FIELD_MATCH;
+                return new MatchInfo(MATCHTYPE.FIELD_MATCH, dtVariance);
             }
         }
         
-        return MATCHTYPE.NO_MATCH;
+        return new MatchInfo(MATCHTYPE.NO_MATCH, 0);
     }
     
     /*******************************************************************************************************
     * @description checks whether the specified opp has a Payment match for this DI record
     * @param di The data import record we are trying to find an Opp & Payment for
     * @param pmt The payment to evaluate
-    * @return matchType
+    * @return MatchInfo
     */
-    private matchType getMatchTypeByPmtRules(DataImport__c di, npe01__OppPayment__c pmt) {
+    private MatchInfo getMatchInfoByPmtRules(DataImport__c di, npe01__OppPayment__c pmt) {
 
         // always match to an Payment we were given the Id to!
         if (di.PaymentImported__c == pmt.Id) {
-            return MATCHTYPE.ID_MATCH;
+            return new MatchInfo(MATCHTYPE.ID_MATCH, 0);
         }
 
-        // try match against all specified fields
-        boolean isAllMatch = true;
-        for (String strDIField : listMatchFields) {
-            Object val = di.get(strDIField);
+        if (di.PaymentImported__c == null) {
+            // try match against all specified fields
+            boolean isAllMatch = true;
+            integer dtVariance = 0;
 
-            // only test pmt fields (failing match if Opp fields specified)
-            string strPmtField = mapDIFieldToPmtField.get(strDIField);
-            if (strPmtField == null || val != pmt.get(strPmtField)) {
-                isAllMatch = false;
-                break;
+            for (String strDIField : listMatchFields) {
+                Object val = di.get(strDIField);
+                string strPmtField = mapDIFieldToPmtField.get(strDIField);
+
+                // special case date matching
+                if (strDIField == UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c').toLowercase() && strPmtField != null) {
+                    integer dtVarianceT = math.abs(date.valueOf(val).daysBetween(date.valueOf(pmt.get(strPmtField))));
+                    if (dtVarianceT <= integer.valueOf(bdi.diSettings.Donation_Date_Range__c)) {
+                        dtVariance = dtVarianceT;
+                        continue;
+                    }
+                }
+
+                // only test pmt fields (failing match if Opp fields specified)
+                if (strPmtField == null || val != pmt.get(strPmtField)) {
+                    isAllMatch = false;
+                    break;
+                }
+            }
+            if (isAllMatch) {
+                return new MatchInfo(MATCHTYPE.FIELD_MATCH, dtVariance);
             }
         }
-        if (isAllMatch) {
-            return MATCHTYPE.FIELD_MATCH;
-        }
-        return MATCHTYPE.NO_MATCH;
+
+        return new MatchInfo(MATCHTYPE.NO_MATCH, 0);
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_MatchDonations.cls
+++ b/src/classes/BDI_MatchDonations.cls
@@ -427,7 +427,7 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
         
         // add Payment subquery
         strSoql += ', (select ' + string.join(new list<String>(setPmtFields), ',');
-        strSoql += ' from npe01__OppPayment__r where npe01__Paid__c = false order by npe01__Scheduled_Date__c ASC)'; 
+        strSoql += ' from npe01__OppPayment__r where npe01__Paid__c = false order by npe01__Scheduled_Date__c ASC, CreatedDate ASC)';
         
         strSoql += ' from Opportunity';
         strSoql += ' where IsClosed = false and (';
@@ -449,7 +449,7 @@ public with sharing class BDI_MatchDonations implements BDI_IMatchDonations {
             strSoql += ' ' + UTIL_Namespace.StrTokenNSPrefix('Primary_Contact__c') + ' in :setConId ';
             cFilter++;
         }
-        strSoql += ') order by CloseDate ASC';
+        strSoql += ') order by CloseDate ASC, CreatedDate ASC';
         list<Opportunity> listOpp = database.query(strSoql); 
         return listOpp;           
     }

--- a/src/classes/BDI_SettingsUI_CTRL.cls
+++ b/src/classes/BDI_SettingsUI_CTRL.cls
@@ -160,7 +160,13 @@ public with sharing class BDI_SettingsUI_CTRL {
             diSettings.Donation_Matching_Behavior__c != BDI_DataImport_API.DoNotMatch &&
             String.isBlank(diSettings.Donation_Matching_Rule__c)) {
 
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Warning, Label.bdiDonationMatchingRuleEmpty));
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, Label.bdiDonationMatchingRuleEmpty));
+            return false;
+        }
+
+        // validate Donation Date Range
+        if (diSettings.Donation_Date_Range__c < 0) {
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, Label.bdiPositiveNumber));
             return false;
         }
 
@@ -176,7 +182,7 @@ public with sharing class BDI_SettingsUI_CTRL {
                 }
             }
             if (iMatchDonations == null) {
-                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Warning,
+                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error,
                     String.format(Label.bdiErrorInvalidIMatchDonations, new list<String>{strClass})));
                 return false;
             }

--- a/src/classes/BDI_SettingsUI_TEST.cls
+++ b/src/classes/BDI_SettingsUI_TEST.cls
@@ -58,4 +58,35 @@ private with sharing class BDI_SettingsUI_TEST {
         system.assertNotEquals(null, ctrl.listSOAccountUniqueID);
         Test.stopTest();
     }
+
+    /*********************************************************************************************************
+    * @description operation:
+    *    test validation of save method
+    * verify:
+    *    errors detected
+    **********************************************************************************************************/
+    static testMethod void testBDISettingsUISaveValidation() {
+
+        Data_Import_Settings__c diSettings = new Data_Import_Settings__c();
+
+        Test.startTest();
+
+        diSettings.Donation_Matching_Behavior__c = BDI_DataImport_API.BestMatchOrCreate;
+        system.assertEquals(false, BDI_SettingsUI_CTRL.saveBDISettings(diSettings));
+        diSettings.Donation_Matching_Rule__c = 'Donation_Date__c';
+        system.assertEquals(true, BDI_SettingsUI_CTRL.saveBDISettings(diSettings));
+
+        diSettings.Donation_Date_Range__c = -1;
+        system.assertEquals(false, BDI_SettingsUI_CTRL.saveBDISettings(diSettings));
+        diSettings.Donation_Date_Range__c = 1;
+        system.assertEquals(true, BDI_SettingsUI_CTRL.saveBDISettings(diSettings));
+
+        diSettings.Donation_Matching_Implementing_Class__c = 'foo';
+        system.assertEquals(false, BDI_SettingsUI_CTRL.saveBDISettings(diSettings));
+        diSettings.Donation_Matching_Implementing_Class__c = 'BDI_MatchDonations';
+        system.assertEquals(true, BDI_SettingsUI_CTRL.saveBDISettings(diSettings));
+
+        Test.stopTest();
+    }
+
 }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -594,15 +594,22 @@ public without sharing class UTIL_CustomSettingsFacade {
     }
     
     private static void configDataImportSettings(Data_Import_Settings__c dis) {
-        if (dis.Batch_Size__c == null)
+        if (dis.Batch_Size__c == null) {
             dis.Batch_Size__c = 50;
-        if (dis.Contact_Matching_Rule__c == null)
+        }
+        if (dis.Contact_Matching_Rule__c == null) {
             dis.Contact_Matching_Rule__c = 'Firstname,Lastname,Email';
-        if (dis.Donation_Matching_Behavior__c == null)
+        }
+        if (dis.Donation_Matching_Behavior__c == null) {
             dis.Donation_Matching_Behavior__c = BDI_DataImport_API.DoNotMatch;
-        if (dis.Donation_Matching_Rule__c == null)
+        }
+        if (dis.Donation_Matching_Rule__c == null) {
             dis.Donation_Matching_Rule__c = UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
                 UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c');
+        }
+        if (dis.Donation_Date_Range__c == null) {
+            dis.Donation_Date_Range__c = 0;
+        }
     }
 
     /*******************************************************************************************************

--- a/src/components/BDI_SettingsUI.component
+++ b/src/components/BDI_SettingsUI.component
@@ -121,8 +121,21 @@
                     </apex:outputPanel>
                 </div>
             </div>
-        </div>                    
-        
+        </div>
+
+        <div class="slds-form slds-form_stacked slds-m-left--large">
+            <div class="slds-form-element">
+                <label class="slds-form-element__label">
+                    <apex:outputLabel for="fldDonationDateRange" value="{!$ObjectType.Data_Import_Settings__c.Fields.Donation_Date_Range__c.Label}"/>
+                </label>
+                <c:UTIL_Tooltip tooltip="{!$ObjectType.Data_Import_Settings__c.Fields.Donation_Date_Range__c.InlineHelpText}" />
+                <div class="slds-form-element__control">
+                    <apex:inputField id="fldDonationDateRange" value="{!diSettings.Donation_Date_Range__c}" type="number" styleClass="slds-input" rendered="{!isEditMode}" />
+                    <apex:outputField id="fldDonationDateRangeRO" value="{!diSettings.Donation_Date_Range__c}" styleClass="slds-input" rendered="{!isReadOnlyMode}"/>
+                </div>
+            </div>
+        </div>
+
         <div class="slds-section slds-is-open slds-p-around--xx-small slds-theme--shade">
             <h4 class="slds-section__title slds-m-left--small ">
                 <span class="slds-truncate slds-p-horizontal_small" title="Section Title">{!$Label.bdiSettingsSectionExtensibility}</span>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1427,6 +1427,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Matched an existing contact from a non-Household Account, which is not supported.</value>
     </labels>
     <labels>
+        <fullName>bdiErrorPaymentMultiMatch</fullName>
+        <categories>Data Importer</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>error message if the donation matched multiple pmts</shortDescription>
+        <value>The Donation information matched against multiple Payments, so it was not imported. The Payment Possible Matches field contains the Salesforce Id&apos;s of the matched Payments.</value>
+    </labels>
+    <labels>
         <fullName>bdiFailed</fullName>
         <categories>Data Importer</categories>
         <language>en_US</language>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1120,7 +1120,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>settings label for BestMatchOrCreate behavior</shortDescription>
-        <value>First Match or Create - Import a record if it matches an existing record; create a new record if no match found.</value>
+        <value>Best Match or Create - Import a record if it matches an existing record; create a new record if no match found.</value>
     </labels>
     <labels>
         <fullName>bdiBehaviorDoNotMatch</fullName>
@@ -1144,7 +1144,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>settings label for RequireBestMatch behavior</shortDescription>
-        <value>First Match - Only import a record when it matches at least 1 existing record, and update the first matched record.</value>
+        <value>Best Match - Only import a record when it matches at least 1 existing record, and update the best matched record.</value>
     </labels>
     <labels>
         <fullName>bdiBehaviorRequireExactMatch</fullName>
@@ -1489,6 +1489,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <protected>false</protected>
         <shortDescription>status on a bdi object when no matching record found</shortDescription>
         <value>Matched None</value>
+    </labels>
+    <labels>
+        <fullName>bdiPositiveNumber</fullName>
+        <categories>Data Importer</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>error when numeric settings set to negative number</shortDescription>
+        <value>Number must be positive.</value>
     </labels>
     <labels>
         <fullName>bdiRecordsFailed</fullName>

--- a/src/layouts/DataImport__c-Data Import Layout.layout
+++ b/src/layouts/DataImport__c-Data Import Layout.layout
@@ -403,8 +403,9 @@
                 <behavior>Edit</behavior>
                 <field>Donation_Description__c</field>
             </layoutItems>
-        </layoutColumns>
-        <layoutColumns>
+            <layoutItems>
+                <emptySpace>true</emptySpace>
+            </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Donation_Member_Level__c</field>
@@ -421,6 +422,8 @@
                 <behavior>Edit</behavior>
                 <field>Donation_Membership_End_Date__c</field>
             </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Payment_Method__c</field>
@@ -428,6 +431,9 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Payment_Check_Reference_Number__c</field>
+            </layoutItems>
+            <layoutItems>
+                <emptySpace>true</emptySpace>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -442,8 +448,15 @@
                 <field>DonationImportStatus__c</field>
             </layoutItems>
             <layoutItems>
+                <emptySpace>true</emptySpace>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Edit</behavior>
                 <field>PaymentImported__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Payment_Possible_Matches__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -487,7 +500,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00hG000000UVE7F</masterLabel>
+        <masterLabel>00hj0000000hdaW</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -1010,6 +1010,18 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Payment_Possible_Matches__c</fullName>
+        <description>A comma separated list of ID&apos;s to the first 10 possible Payment matches to a donation.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>A comma separated list of ID&apos;s to the first 10 possible Payment matches to a donation.</inlineHelpText>
+        <label>Payment Possible Matches</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Status__c</fullName>
         <description>The status of importing the Data Import record.</description>
         <externalId>false</externalId>

--- a/src/objects/Data_Import_Settings__c.object
+++ b/src/objects/Data_Import_Settings__c.object
@@ -65,6 +65,20 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Donation_Date_Range__c</fullName>
+        <defaultValue>0</defaultValue>
+        <description>Enter the number of days from the Donation Date that the Data Importer should consider when looking for a matching Opportunity or Payment. The Data Importer will choose the matching Opportunity or Payment whose date falls within the number of days AND is closest to the Donation Date.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Enter the number of days from the Donation Date to consider when looking for a matching Opportunity or Payment. The Data Importer will choose the matching Opp or Payment whose date falls within the number of days AND is closest to the Donation Date.</inlineHelpText>
+        <label>Number of Days from Donation Date</label>
+        <precision>2</precision>
+        <required>false</required>
+        <scale>0</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Donation_Matching_Behavior__c</fullName>
         <defaultValue>&quot;DoNotMatch&quot;</defaultValue>
         <description>Defines how the Data Importer should handle matching Donations.  Must be one of the following values: DoNotMatch, RequireNoMatch, RequireExactMatch, ExactMatchOrCreate, RequireBestMatch, BestMatchOrCreate.</description>

--- a/src/package.xml
+++ b/src/package.xml
@@ -994,6 +994,7 @@
         <members>bdiErrorInvalidLastname</members>
         <members>bdiErrorInvalidOppRTName</members>
         <members>bdiErrorNonHHAccountContact</members>
+        <members>bdiErrorPaymentMultiMatch</members>
         <members>bdiFailed</members>
         <members>bdiHouseholdModelRequired</members>
         <members>bdiIgnored</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -638,6 +638,7 @@
         <members>Data_Import_Settings__c.Batch_Size__c</members>
         <members>Data_Import_Settings__c.Contact_Custom_Unique_ID__c</members>
         <members>Data_Import_Settings__c.Contact_Matching_Rule__c</members>
+        <members>Data_Import_Settings__c.Donation_Date_Range__c</members>
         <members>Data_Import_Settings__c.Donation_Matching_Behavior__c</members>
         <members>Data_Import_Settings__c.Donation_Matching_Implementing_Class__c</members>
         <members>Data_Import_Settings__c.Donation_Matching_Rule__c</members>
@@ -1000,6 +1001,7 @@
         <members>bdiMatchedBest</members>
         <members>bdiMatchedId</members>
         <members>bdiMatchedNone</members>
+        <members>bdiPositiveNumber</members>
         <members>bdiRecordsFailed</members>
         <members>bdiRecordsImported</members>
         <members>bdiRecordsProcessed</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -632,6 +632,7 @@
         <members>DataImport__c.PaymentImported__c</members>
         <members>DataImport__c.Payment_Check_Reference_Number__c</members>
         <members>DataImport__c.Payment_Method__c</members>
+        <members>DataImport__c.Payment_Possible_Matches__c</members>
         <members>DataImport__c.Status__c</members>
         <members>Data_Import_Settings__c.Account_Custom_Unique_ID__c</members>
         <members>Data_Import_Settings__c.Account_Matching_Rule__c</members>


### PR DESCRIPTION
@jjbennett this pull request adds support for a new custom setting field, Number of Days from Donation Date, that now allows matching against Opportunities and Payments with an inexact date match.  Since this involves changes in the matching code which previously only Nic has looked at, I'm happy to schedule a time to walk you thru the code and changes.

Also included is logic to now track multiple payments that are match candidates.  Previously we only tracked multiple Opportunities that are match candidates.

# Critical Changes

# Changes

# Issues Closed