### PR TITLE
#2527 Manage household contact search does not support middle name

### DIFF
--- a/src/aura/HH_AutoCompleteOption/HH_AutoCompleteOption.cmp
+++ b/src/aura/HH_AutoCompleteOption/HH_AutoCompleteOption.cmp
@@ -8,7 +8,7 @@
                 </div>
                 <div class="slds-media__body">
                     <div class="slds-grid slds-grid--align-spread slds-has-flexi-truncate">
-                        <p class="slds-tile__title slds-truncate">{!v.value.FirstName}&nbsp;{!v.value.LastName}</p>
+                        <p class="slds-tile__title slds-truncate">{!v.value.Name}</p>
                         <lightning:buttonIcon iconName="utility:new" variant="bare" onclick="{!c.handleClick}"
                             class="slds-shrink-none" size="large" alternativeText="{!$Label.npo02.Add}" />
                     </div>

--- a/src/aura/HH_ContactCard/HH_ContactCard.cmp
+++ b/src/aura/HH_ContactCard/HH_ContactCard.cmp
@@ -17,7 +17,7 @@
                             <lightning:icon iconName="standard:contact" class="slds-icon--small" size="small"/>
                         </div>
                         <div class="slds-media__body">
-                            <a href="{! '/' + v.contact.Id}" target="_blank">{!v.contact.FirstName}&nbsp;{!v.contact.LastName}</a>
+                            <a href="{! '/' + v.contact.Id}" target="_blank">{!v.contact.Name}</a>
                         </div>
                         <div class="slds-media__figure slds-m-right--none">
                             <lightning:buttonIcon iconName="utility:close" class="removeBtn" variant="bare"

