### PR TITLE
Manage Household: Add a Contact with the same Address creates multiple default Addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ Referenced Packages
 .*.swp
 *.pyc
 *.sublime-project
+*.sublime-workspace
 /config/

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -210,13 +210,7 @@ flows:
                 task: browsertests_unmanaged_chrome
                 options:
                     use_saucelabs: True
-    ci_feature:
-        tasks:
-            # Set run_tests_debug to query for test classes with the namespace
-            8:
-                options:
-                    managed: True
-            
+     
     dev_org:
         tasks:
             8:

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -348,27 +348,6 @@ public with sharing class HH_Container_LCTRL {
     }
 
     /*******************************************************************************************************
-    * @description deletes the Contacts in the database
-    * @param listCon The list of Contacts to delete
-    * @return void
-    @AuraEnabled
-    public static void deleteContacts(list<Contact> listCon) {
-        try {
-            if (listCon.size() == 0)
-                return;
-            
-            // Check object permissions
-            if (!Contact.sObjectType.getDescribe().isDeletable()) {
-                throw new System.NoAccessException();    
-            }
-            delete listCon;
-        } catch (Exception ex) {
-            throw new AuraHandledException(ex.getMessage());
-        }
-    }
-    */
-
-    /*******************************************************************************************************
     * @description saves any changes to the Household in the database
     * @param hh The Household
     * @return void
@@ -446,23 +425,46 @@ public with sharing class HH_Container_LCTRL {
     */
     @AuraEnabled
     public static void saveHouseholdPage(SObject hh, list<Contact> listCon, list<Contact> listConRemove, list<Account>listHHMerge) {
-
-        // save the Household
         updateHousehold(hh);
         
         // need to merge any households (Accounts only) before we save contacts
         // so we avoid deleting a household if that contact was the last one in the hh.
-        if (listHHMerge != null && listHHMerge.size() > 0) {
+        if (isNotEmpty(listHHMerge)) {
             mergeHouseholds((Account)hh, listHHMerge);
         }
+
+        List<Contact> contacts = new List<Contact>(listCon);
+        contacts.addAll(listConRemove);        
+        upsertContacts(contacts);  
         
-        // save the contacts
-        upsertContacts(listCon);
-        
-        // remove any contacts
-        upsertContacts(listConRemove);                
+        if (isNotEmpty(listHHMerge)) {
+            cleanupAddresses(new List<Id>{ (Id) hh.get('Id') });
+        }          
+    }
+    
+    static Boolean isNotEmpty(List<Account> accounts) {
+        return accounts != null && !accounts.isEmpty();
     }
 
+    static void cleanupAddresses(List<Id> accountIds) {
+        Id[] cleanupAccountIds = new Id[0];       
+        
+        for (Account acc : [SELECT npe01__SYSTEM_AccountType__c FROM Account WHERE Id IN :accountIds]) {
+            if (isHouseholdOrOrganization(acc)) {
+                cleanupAccountIds.add(acc.Id);
+            }           
+        }
+
+        ADDR_Addresses_TDTM.cleanupAccountAddresses(cleanupAccountIds);
+    }
+
+    static Boolean isHouseholdOrOrganization(Account acc) {
+        return acc.npe01__SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_TYPE ||
+            (
+                acc.npe01__SYSTEM_AccountType__c != CAO_Constants.ONE_TO_ONE_ORGANIZATION_TYPE &&
+                acc.npe01__SYSTEM_AccountType__c != CAO_Constants.BUCKET_ORGANIZATION_TYPE
+            );
+    } 
 
     /*******************************************************************************************************
     * @description sets the Household Name and Greetings on the Household object, given the list of Contacts

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -447,7 +447,7 @@ public with sharing class HH_Container_LCTRL {
     * @param accounts The list of Accounts
     * @return Boolean True is the list is not empty, false if the list is null or empty
     */
-    static Boolean isNotEmpty(List<Account> accounts) {
+    private static Boolean isNotEmpty(List<Account> accounts) {
         return accounts != null && !accounts.isEmpty();
     }
 
@@ -456,7 +456,7 @@ public with sharing class HH_Container_LCTRL {
     * @param accountIds List of Account Ids
     * @return void
     */
-    static void cleanupAddresses(List<Id> accountIds) {
+    private static void cleanupAddresses(List<Id> accountIds) {
         Id[] cleanupAccountIds = new Id[0];       
         
         for (Account acc : [SELECT npe01__SYSTEM_AccountType__c FROM Account WHERE Id IN :accountIds]) {
@@ -474,7 +474,7 @@ public with sharing class HH_Container_LCTRL {
     * @return Boolean True if the Account Type is Household Account or another type 
     * except One-to-One Individual and Bucket Individual Account types
     */
-    static Boolean isHouseholdOrOrganization(Account acc) {
+    private static Boolean isHouseholdOrOrganization(Account acc) {
         return acc.npe01__SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_TYPE ||
             (
                 acc.npe01__SYSTEM_AccountType__c != CAO_Constants.ONE_TO_ONE_ORGANIZATION_TYPE &&

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -319,15 +319,15 @@ public with sharing class HH_Container_LCTRL {
                 UTIL_Describe.copyObjectFLS('Contact', con, con2, listStrFld);
                 // Due to the complexity of working in both the Household and Account Household models,
                 // we need to skip the security check on the Household field.
-                    con2.npo02__Household__c = con.npo02__Household__c;
+                con2.npo02__Household__c = con.npo02__Household__c;
                 if (con.Id != null) {
                     listUpdate.add(con2);
                 } else {
                     listInsert.add(con2);
                 }
             }
-            
 
+            
             // avoid saving of contacts from updating household names
             // to avoid record lock errors.  let the household be responsible
             // for updating its name.
@@ -440,12 +440,22 @@ public with sharing class HH_Container_LCTRL {
         if (isNotEmpty(listHHMerge)) {
             cleanupAddresses(new List<Id>{ (Id) hh.get('Id') });
         }          
-    }
-    
+    }    
+
+    /*******************************************************************************************************
+    * @description Checks if the Account list is not empty
+    * @param accounts The list of Accounts
+    * @return Boolean True is the list is not empty, false if the list is null or empty
+    */
     static Boolean isNotEmpty(List<Account> accounts) {
         return accounts != null && !accounts.isEmpty();
     }
 
+    /*******************************************************************************************************
+    * @description Cleans up/refreshes the Addresses for specified Account Ids
+    * @param accountIds List of Account Ids
+    * @return void
+    */
     static void cleanupAddresses(List<Id> accountIds) {
         Id[] cleanupAccountIds = new Id[0];       
         
@@ -458,6 +468,12 @@ public with sharing class HH_Container_LCTRL {
         ADDR_Addresses_TDTM.cleanupAccountAddresses(cleanupAccountIds);
     }
 
+    /*******************************************************************************************************
+    * @description Verifies the Account Type
+    * @param acc An Account
+    * @return Boolean True if the Account Type is Household Account or another type 
+    * except One-to-One Individual and Bucket Individual Account types
+    */
     static Boolean isHouseholdOrOrganization(Account acc) {
         return acc.npe01__SYSTEM_AccountType__c == CAO_Constants.HH_ACCOUNT_TYPE ||
             (

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -132,22 +132,6 @@ private class HH_Container_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Tests deleteContacts()
-    public static testMethod void testDeleteContacts() { 
-        initTestData();
-        list<Contact> listCon = new list<Contact>{conA, conO};
-
-        Test.startTest();
-                    
-        HH_Container_LCTRL.deleteContacts(listCon);
-        listCon = [select FirstName from Contact order by FirstName desc];
-        system.assertEquals(0, listCon.size());
-
-        Test.stopTest();        
-    }
-    */
-
-    /*********************************************************************************************************
     * @description Tests updateHousehold()
     */
     public static testMethod void testUpdateHousehold() { 
@@ -185,6 +169,157 @@ private class HH_Container_TEST {
         
         Test.stopTest();        
     }
+
+    static testMethod void saveHouseholdMergeShouldResultInOneDefaultAddress() {
+        Integer accountSize = 3;
+        Account[] accounts = buildAccounts(accountSize);
+        insert accounts;
+
+        Address__c[] addresses = buildAddresses(accounts);
+        //One Account has the same address as the Household
+        addresses[1].MailingStreet__c = addresses[0].MailingStreet__c;
+        insert addresses;
+
+        Integer contactsPerAccount = 1;
+        insert buildContacts(accounts, contactsPerAccount);
+
+        Map<Id, Contact[]> contactsByHh = getContactsByHousehold();
+        System.assertEquals(accountSize, contactsByHh.size());
+
+        Contact[] hhContacts = contactsByHh.get(accounts[0].Id);
+        for (Integer i = 1; i < accountSize; i++) {
+            Contact newContact = contactsByHh.get(accounts[i].Id)[0];
+
+            newContact.AccountId = accounts[0].Id;
+
+            //Copy the Address to Contact the same way as it being done from Manage Household.
+            //No other update, such as Household Naming, is done since it does not impact this test.
+            copyAddressToContact(addresses[0], newContact);
+            
+            hhContacts.add(newContact);
+        }
+
+        Contact[] hhContactsToRemove = new Contact[0];
+        Account[] accountsToMerge = new Account[] { accounts[1], accounts[2] };
+
+        Test.startTest();
+        HH_Container_LCTRL.saveHouseholdPage(accounts[0], hhContacts, hhContactsToRemove, accountsToMerge);
+        Test.stopTest();
+
+        Address__c[] actualAddresses = getAddresses();
+        System.assertEquals(2, actualAddresses.size(), actualAddresses);
+
+        Address__c defaultAddress = null;
+        for (Address__c addr : actualAddresses) {
+            Boolean isDefault = addr.Id == addresses[0].Id;
+            System.assertEquals(isDefault, addr.Default_Address__c, addr); 
+
+            if (isDefault) {
+                defaultAddress = addr;
+            }
+        }
+
+        System.assertNotEquals(null, defaultAddress); 
+
+        contactsByHh = getContactsByHousehold();
+        System.assertEquals(1, contactsByHh.size()); 
+        Contact[] actualContacts = contactsByHh.get(accounts[0].Id);
+        System.assertEquals(hhContacts.size(), actualContacts.size(), actualContacts); 
+
+        for (Contact c : actualContacts) {
+            System.assertEquals(defaultAddress.Id, c.Current_Address__c);
+        }     
+    }
+
+    static Account[] buildAccounts(Integer size) {
+        Account[] accounts = new Account[0];
+
+        for (Integer i = 0; i < size; i++) {
+            accounts.add(new Account(
+                Name = 'TestManageHousehold' + i,
+                npe01__SYSTEM_AccountType__c = CAO_Constants.HH_ACCOUNT_TYPE
+            ));
+        }
+
+        return accounts;
+    }
+
+    static Address__c[] buildSameStreetAddresses(Account[] accounts) {
+        return buildAddresses(accounts, true);
+    }
+
+    static Address__c[] buildAddresses(Account[] accounts) {
+        return buildAddresses(accounts, false);
+    }
+
+    static Address__c[] buildAddresses(Account[] accounts, Boolean isSameStreetAddress) {
+        Address__c[] addresses = new Address__c[0];
+
+        for (Integer i = 0, size = accounts.size(); i < size; i++) {
+            String streetPrefix = isSameStreetAddress ? '' : String.valueOf(i);
+
+            addresses.add(new Address__c(
+                Household_Account__c = accounts[i].Id,
+                Default_Address__c = true,
+                MailingStreet__c = streetPrefix + ' Main St',
+                MailingCity__c = 'New York',
+                MailingCountry__c = 'United States'
+            ));
+        }
+
+        return addresses;
+    }
+
+    static Contact[] buildContacts(Account[] accounts, Integer sizePerAccount) {
+        Contact[] contacts = new Contact[0];
+
+        for (Account acc : accounts) {
+            for (Integer i = 0; i < sizePerAccount; i++) {
+                contacts.add(new Contact(
+                    LastName = acc.Name + i, 
+                    AccountId = acc.Id
+                ));
+            }
+        }
+
+        return contacts;
+    }
+
+    static void copyAddressToContact(Address__c addr, Contact c) {
+        c.MailingStreet = addr.MailingStreet__c;
+        c.MailingCity = addr.MailingCity__c;
+        c.MailingState = addr.MailingState__c;
+        c.MailingPostalCode = addr.MailingPostalCode__c;
+        c.MailingCountry = addr.MailingCountry__c;
+    }
+
+    static Map<Id, Contact[]> getContactsByHousehold() {
+        Map<Id, Contact[]> contactsByHh = new Map<Id, Contact[]>();
+
+        for (Contact c : getContacts()) {
+            if (!contactsByHh.containsKey(c.AccountId)) {
+                contactsByHh.put(c.AccountId, new Contact[0]);
+            }
+
+            contactsByHh.get(c.AccountId).add(c);
+        }
+
+        return contactsByHh;
+    }
+
+    static Contact[] getContacts() {
+        return Database.query(HH_Container_LCTRL.getContactSelectQueryWithFls());     
+    }
+
+    static Address__c[] getAddresses() {
+        return [
+            SELECT Default_Address__c, Household_Account__c, Address_Type__c,
+                MailingStreet__c, MailingCity__c, MailingState__c,
+                MailingPostalCode__c, MailingCountry__c
+            FROM Address__c
+        ];
+    }
+    
     
     /*********************************************************************************************************
     * @description Tests getHHNamesGreetings()

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -482,7 +482,7 @@ private class HH_Container_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Retrieved Contacts and maps Contacts to a Household
+    * @description Retrieves Contacts and maps Contacts to a Household
     * @return Map<Id, Contact[]> Map of Contacts by a Household
     **********************************************************************************************************/
     static Map<Id, Contact[]> getContactsByHousehold() {

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -179,7 +179,7 @@ private class HH_Container_TEST {
         Only one default Address exists for the Household.
         Other Households are merged with the Household.
     **********************************************************************************************************/ 
-    static testMethod void saveShouldResultInOneDefaultAddressWhenContactsAreAddedToTheHousehold() {
+    private static testMethod void saveShouldResultInOneDefaultAddressWhenContactsAreAddedToTheHousehold() {
         Integer accountSize = 3;
         Account[] accounts = buildAccounts(accountSize);
         insert accounts;
@@ -256,7 +256,7 @@ private class HH_Container_TEST {
         A new Household and an Address are created for the Removed Contact.
         No Household is merged.
     **********************************************************************************************************/ 
-    static testMethod void saveShouldAddRemovedContactToNewHousehold() {
+    private static testMethod void saveShouldAddRemovedContactToNewHousehold() {
         Integer accountSize = 2;
         Account[] accounts = buildAccounts(accountSize);
         insert accounts;
@@ -412,7 +412,7 @@ private class HH_Container_TEST {
     * @param size Number of Accounts to build
     * @return Account[] List of Accounts
     **********************************************************************************************************/
-    static Account[] buildAccounts(Integer size) {
+    private static Account[] buildAccounts(Integer size) {
         Account[] accounts = new Account[0];
 
         for (Integer i = 0; i < size; i++) {
@@ -430,7 +430,7 @@ private class HH_Container_TEST {
     * @param accounts List of Accounts to associate Addresses with
     * @return Address__c[] List of Addresses
     **********************************************************************************************************/
-    static Address__c[] buildAddresses(Account[] accounts) {
+    private static Address__c[] buildAddresses(Account[] accounts) {
         Address__c[] addresses = new Address__c[0];
 
         for (Integer i = 0, size = accounts.size(); i < size; i++) {
@@ -452,7 +452,7 @@ private class HH_Container_TEST {
     * @param sizePerAccount Number of Contacts per Account
     * @return Contact[] List of Contacts
     **********************************************************************************************************/
-    static Contact[] buildContacts(Account[] accounts, Integer sizePerAccount) {
+    private static Contact[] buildContacts(Account[] accounts, Integer sizePerAccount) {
         Contact[] contacts = new Contact[0];
 
         for (Account acc : accounts) {
@@ -473,7 +473,7 @@ private class HH_Container_TEST {
     * @param c Contact
     * @return void
     **********************************************************************************************************/
-    static void copyAddressToContact(Address__c addr, Contact c) {
+    private static void copyAddressToContact(Address__c addr, Contact c) {
         c.MailingStreet = addr.MailingStreet__c;
         c.MailingCity = addr.MailingCity__c;
         c.MailingState = addr.MailingState__c;
@@ -485,7 +485,7 @@ private class HH_Container_TEST {
     * @description Retrieves Contacts and maps Contacts to a Household
     * @return Map<Id, Contact[]> Map of Contacts by a Household
     **********************************************************************************************************/
-    static Map<Id, Contact[]> getContactsByHousehold() {
+    private static Map<Id, Contact[]> getContactsByHousehold() {
         Map<Id, Contact[]> contactsByHh = new Map<Id, Contact[]>();
 
         for (Contact c : getContacts()) {
@@ -503,7 +503,7 @@ private class HH_Container_TEST {
     * @description Retrieves all Contacts with fields relevant for the Manage Household page
     * @return Contact[] List of all Contacts
     **********************************************************************************************************/
-    static Contact[] getContacts() {
+    private static Contact[] getContacts() {
         return Database.query(HH_Container_LCTRL.getContactSelectQueryWithFls());     
     }
 
@@ -511,7 +511,7 @@ private class HH_Container_TEST {
     * @description Retrieves all Addresses from database
     * @return Address__c[] List of all Addresses
     **********************************************************************************************************/
-    static Address__c[] getAddresses() {
+    private static Address__c[] getAddresses() {
         return [
             SELECT Default_Address__c, Household_Account__c, Address_Type__c,
                 MailingStreet__c, MailingCity__c, MailingState__c,
@@ -524,7 +524,7 @@ private class HH_Container_TEST {
     * @description Retrieves all Account from database
     * @return Account[] List of all Accounts
     **********************************************************************************************************/
-    static Account[] getAccounts() {
+    private static Account[] getAccounts() {
         return [
             SELECT Name, BillingStreet, BillingCity, 
                 BillingState, BillingPostalCode, BillingCountry

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -170,7 +170,16 @@ private class HH_Container_TEST {
         Test.stopTest();        
     }
 
-    static testMethod void saveHouseholdMergeShouldResultInOneDefaultAddress() {
+    /*********************************************************************************************************
+    @description
+        Add new Contacts into the Household where:
+            - The only Contact from another Household has the same Address
+            - The only Contact from another Household has different Address
+    verify:
+        Only one default Address exists for the Household.
+        Other Households are merged with the Household.
+    **********************************************************************************************************/ 
+    static testMethod void saveShouldResultInOneDefaultAddressWhenContactsAreAddedToTheHousehold() {
         Integer accountSize = 3;
         Account[] accounts = buildAccounts(accountSize);
         insert accounts;
@@ -182,6 +191,9 @@ private class HH_Container_TEST {
 
         Integer contactsPerAccount = 1;
         insert buildContacts(accounts, contactsPerAccount);
+
+        //Refresh the Household data from database
+        accounts[0] = (Account) HH_Container_LCTRL.getHH(accounts[0].Id);
 
         Map<Id, Contact[]> contactsByHh = getContactsByHousehold();
         System.assertEquals(accountSize, contactsByHh.size());
@@ -203,8 +215,13 @@ private class HH_Container_TEST {
         Account[] accountsToMerge = new Account[] { accounts[1], accounts[2] };
 
         Test.startTest();
+        ADDR_Addresses_TDTM.hasRunAddrTrigger = false;
         HH_Container_LCTRL.saveHouseholdPage(accounts[0], hhContacts, hhContactsToRemove, accountsToMerge);
         Test.stopTest();
+
+        Account[] actualAccounts = getAccounts();
+        System.assertEquals(1, actualAccounts.size(), actualAccounts);
+        System.assertEquals(accounts[0].Id, actualAccounts[0].Id);
 
         Address__c[] actualAddresses = getAddresses();
         System.assertEquals(2, actualAddresses.size(), actualAddresses);
@@ -231,95 +248,87 @@ private class HH_Container_TEST {
         }     
     }
 
-    static Account[] buildAccounts(Integer size) {
-        Account[] accounts = new Account[0];
+    /*********************************************************************************************************
+    @description
+        Add a new Contact into the Household and remove a Contact from the Household.
+    verify:
+        The new Contact is added to the Household.
+        A new Household and an Address are created for the Removed Contact.
+        No Household is merged.
+    **********************************************************************************************************/ 
+    static testMethod void saveShouldAddRemovedContactToNewHousehold() {
+        Integer accountSize = 2;
+        Account[] accounts = buildAccounts(accountSize);
+        insert accounts;
 
-        for (Integer i = 0; i < size; i++) {
-            accounts.add(new Account(
-                Name = 'TestManageHousehold' + i,
-                npe01__SYSTEM_AccountType__c = CAO_Constants.HH_ACCOUNT_TYPE
-            ));
-        }
+        Address__c[] addresses = buildAddresses(accounts);
+        insert addresses;
 
-        return accounts;
-    }
+        Integer contactsPerAccount = 2;
+        insert buildContacts(accounts, contactsPerAccount);
 
-    static Address__c[] buildSameStreetAddresses(Account[] accounts) {
-        return buildAddresses(accounts, true);
-    }
+        //Refresh the Household data from database
+        accounts[0] = (Account) HH_Container_LCTRL.getHH(accounts[0].Id);
 
-    static Address__c[] buildAddresses(Account[] accounts) {
-        return buildAddresses(accounts, false);
-    }
+        Map<Id, Contact[]> contactsByHh = getContactsByHousehold();
+        System.assertEquals(accountSize, contactsByHh.size());
 
-    static Address__c[] buildAddresses(Account[] accounts, Boolean isSameStreetAddress) {
-        Address__c[] addresses = new Address__c[0];
+        Contact[] hhContacts = new Contact[] { contactsByHh.get(accounts[0].Id)[0] };
 
-        for (Integer i = 0, size = accounts.size(); i < size; i++) {
-            String streetPrefix = isSameStreetAddress ? '' : String.valueOf(i);
+        Contact newContact = contactsByHh.get(accounts[1].Id)[0];
+        newContact.AccountId = accounts[0].Id;
+        copyAddressToContact(addresses[0], newContact);        
+        hhContacts.add(newContact);
 
-            addresses.add(new Address__c(
-                Household_Account__c = accounts[i].Id,
-                Default_Address__c = true,
-                MailingStreet__c = streetPrefix + ' Main St',
-                MailingCity__c = 'New York',
-                MailingCountry__c = 'United States'
-            ));
-        }
+        Contact removedContact = contactsByHh.get(accounts[0].Id)[1];
+        removedContact.AccountId = null;
 
-        return addresses;
-    }
+        Contact[] hhContactsToRemove = new Contact[] { removedContact };
+        Account[] accountsToMerge = new Account[0];
 
-    static Contact[] buildContacts(Account[] accounts, Integer sizePerAccount) {
-        Contact[] contacts = new Contact[0];
+        Test.startTest();
+        ADDR_Addresses_TDTM.hasRunAddrTrigger = false;
+        HH_Container_LCTRL.saveHouseholdPage(accounts[0], hhContacts, hhContactsToRemove, accountsToMerge);
+        Test.stopTest();
 
-        for (Account acc : accounts) {
-            for (Integer i = 0; i < sizePerAccount; i++) {
-                contacts.add(new Contact(
-                    LastName = acc.Name + i, 
-                    AccountId = acc.Id
-                ));
-            }
-        }
+        //Verify a new Account and an Address have been created for the removed Contact
+        Integer actualAccountSize = accountSize + 1;
+        Account[] actualAccounts = getAccounts();
+        System.assertEquals(actualAccountSize, actualAccounts.size(), actualAccounts);
 
-        return contacts;
-    }
+        Address__c[] actualAddresses = getAddresses();
+        System.assertEquals(actualAccountSize, actualAddresses.size(), actualAddresses);
+        
+        contactsByHh = getContactsByHousehold();
+        System.assertEquals(actualAccountSize, contactsByHh.size(), contactsByHh); 
 
-    static void copyAddressToContact(Address__c addr, Contact c) {
-        c.MailingStreet = addr.MailingStreet__c;
-        c.MailingCity = addr.MailingCity__c;
-        c.MailingState = addr.MailingState__c;
-        c.MailingPostalCode = addr.MailingPostalCode__c;
-        c.MailingCountry = addr.MailingCountry__c;
-    }
-
-    static Map<Id, Contact[]> getContactsByHousehold() {
-        Map<Id, Contact[]> contactsByHh = new Map<Id, Contact[]>();
-
-        for (Contact c : getContacts()) {
-            if (!contactsByHh.containsKey(c.AccountId)) {
-                contactsByHh.put(c.AccountId, new Contact[0]);
+        for (Account acc : actualAccounts) {
+            Address__c[] accountAddresses = new Address__c[0];
+            for (Address__c addr : actualAddresses) {
+                if (addr.Household_Account__c == acc.Id) {
+                    accountAddresses.add(addr);
+                }
             }
 
-            contactsByHh.get(c.AccountId).add(c);
-        }
+            System.assertEquals(1, accountAddresses.size(), accountAddresses);
 
-        return contactsByHh;
-    }
+            Contact[] contacts = contactsByHh.get(acc.Id);
+            Integer expectedContactSize = acc.Id == accounts[0].Id ? 2 : 1;
 
-    static Contact[] getContacts() {
-        return Database.query(HH_Container_LCTRL.getContactSelectQueryWithFls());     
-    }
+            System.assertNotEquals(null, contacts);
+            System.assertEquals(expectedContactSize, contacts.size());
 
-    static Address__c[] getAddresses() {
-        return [
-            SELECT Default_Address__c, Household_Account__c, Address_Type__c,
-                MailingStreet__c, MailingCity__c, MailingState__c,
-                MailingPostalCode__c, MailingCountry__c
-            FROM Address__c
-        ];
-    }
-    
+            for (Contact c : contacts) {
+                if (acc.Id == accounts[0].Id) {
+                    System.assert(c.Id == hhContacts[0].Id || c.Id == hhContacts[1].Id);
+                } else if (acc.Id != accounts[1].Id) {
+                    System.assertEquals(removedContact.Id, c.Id);
+                }
+                
+                System.assertEquals(accountAddresses[0].Id, c.Current_Address__c);
+            }     
+        } 
+    }    
     
     /*********************************************************************************************************
     * @description Tests getHHNamesGreetings()
@@ -393,5 +402,133 @@ private class HH_Container_TEST {
         system.assertEquals(0, listPR.size());
         
         Test.stopTest();
+    }
+
+    // Helpers
+    ////////////
+
+    /*********************************************************************************************************
+    * @description Builds Accounts with Household Account Type
+    * @param size Number of Accounts to build
+    * @return Account[] List of Accounts
+    **********************************************************************************************************/
+    static Account[] buildAccounts(Integer size) {
+        Account[] accounts = new Account[0];
+
+        for (Integer i = 0; i < size; i++) {
+            accounts.add(new Account(
+                Name = 'TestManageHousehold' + i,
+                npe01__SYSTEM_AccountType__c = CAO_Constants.HH_ACCOUNT_TYPE
+            ));
+        }
+
+        return accounts;
+    }
+
+    /*********************************************************************************************************
+    * @description Builds a default Address for each Account
+    * @param accounts List of Accounts to associate Addresses with
+    * @return Address__c[] List of Addresses
+    **********************************************************************************************************/
+    static Address__c[] buildAddresses(Account[] accounts) {
+        Address__c[] addresses = new Address__c[0];
+
+        for (Integer i = 0, size = accounts.size(); i < size; i++) {
+            addresses.add(new Address__c(
+                Household_Account__c = accounts[i].Id,
+                Default_Address__c = true,
+                MailingStreet__c = i + ' Main St',
+                MailingCity__c = 'New York',
+                MailingCountry__c = 'United States'
+            ));
+        }
+
+        return addresses;
+    }
+
+    /*********************************************************************************************************
+    * @description Builds specified number of Contacts for Accounts
+    * @param accounts List of Accounts to build Contacts for
+    * @param sizePerAccount Number of Contacts per Account
+    * @return Contact[] List of Contacts
+    **********************************************************************************************************/
+    static Contact[] buildContacts(Account[] accounts, Integer sizePerAccount) {
+        Contact[] contacts = new Contact[0];
+
+        for (Account acc : accounts) {
+            for (Integer i = 0; i < sizePerAccount; i++) {
+                contacts.add(new Contact(
+                    LastName = acc.Name + i, 
+                    AccountId = acc.Id
+                ));
+            }
+        }
+
+        return contacts;
+    }
+
+    /*********************************************************************************************************
+    * @description Populates Contact's Mailing Address from the source Address
+    * @param addr Address
+    * @param c Contact
+    * @return void
+    **********************************************************************************************************/
+    static void copyAddressToContact(Address__c addr, Contact c) {
+        c.MailingStreet = addr.MailingStreet__c;
+        c.MailingCity = addr.MailingCity__c;
+        c.MailingState = addr.MailingState__c;
+        c.MailingPostalCode = addr.MailingPostalCode__c;
+        c.MailingCountry = addr.MailingCountry__c;
+    }
+
+    /*********************************************************************************************************
+    * @description Retrieved Contacts and maps Contacts to a Household
+    * @return Map<Id, Contact[]> Map of Contacts by a Household
+    **********************************************************************************************************/
+    static Map<Id, Contact[]> getContactsByHousehold() {
+        Map<Id, Contact[]> contactsByHh = new Map<Id, Contact[]>();
+
+        for (Contact c : getContacts()) {
+            if (!contactsByHh.containsKey(c.AccountId)) {
+                contactsByHh.put(c.AccountId, new Contact[0]);
+            }
+
+            contactsByHh.get(c.AccountId).add(c);
+        }
+
+        return contactsByHh;
+    }
+
+    /*********************************************************************************************************
+    * @description Retrieves all Contacts with fields relevant for the Manage Household page
+    * @return Contact[] List of all Contacts
+    **********************************************************************************************************/
+    static Contact[] getContacts() {
+        return Database.query(HH_Container_LCTRL.getContactSelectQueryWithFls());     
+    }
+
+    /*********************************************************************************************************
+    * @description Retrieves all Addresses from database
+    * @return Address__c[] List of all Addresses
+    **********************************************************************************************************/
+    static Address__c[] getAddresses() {
+        return [
+            SELECT Default_Address__c, Household_Account__c, Address_Type__c,
+                MailingStreet__c, MailingCity__c, MailingState__c,
+                MailingPostalCode__c, MailingCountry__c
+            FROM Address__c
+        ];
+    }
+
+    /*********************************************************************************************************
+    * @description Retrieves all Account from database
+    * @return Account[] List of all Accounts
+    **********************************************************************************************************/
+    static Account[] getAccounts() {
+        return [
+            SELECT Name, BillingStreet, BillingCity, 
+                BillingState, BillingPostalCode, BillingCountry
+            FROM Account
+        ];
     }
 }


### PR DESCRIPTION
Currently, an update of Addresses is done asynchronously (via a future Apex method) for Account Merge, Contact Merge and a Household update via Manage Household. So, due to the Address update lag, users might see Addresses that are not cleaned up if the future job does not execute relatively soon upon saving changes and closing Manage Household page. Thus, a change has been made to cleanup Addresses synchronously via Manage Household.
# Critical Changes

# Changes

# Issues Closed
Fixes #2566 