### PR TITLE
only set personaccountdefault on org type

### DIFF
--- a/tasks/salesforce.py
+++ b/tasks/salesforce.py
@@ -6,9 +6,9 @@ from cumulusci.utils import findReplaceRegex
 rt_visibility_template = """
 <recordTypeVisibilities>
     <default>{}</default>
-    <personAccountDefault>true</personAccountDefault>
     <recordType>{}</recordType>
     <visible>true</visible>
+    {}
 </recordTypeVisibilities>
 """
 
@@ -27,11 +27,13 @@ class UpdateAdminProfile(BaseUpdateAdminProfile):
         
         # Set record type visibilities
         self._set_record_type('Account.HH_Account', 'false')
-        self._set_record_type('Account.Organization', 'true')
+        self._set_record_type('Account.Organization', 'true', '    <personAccountDefault>true</personAccountDefault>')
         self._set_record_type('Opportunity.NPSP_Default', 'true')
 
-    def _set_record_type(self, name, default):
-        rt = rt_visibility_template.format(default, name)
+    def _set_record_type(self, name, default, extra=None):
+        if not extra:
+            extra = ''
+        rt = rt_visibility_template.format(default, name, extra)
         findReplace(
             '<tabVisibilities>',
             '{}<tabVisibilities>'.format(rt),


### PR DESCRIPTION
# Critical Changes

# Changes

Fix the update_admin_profile task to only assign a single Account Record Type as the Person Accounts Default

# Issues Closed