--- a/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
+++ b/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
@@ -57,28 +57,22 @@ public with sharing class HH_AutoCompleteDataProvider_LCTRL {
             // note that our helper does FLS, so we don't have to do it here.
             String strSoql = HH_Container_LCTRL.getContactSelectQueryWithFls() + ' WHERE ';
 
+            Set<Id> contactIds = new Set<Id>();
             if (UTIL_Describe.isMiddleNameEnabled()) {
                 // When the Middlename field is enabled, there is a known issue (as of 6/15/2017) that
                 // prevents a query on the Name field from working properly if the record has a
-                // middlename or suffix value. To work-around this, we'll parse the queryValue into
-                // individual "words" and build a more generic query to find the records.
-                // Technically this will result in a larger result set than we really want
-                // however the only other solution would be to assume that three values will
-                // always match to first/middle/last. If the user enters two values, it could assume
-                // that matches to first + middle OR last. That gets more complicated and doesn't take
-                // into account compound firstnames such as "Anne Marie".
+                // middlename or suffix value. To work around this, use SOSL to search by name
+                // and then run a second query for the returned set of contacts.
                 // This should be considered a temporary work-around until such time as Salesforce
                 // fixes the known issue:
                 // https://success.salesforce.com/issues_view?id=a1p30000000eQRxAAM
-                strSoql += '(';
-                for (String p : preparedQueryValue.remove('%').split(' ')) {
-                    strSoql += ' FirstName LIKE \'%' + String.escapeSingleQuotes(p) + '%\' OR ' +
-                            ' MiddleName LIKE \'%' + String.escapeSingleQuotes(p) + '%\' OR ' +
-                            ' LastName LIKE \'%' + String.escapeSingleQuotes(p) + '%\' OR ';
+                List<List<SObject>> searchResults = [FIND :queryValue IN NAME FIELDS RETURNING Contact(Id, Name) LIMIT 100];
+                for (SObject s : searchResults[0]) {
+                    contactIds.add((Id)s.get('Id'));
                 }
-                strSoql = strSoql.removeEnd(' OR ') + ') ';
+                strSoql += ' Id in :contactIds ';
             } else {
-                strSoql += ' Name LIKE :preparedQueryValue';
+                strSoql += ' Name LIKE :preparedQueryValue ';
             }
             strSoql += ' AND Id not in :listCon LIMIT 100';
 

--- a/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
+++ b/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
@@ -48,7 +48,7 @@ public with sharing class HH_AutoCompleteDataProvider_LCTRL {
             if (listCon == null) {
                 listCon = new list<Contact>();
             }
-            
+
             // '%', '_', and '\' all are special characters in LIKE syntax.
             // We escape them here by prepending those characters with a backslash
             String preparedQueryValue = '%' + queryValue.replaceAll('([%_\\\\])', '\\\\$0') + '%';
@@ -58,7 +58,7 @@ public with sharing class HH_AutoCompleteDataProvider_LCTRL {
             String strSoql = HH_Container_LCTRL.getContactSelectQueryWithFls() + ' WHERE ';
 
             Set<Id> contactIds = new Set<Id>();
-            if (UTIL_Describe.isMiddleNameEnabled()) {
+            if (UTIL_Describe.isMiddleNameEnabled() && queryValue.length() > 1) {
                 // When the Middlename field is enabled, there is a known issue (as of 6/15/2017) that
                 // prevents a query on the Name field from working properly if the record has a
                 // middlename or suffix value. To work around this, use SOSL to search by name
@@ -68,7 +68,7 @@ public with sharing class HH_AutoCompleteDataProvider_LCTRL {
                 // https://success.salesforce.com/issues_view?id=a1p30000000eQRxAAM
                 List<List<SObject>> searchResults = [FIND :queryValue IN NAME FIELDS RETURNING Contact(Id, Name) LIMIT 100];
                 for (SObject s : searchResults[0]) {
-                    contactIds.add((Id)s.get('Id'));
+                    contactIds.add((Id) s.get('Id'));
                 }
                 strSoql += ' Id in :contactIds ';
             } else {
@@ -77,16 +77,16 @@ public with sharing class HH_AutoCompleteDataProvider_LCTRL {
             strSoql += ' AND Id not in :listCon LIMIT 100';
 
             List<SObject> results = Database.query(strSoql);
-    
+
             List<ProviderResult> providerResults = new List<ProviderResult>();
-    
+
             for (SObject so : results) {
                 ProviderResult result = new ProviderResult();
                 result.value = so;
                 result.displayValue = (String) so.get('Name');
                 providerResults.add(result);
             }
-    
+
             return providerResults;
         } catch (Exception e) {
             throw new AuraHandledException(e.getMessage());

--- a/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
+++ b/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
@@ -45,8 +45,9 @@ public with sharing class HH_AutoCompleteDataProvider_LCTRL {
     @AuraEnabled
     public static List<ProviderResult> queryObjects(String queryValue, list<Contact> listCon) {
         try {
-            if (listCon == null)
+            if (listCon == null) {
                 listCon = new list<Contact>();
+            }
             
             // '%', '_', and '\' all are special characters in LIKE syntax.
             // We escape them here by prepending those characters with a backslash

--- a/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
+++ b/src/classes/HH_AutoCompleteDataProvider_LCTRL.cls
@@ -54,9 +54,33 @@ public with sharing class HH_AutoCompleteDataProvider_LCTRL {
             
             // use helper to get all contact fields to support custom household naming and greetings.
             // note that our helper does FLS, so we don't have to do it here.
-            String strSoql = HH_Container_LCTRL.getContactSelectQueryWithFls();
-            strSoql += ' WHERE Name LIKE :preparedQueryValue AND Id not in :listCon LIMIT 100';
-    
+            String strSoql = HH_Container_LCTRL.getContactSelectQueryWithFls() + ' WHERE ';
+
+            if (UTIL_Describe.isMiddleNameEnabled()) {
+                // When the Middlename field is enabled, there is a known issue (as of 6/15/2017) that
+                // prevents a query on the Name field from working properly if the record has a
+                // middlename or suffix value. To work-around this, we'll parse the queryValue into
+                // individual "words" and build a more generic query to find the records.
+                // Technically this will result in a larger result set than we really want
+                // however the only other solution would be to assume that three values will
+                // always match to first/middle/last. If the user enters two values, it could assume
+                // that matches to first + middle OR last. That gets more complicated and doesn't take
+                // into account compound firstnames such as "Anne Marie".
+                // This should be considered a temporary work-around until such time as Salesforce
+                // fixes the known issue:
+                // https://success.salesforce.com/issues_view?id=a1p30000000eQRxAAM
+                strSoql += '(';
+                for (String p : preparedQueryValue.remove('%').split(' ')) {
+                    strSoql += ' FirstName LIKE \'%' + String.escapeSingleQuotes(p) + '%\' OR ' +
+                            ' MiddleName LIKE \'%' + String.escapeSingleQuotes(p) + '%\' OR ' +
+                            ' LastName LIKE \'%' + String.escapeSingleQuotes(p) + '%\' OR ';
+                }
+                strSoql = strSoql.removeEnd(' OR ') + ') ';
+            } else {
+                strSoql += ' Name LIKE :preparedQueryValue';
+            }
+            strSoql += ' AND Id not in :listCon LIMIT 100';
+
             List<SObject> results = Database.query(strSoql);
     
             List<ProviderResult> providerResults = new List<ProviderResult>();

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -233,6 +233,9 @@ public with sharing class HH_Container_LCTRL {
                 'MailingLongitude', 
                 'CreatedDate'
             };
+            if (UTIL_Describe.isMiddleNameEnabled()) {
+                setContactFields.add('Middlename');
+            }
 
                 /*** until we support these, we don't want them to interfere with what the user specifies.
                 if (ADDR_Addresses_TDTM.isStateCountryPicklistsEnabled)
@@ -267,7 +270,10 @@ public with sharing class HH_Container_LCTRL {
             'MailingPostalCode', 
             'MailingCountry', 
             'MailingLatitude', 
-            'MailingLongitude'};        
+            'MailingLongitude'};
+        if (UTIL_Describe.isMiddleNameEnabled()) {
+            setContactFields.add('Middlename');
+        }
         return setContactFields;
     }
 

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -246,6 +246,7 @@ private class HH_Container_TEST {
         initTestData();
 
         Test.startTest();
+        Test.setFixedSearchResults(new List<Id>{ conA.Id, conO.Id });
         
         list<HH_AutoCompleteDataProvider_LCTRL.ProviderResult> listPR = HH_AutoCompleteDataProvider_LCTRL.queryObjects('con', null);
         system.assertEquals(2, listPR.size());

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -452,6 +452,15 @@ public class UTIL_Describe {
         }
     }
 
+    /** @description returns true if the MiddleName field is enabled in this org */
+    public static Boolean isMiddleNameEnabled() {
+        if (!fieldTokens.containsKey('Contact')) {
+            fieldTokens.put('Contact', Contact.sObjectType.getDescribe().fields.getMap());
+            fieldDescribes.put('Contact', new Map<String, Schema.DescribeFieldResult>());
+        }
+        return fieldTokens.get('Contact').containsKey('middlename');
+    }
+
     /** @description our exception object for Field Level & Object Security errors. */
     private class permsException extends Exception {}
     


### PR DESCRIPTION
# Critical Changes

# Changes
* Add work-around support for known issue searching for Contacts when the MiddleName feature is enabled: https://success.salesforce.com/issues_view?id=a1p30000000eQRxAAM

# Issues Closed
Fixes #2527 