### PR TITLE
Recurring donations - Support option for "Always use last day of month"

### DIFF
--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -260,39 +260,41 @@ public class RD_RecurringDonations {
     * currency iso fields.  Does not include the where clause since different callers have different
     * filtering needs.
     * @return string
-    */ 
+    */
     public static string strQueryRDNoWhere() {
-    	
-    	// these must be lowercase so set.contains() will work
+
+        // these must be lowercase so set.contains() will work
         set<string> existingFields = new set<string>{  'npe03__open_ended_status__c', 'npe03__next_payment_date__c', 'name', 'npe03__Paid_Amount__c',
-                                                       'npe03__organization__c', 'npe03__contact__c', 'npe03__installment_amount__c',
-                                                       'npe03__installments__c', 'npe03__amount__c', 'npe03__total__c', 'npe03__installment_period__c',
-                                                       'npe03__date_established__c', 'npe03__donor_name__c', 'npe03__schedule_type__c', 
-                                                       'npe03__recurring_donation_campaign__c', 'npe03__total_paid_installments__c', 'ownerid'};
-        
+                'npe03__organization__c', 'npe03__contact__c', 'npe03__installment_amount__c',
+                'npe03__installments__c', 'npe03__amount__c', 'npe03__total__c', 'npe03__installment_period__c',
+                'npe03__date_established__c', 'npe03__donor_name__c', 'npe03__schedule_type__c',
+                'npe03__recurring_donation_campaign__c', 'npe03__total_paid_installments__c', 'ownerid',
+                'always_use_last_day_of_month__c'};
+
         String queryRCD = 'select id';
         for (string s : existingFields){
-            queryRCD += ', ' + s;               
+            queryRCD += ', ' + s;
         }
-   
+
         //add any custom mapping to make sure we have the required fields
         for (string s : customFieldMappingSettings.keySet()){
-            string RDFieldName = customFieldMappingSettings.get(s).npe03__Recurring_Donation_Field__c;             
+            string RDFieldName = customFieldMappingSettings.get(s).npe03__Recurring_Donation_Field__c;
             if (!existingFields.contains(RDFieldName.toLowerCase()) && s != 'id'){
-               queryRCD = queryRCD + ',' + customFieldMappingSettings.get(s).npe03__Recurring_Donation_Field__c;
-               existingFields.add(RDFieldName.toLowerCase());   
+                queryRCD = queryRCD + ',' + customFieldMappingSettings.get(s).npe03__Recurring_Donation_Field__c;
+                existingFields.add(RDFieldName.toLowerCase());
             }
-        }       
-   
+        }
+
         //if currencyiso field exists add it to query for use later
-        if (isMultiCurrency)
+        if (isMultiCurrency) {
             queryRCD = queryRCD + ',CurrencyIsoCode';
-    
+        }
+
         queryRCD=queryRCD+' from npe03__Recurring_Donation__c';
-        
+
         return (queryRCD);
-    }   
-     
+    }
+
     /*******************************************************************************************************
     * @description Future method that creates new Opportunities for the specified Recurring Donations.
     * @param recurringDonations The list of RD's being created

--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -1133,13 +1133,13 @@ public class RD_RecurringDonations {
     private static date dtEndOfMonthFixup(date dt, npe03__Recurring_Donation__c rd) {
         if (dt.day() == 31 || rd.Always_Use_Last_Day_Of_Month__c == true) {
             dt = date.newInstance(dt.year(), dt.month(), date.daysInMonth(dt.year(), dt.Month()));
-        } else if (dt.day() >= 28 && rd.npe03__Next_Payment_Date__c != null) {
-            // To handle a scenario where the DateEstablished is the >= 29 for a Monthly Donation,
-            // when the system gets around to February, it'll change the next donation to 28/29
+        } else if (dt.day() >= 28 && (rd.npe03__Next_Payment_Date__c != null || rd.npe03__Date_Established__c != null)) {
+            // To handle a scenario where the NextPayment or DateEstablished is the >= 29 for a Monthly
+            // Donation, when the system gets around to February, it'll change the next donation to 28/29
             // which then causes all subsequent months to be set to the 28th (or 29th).
             // This logic ensures that the calculated End Of Month date takes this into account
             // rather than just use the DayOfMonth from the previous installment.
-            Date estDate = rd.npe03__Next_Payment_Date__c;
+            Date estDate = (rd.npe03__Next_Payment_Date__c != null ? rd.npe03__Next_Payment_Date__c : rd.npe03__Date_Established__c);
             Integer dayOfMonth = (date.daysInMonth(dt.year(), dt.Month()) < estDate.day() ?
                     date.daysInMonth(dt.year(), dt.Month()) : estDate.day());
             dt = date.newInstance(dt.year(), dt.month(), dayOfMonth);

--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -350,13 +350,8 @@ public class RD_RecurringDonations {
                 Decimal installs = r.npe03__Installments__c;
                 Integer installments = (installs == null ? 0 : installs.intValue());
                     
-                date OppCloseDate;             
-                if (r.npe03__Next_Payment_Date__c != null)                     
-                    OppCloseDate = r.npe03__Next_Payment_Date__c;
-                else{
-                    OppCloseDate = r.npe03__Date_Established__c;                                                                        
-                }                                             
-                
+                date OppCloseDate = getStartDate(r);
+
                 Integer j=0;
                 decimal installmentAmount = r.npe03__Installment_Amount__c;
 
@@ -438,7 +433,8 @@ public class RD_RecurringDonations {
                     *********************************/
                                         
                     OppCloseDate = getNextDate(OppCloseDate, r);
-                
+
+                    // TODO: Rewrite this to use the NPSP settings for Opportunity Naming
                     String oName = '';
                     oName += r.npe03__Donor_Name__c; 
                     oName += ' ';
@@ -485,13 +481,8 @@ public class RD_RecurringDonations {
                 //if its not 'open', we're not doing anything to it
                 if (r.npe03__Open_Ended_Status__c == system.label.npe03.RecurringDonationOpenStatus){
                     //get settings so we can figure out how many donations to create                    
-                    date OppCloseDate;
-                  
-                    if (r.npe03__Next_Payment_Date__c != null)                     
-                        OppCloseDate = r.npe03__Next_Payment_Date__c;
-                    else{
-                        OppCloseDate = r.npe03__Date_Established__c;                                                                        
-                    }                                             
+                    date OppCloseDate = getStartDate(r);
+
                     /*
                     if (r.npe03__Total_Paid_Installments__c > 0){
                             OppCloseDate = getNextDate(OppCloseDate, r);
@@ -736,10 +727,8 @@ public class RD_RecurringDonations {
         //loop through existing opps for each RD and update according to values on the RD
         for (id RDid : RDOppMap.keySet()){
             
-            date PaymentDate = RDMap.get(RDid).npe03__Next_Payment_Date__c;
-            if (PaymentDate == null)
-                PaymentDate = RDMap.get(RDid).npe03__Date_Established__c;
-            
+            date PaymentDate = getStartDate(RDMap.get(RDid));
+
             for (Opportunity o : RDOppMap.get(RDid)){
                 
                 o.Amount = rdMap.get(RDid).npe03__Amount__c;
@@ -818,10 +807,10 @@ public class RD_RecurringDonations {
             boolean cfmFieldChanged=false;
             for (string s : customFieldMappingSettings.keySet()){
                 npe03__Custom_Field_Mapping__c cfm = customFieldMappingSettings.get(s);
-               if(oldRD.get(cfm.npe03__Recurring_Donation_Field__c)!=r.get(cfm.npe03__Recurring_Donation_Field__c)){
+                if(oldRD.get(cfm.npe03__Recurring_Donation_Field__c)!=r.get(cfm.npe03__Recurring_Donation_Field__c)){
                     cfmFieldChanged=true;
-               }
-            }  
+                }
+            }
             //if we're closing an open ended donation, modify the existing opps as required by the custom setting
             if (r.npe03__Open_Ended_Status__c == closedlabel && oldRD.npe03__Open_Ended_Status__c != r.npe03__Open_Ended_Status__c){
                 newlycloseddonations.add(r);        
@@ -837,8 +826,9 @@ public class RD_RecurringDonations {
                     r.npe03__Recurring_Donation_Campaign__c != oldRD.npe03__Recurring_Donation_Campaign__c ||
                     r.npe03__Organization__c != oldRD.npe03__Organization__c ||
                     r.npe03__Next_Payment_Date__c != oldRD.npe03__Next_Payment_Date__c ||
+                    r.Always_Use_Last_Day_Of_Month__c != oldRD.Always_Use_Last_Day_Of_Month__c ||
                     cfmFieldChanged==true
-                    ){             
+                    ){
                     reevaluateopps.add(r.id);
                 }
                 else if (r.npe03__Installment_Period__c != oldRD.npe03__Installment_Period__c || r.npe03__Contact__c != oldRD.npe03__Contact__c){
@@ -978,7 +968,7 @@ public class RD_RecurringDonations {
                         //multicurrency?
                         if(isMultiCurrency)
                             o.put(OppCurrencyField,rd.get(RDCurrencyField));
-                    
+
                         //account or contact?
                         if (rd.npe03__Organization__c != null){
                            o.AccountId = rd.npe03__Organization__c;
@@ -989,12 +979,12 @@ public class RD_RecurringDonations {
                             if (ConIDForRole != null){
                                 o.put('npe01__Contact_Id_For_Role__c', (string)c.id);
                             }
-                        }                    
-                    
-                        o.CloseDate = oppclosedate;                                                                                        
+                        }
+
+                        o.CloseDate = oppclosedate;
                         string oName = rd.npe03__Donor_Name__c + ' ' + system.label.npe03.RecurringDonationPrefix +
                         ' (' + string.valueOf(oppCounter) + ') ' + o.CloseDate.format();
-                    
+
                         o.Name = oName;
                         o.Amount = rd.npe03__Amount__c;
                         o.StageName = system.label.npe03.RecurringDonationStageName;                    
@@ -1006,15 +996,15 @@ public class RD_RecurringDonations {
                             npe03__Custom_Field_Mapping__c cfm = customFieldMappingSettings.get(s);
                             o.put(cfm.npe03__Opportunity_Field__c, rd.get(cfm.npe03__Recurring_Donation_Field__c));
                         }
-                    
+
                         if (rd.npe03__Recurring_Donation_Campaign__c != null && (rds.npe03__Add_Campaign_to_All_Opportunites__c || oppCounter == 1)){
                             o.CampaignId = rd.npe03__Recurring_Donation_Campaign__c;
                         }
-                        
+
 	                    if (rds.npe03__Record_Type__c != null){
 	                        o.put('RecordTypeId', rds.npe03__Record_Type__c);
 	                    }
-                                            
+
                         oppCounter++;
                         oppInsertList.add(o);                   
                         oppclosedate = getNextDate(oppclosedate, rd);
@@ -1113,23 +1103,47 @@ public class RD_RecurringDonations {
     }
 
     /*******************************************************************************************************
-    * @description Returns the last day of month for the provided date, assuming is set for
-    * the 28th or later.  This is a way to avoid the last day of month getting pushed to the
-    * 30th, and then the 28th.  Note that if Date Established is >= 28, we assume it instead.
+    * @description Returns the date to start the installment with based on the period type and dates
+    * @param r recurring donation record
+    * @return date First date to use for created Donations
+    */
+    private static date getStartDate(npe03__Recurring_Donation__c r) {
+        Date startDt;
+        if (r.npe03__Next_Payment_Date__c != null)
+            startDt = r.npe03__Next_Payment_Date__c;
+        else {
+            startDt = r.npe03__Date_Established__c;
+        }
+
+        if (r.npe03__Installment_Period__c == system.label.npe03.RecurringDonationInstallmentPeriodMonthly
+                || r.npe03__Installment_Period__c == system.label.npe03.RecurringDonationInstallmentPeriodQuarterly) {
+            // For monthly or quarterly installments only, the initial date needs to be tweaked to be the appropriate
+            // start date in the current month
+            startDt = dtEndOfMonthFixup(startDt, r); // fix the date to account for end of month
+        }
+        return startDt;
+    }
+
+    /*******************************************************************************************************
+    * @description Returns the last day of month for the provided date if the Day of Month is either the
+    * the 31st or the Always_Use_Last_Day_Of_Month__c box has been checked. Otherwise, use the specific
+    * date they have set.
     * @param dt The date to analyze
-    * @return date Either the passed in date, or the last day of the month if the provided date
-    * was >= the 28th.
-    */ 
-    private static date dtEndOfMonthFixup(Date dt, npe03__Recurring_Donation__c rd) {
-        if (dt.day() >= 28) {
-            // only push to end of month if we are pretty sure they weren't trying specifically for the 28th-30th.
-            if (rd.npe03__Date_Established__c != null && rd.npe03__Date_Established__c.day() >= 28 &&
-                rd.npe03__Date_Established__c.day() <= date.daysInMonth(dt.year(), dt.Month()))
-                dt = date.newInstance(dt.year(), dt.month(), rd.npe03__Date_Established__c.day());
-            else
-                dt = date.newInstance(dt.year(), dt.month(), date.daysInMonth(dt.year(), dt.Month()));
-        } 
-        return dt;   	
+    * @return date Either the passed in date, or the last day of the month
+    */
+    private static date dtEndOfMonthFixup(date dt, npe03__Recurring_Donation__c rd) {
+        if (dt.day() == 31 || rd.Always_Use_Last_Day_Of_Month__c == true) {
+            dt = date.newInstance(dt.year(), dt.month(), date.daysInMonth(dt.year(), dt.Month()));
+        } else if (dt.day() >= 28 && rd.npe03__Date_Established__c != null) {
+            // If the DateEstablished is >= 28th, then make sure that the calculated End Of Month
+            // date takes this into account rather than just use the DayOfMonth from the previous
+            // installment
+            Date estDate = rd.npe03__Date_Established__c;
+            Integer dayOfMonth = (date.daysInMonth(dt.year(), dt.Month()) < estDate.day() ?
+                    date.daysInMonth(dt.year(), dt.Month()) : estDate.day());
+            dt = date.newInstance(dt.year(), dt.month(), dayOfMonth);
+        }
+        return dt;
     }
 
     /*******************************************************************************************************
@@ -1138,60 +1152,60 @@ public class RD_RecurringDonations {
     * @param rd The Recurring Donation.
     * @return date 
     */ 
-    private static date getNextDate(date CalcDate, npe03__Recurring_Donation__c rd) {
+    private static date getNextDate(Date calcDate, npe03__Recurring_Donation__c rd) {
         npe03__Recurring_Donations_Settings__c rds = UTIL_CustomSettingsFacade.getRecurringDonationsSettings();
         string InstallmentType = rd.npe03__Installment_Period__c;
-        
+
         if (InstallmentType == system.label.npe03.RecurringDonationInstallmentPeriodYearly){
-            CalcDate = CalcDate.addYears(1);
+            calcDate = calcDate.addYears(1);
         } 
         else if (InstallmentType == system.label.npe03.RecurringDonationInstallmentPeriodQuarterly){
-            CalcDate = CalcDate.addMonths(3);
-            CalcDate = dtEndOfMonthFixup(CalcDate, rd);
+            calcDate = calcDate.addMonths(3);
+            calcDate = dtEndOfMonthFixup(calcDate, rd);
         } 
         else if (InstallmentType == system.label.npe03.RecurringDonationInstallmentPeriodMonthly){
-            CalcDate = CalcDate.addMonths(1);
-            CalcDate = dtEndOfMonthFixup(CalcDate, rd);
+            calcDate = calcDate.addMonths(1);
+            calcDate = dtEndOfMonthFixup(calcDate, rd);
         } 
         else if (InstallmentType == system.label.npe03.RecurringDonationInstallmentPeriodWeekly){
-            CalcDate = CalcDate.addDays(7);
+            calcDate = calcDate.addDays(7);
         }
-      /*  else if (InstallmentType == system.label.npe03.RecurringDonationInstallmentPeriodCustom){ 
+        /*  else if (InstallmentType == system.label.npe03.RecurringDonationInstallmentPeriodCustom){
             CalcDate = CalcDate.addDays((integer)rds.Custom_Days__c);
         }*/
         else if (InstallmentType == system.label.npe03.RecurringDonationInstallmentPeriod1stand15th){
-            //increment it by one day until we hit either the 1st or 15th            
+            //increment it by one day until we hit either the 1st or 15th
             do{
-                CalcDate = CalcDate.addDays(1);
-            }while (CalcDate.day() != 15 && CalcDate.day() != 1);
-        }        
+                calcDate = calcDate.addDays(1);
+            }while (calcDate.day() != 15 && calcDate.day() != 1);
+        }
         else{
             map<string, npe03__Custom_Installment_Settings__c> cisMap = UTIL_ListCustomSettingsFacade.getMapCustomInstallmentSettings();
             //handle custom installment types           
             if (cisMap.containsKey(InstallmentType)){
                 npe03__Custom_Installment_Settings__c c = cisMap.get(InstallmentType);
-                
+
                 if (c.npe03__Increment__c == 'Days'){
-                    CalcDate = CalcDate.addDays(integer.valueOf(c.npe03__Value__c));
+                    calcDate = calcDate.addDays(integer.valueOf(c.npe03__Value__c));
                 }
                 else if (c.npe03__Increment__c == 'Weeks'){
-                    CalcDate = CalcDate.addDays(integer.valueOf(c.npe03__Value__c * 7));
+                    calcDate = calcDate.addDays(integer.valueOf(c.npe03__Value__c * 7));
                 }
                 else if (c.npe03__Increment__c == 'Months'){
-                    CalcDate = CalcDate.addMonths(integer.valueOf(c.npe03__Value__c));
-                    CalcDate = dtEndOfMonthFixup(CalcDate, rd);                    
+                    calcDate = calcDate.addMonths(integer.valueOf(c.npe03__Value__c));
+                    calcDate = dtEndOfMonthFixup(calcDate, rd);
                 }
                 else if (c.npe03__Increment__c == 'Years'){
-                    CalcDate = CalcDate.addYears(integer.valueOf(c.npe03__Value__c));
-                }           
+                    calcDate = calcDate.addYears(integer.valueOf(c.npe03__Value__c));
+                }
             }
             //if its not a valid value, set it to the max last payment date plus the 
-            //the open ended value so we only create one opp max                           
+            //the open ended value so we only create one opp max
             else{   
-                CalcDate = CalcDate.addMonths((integer)rds.npe03__Opportunity_Forecast_Months__c);
-                CalcDate = dtEndOfMonthFixup(CalcDate, rd);            
-            }                
+                calcDate = calcDate.addMonths((integer)rds.npe03__Opportunity_Forecast_Months__c);
+                calcDate = dtEndOfMonthFixup(calcDate, rd);
+            }
         }
-        return CalcDate;
+        return calcDate;
     }
 }

--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -1133,11 +1133,13 @@ public class RD_RecurringDonations {
     private static date dtEndOfMonthFixup(date dt, npe03__Recurring_Donation__c rd) {
         if (dt.day() == 31 || rd.Always_Use_Last_Day_Of_Month__c == true) {
             dt = date.newInstance(dt.year(), dt.month(), date.daysInMonth(dt.year(), dt.Month()));
-        } else if (dt.day() >= 28 && rd.npe03__Date_Established__c != null) {
-            // If the DateEstablished is >= 28th, then make sure that the calculated End Of Month
-            // date takes this into account rather than just use the DayOfMonth from the previous
-            // installment
-            Date estDate = rd.npe03__Date_Established__c;
+        } else if (dt.day() >= 28 && rd.npe03__Next_Payment_Date__c != null) {
+            // To handle a scenario where the DateEstablished is the >= 29 for a Monthly Donation,
+            // when the system gets around to February, it'll change the next donation to 28/29
+            // which then causes all subsequent months to be set to the 28th (or 29th).
+            // This logic ensures that the calculated End Of Month date takes this into account
+            // rather than just use the DayOfMonth from the previous installment.
+            Date estDate = rd.npe03__Next_Payment_Date__c;
             Integer dayOfMonth = (date.daysInMonth(dt.year(), dt.Month()) < estDate.day() ?
                     date.daysInMonth(dt.year(), dt.Month()) : estDate.day());
             dt = date.newInstance(dt.year(), dt.month(), dayOfMonth);

--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -434,7 +434,6 @@ public class RD_RecurringDonations {
                                         
                     OppCloseDate = getNextDate(OppCloseDate, r);
 
-                    // TODO: Rewrite this to use the NPSP settings for Opportunity Naming
                     String oName = '';
                     oName += r.npe03__Donor_Name__c; 
                     oName += ' ';

--- a/src/classes/RD_RecurringDonations_TDTM.cls
+++ b/src/classes/RD_RecurringDonations_TDTM.cls
@@ -86,6 +86,11 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
                      r.npe03__Open_Ended_Status__c != system.label.npe03.RecurringDonationClosedStatus)) {
                     r.addError(system.label.npe03.RecurringDonationTooManyInstallmentsError);
                 }            
+                // Reset this field to false if the installment period is not Monthly or Quarterly
+                if (r.Always_Use_Last_Day_Of_Month__c == true && r.npe03__Installment_Period__c != system.label.npe03.RecurringDonationInstallmentPeriodMonthly
+                        && r.npe03__Installment_Period__c != system.label.npe03.RecurringDonationInstallmentPeriodQuarterly) {
+                    r.Always_Use_Last_Day_Of_Month__c = false;
+                }
             } else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
                 mapIdRDInserts.put(r.id, r);
             } else if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {

--- a/src/classes/RD_RecurringDonations_TDTM.cls
+++ b/src/classes/RD_RecurringDonations_TDTM.cls
@@ -54,6 +54,9 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
         if (RD_ProcessControl.hasRun) 
             return null;
             
+        map<string, npe03__Custom_Installment_Settings__c> customInstallmentsMap
+                = UTIL_ListCustomSettingsFacade.getMapCustomInstallmentSettings();
+
         if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
             set<Id> setRDId = new set<Id>();
             for (SObject s : newlist) 
@@ -85,10 +88,12 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
                     (r.npe03__Open_Ended_Status__c != system.label.npe03.RecurringDonationOpenStatus && 
                      r.npe03__Open_Ended_Status__c != system.label.npe03.RecurringDonationClosedStatus)) {
                     r.addError(system.label.npe03.RecurringDonationTooManyInstallmentsError);
-                }            
-                // Reset this field to false if the installment period is not Monthly or Quarterly
+                }
+                // Reset this field to false if the installment period is not Monthly, Quarterly, or one of the
+                // custom installment periods
                 if (r.Always_Use_Last_Day_Of_Month__c == true && r.npe03__Installment_Period__c != system.label.npe03.RecurringDonationInstallmentPeriodMonthly
-                        && r.npe03__Installment_Period__c != system.label.npe03.RecurringDonationInstallmentPeriodQuarterly) {
+                        && r.npe03__Installment_Period__c != system.label.npe03.RecurringDonationInstallmentPeriodQuarterly
+                        && !customInstallmentsMap.containsKey(r.npe03__Installment_Period__c)) {
                     r.Always_Use_Last_Day_Of_Month__c = false;
                 }
             } else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {

--- a/src/classes/RD_RecurringDonations_TEST.cls
+++ b/src/classes/RD_RecurringDonations_TEST.cls
@@ -237,7 +237,7 @@ public class RD_RecurringDonations_TEST {
         r2.npe03__Organization__c = a.Id;
         r2.npe03__Amount__c = 100;
         r2.npe03__Installment_Period__c = system.label.npe03.RecurringDonationInstallmentPeriodMonthly;
-        r2.npe03__Date_Established__c = date.newinstance(1970,6,12);
+        r2.npe03__Date_Established__c = date.newinstance(1970,6,30);
         r2.npe03__Schedule_Type__c = system.label.npe03.RecurringDonationDivideValue;
         r2.npe03__Open_Ended_Status__c = 'None'; 
         insert r2;
@@ -245,11 +245,11 @@ public class RD_RecurringDonations_TEST {
         Opportunity[] installments2 = [select Name,amount,accountid,CloseDate from Opportunity where npe03__Recurring_Donation__c = :r2.id];
         system.assertEquals(3,installments2.size());
         system.assertEquals(33.33,installments2[0].Amount);
-        system.assertEquals(date.newinstance(1970,6,12),installments2[0].CloseDate);
+        system.assertEquals(date.newinstance(1970,6,30),installments2[0].CloseDate);
         system.assertEquals(33.33,installments2[1].Amount);
-        system.assertEquals(date.newinstance(1970,7,12),installments2[1].CloseDate);
+        system.assertEquals(date.newinstance(1970,7,30),installments2[1].CloseDate);
         system.assertEquals(33.34,installments2[2].Amount);
-        system.assertEquals(date.newinstance(1970,8,12),installments2[2].CloseDate);
+        system.assertEquals(date.newinstance(1970,8,30),installments2[2].CloseDate);
         system.assertEquals(a.id,installments2[0].AccountId);
         UTIL_Debug.debug('**** '+installments2);
         RD_ProcessControl.hasRun = false;

--- a/src/classes/RD_RecurringDonations_TEST2.cls
+++ b/src/classes/RD_RecurringDonations_TEST2.cls
@@ -84,7 +84,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         o.StageName = closedstage;
         o.CloseDate = system.today();
         RD_ProcessControl.hasRun = false;
-        Test.startTest();        
+        Test.startTest();
         //update opp
         update o;
         //call the update method
@@ -187,7 +187,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         r1.npe03__Last_Payment_Date__c = system.today();
         update r1;
         RD_ProcessControl.hasRun = false;                
-        Test.startTest();        
+        Test.startTest();
         r1.npe03__Installment_Period__c = system.label.npe03.RecurringDonationInstallmentPeriodYearly;
         update r1;
         Test.stopTest();        
@@ -239,7 +239,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         o.Name = 'test';
         o.npe03__Recurring_Donation__c = r1.Id;
         RD_ProcessControl.hasRun = false;
-        Test.startTest();        
+        Test.startTest();
         insert o;
         Test.stopTest();
 
@@ -284,7 +284,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         r1.npe03__Open_Ended_Status__c = system.label.npe03.RecurringDonationOpenStatus;
         r1.npe03__Next_Payment_Date__c = system.today();
         insert r1;
-        
+
         list<Opportunity> originalOpps = new list<Opportunity>([select id, Name,amount,accountid,CloseDate from Opportunity where npe03__Recurring_Donation__c = :r1.id order by CloseDate]);
         Opportunity o = originalOpps[0];
         string closedstage = [select masterlabel from opportunitystage where isActive = true and iswon = true and isClosed = true limit 1].masterlabel;
@@ -293,7 +293,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         r1.npe03__Installment_Period__c = 'GarbageDate';
         update r1;
         RD_ProcessControl.hasRun = false;
-        Test.startTest();        
+        Test.startTest();
         update o;
         Test.stopTest();
     }
@@ -338,7 +338,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         system.assertNotEquals(0, [select count() from Opportunity where npe03__Recurring_Donation__c = :r1.id and isClosed = false]);
         //reset the semaphore
         RD_ProcessControl.hasRun = false;
-        Test.startTest();        
+        Test.startTest();
         r1.npe03__Open_Ended_Status__c = system.label.npe03.RecurringDonationClosedStatus;
         update r1;
         Test.stopTest();
@@ -406,9 +406,9 @@ private with sharing class RD_RecurringDonations_TEST2 {
         rdlist[1].npe03__Amount__c = 50;
         rdlist[1].npe03__Next_Payment_Date__c = system.today().toStartOfMonth().addDays(5);
         RD_ProcessControl.hasRun = false;
-        update rdlist;        
+        update rdlist;
         Test.stopTest();
-        
+
         list<Opportunity> originalOpps = new list<Opportunity>([select id, Name,amount,accountid,CloseDate,Description from Opportunity where npe03__Recurring_Donation__r.id = :r1.id or npe03__Recurring_Donation__c = :r2.id]);
         system.assertEquals(7, originalOpps.size());
         system.assertEquals(50, originalOpps[0].Amount);
@@ -508,7 +508,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         r2.npe03__Next_Payment_Date__c = system.today();
         insert r2;
         RD_ProcessControl.hasRun = false;
-        list<Opportunity> originalOpps = new list<Opportunity>([select id, Name,amount,accountid,CloseDate from Opportunity where npe03__Recurring_Donation__r.id = :r1.id or npe03__Recurring_Donation__c = :r2.id]);                                
+        list<Opportunity> originalOpps = new list<Opportunity>([select id, Name,amount,accountid,CloseDate from Opportunity where npe03__Recurring_Donation__r.id = :r1.id or npe03__Recurring_Donation__c = :r2.id]);
         string closedstage = [select masterlabel from opportunitystage where isActive = true and iswon = true and isClosed = true limit 1].masterlabel;
         system.assert(originalOpps.size() > 1);
         
@@ -1055,7 +1055,8 @@ private with sharing class RD_RecurringDonations_TEST2 {
         insert camp;
         
         list<npe03__Recurring_Donation__c> rdlist = new list<npe03__Recurring_Donation__c>();
-        
+
+        // This should create Installments with a date of the 28th.
         npe03__Recurring_Donation__c RD = new npe03__Recurring_Donation__c();
         RD.Name = 'test28th';
         RD.npe03__Contact__c = c.Id;
@@ -1068,16 +1069,18 @@ private with sharing class RD_RecurringDonations_TEST2 {
         
         RD = RD.clone(false);
         RD.Name = 'testEndOfMonth';
-        RD.npe03__Date_Established__c = system.today().toStartOfMonth();
-        RD.npe03__Next_Payment_Date__c = system.today().addMonths(1).toStartOfMonth().addDays(-1);
+        RD.Always_Use_Last_Day_Of_Month__c = true;
         rdlist.add(RD);
-                
+
+        // This should create Installments with a date of the 30th.
         RD = RD.clone(false);
         RD.Name = 'test30th';
-        integer iday = 30;
-        if (date.daysInMonth(system.today().year(), system.today().Month()) < 30)
-            iday = 28;
-        RD.npe03__Date_Established__c = system.today().toStartOfMonth().addDays(iday-1);
+        RD.Always_Use_Last_Day_Of_Month__c = false;
+        Date startDt = system.today().toStartOfMonth().addMonths(1).addDays(-2);
+        while (startDt.day() != 30) {
+            startDt = startDt.addMonths(2).toStartOfMonth().addDays(-1);
+        }
+        RD.npe03__Date_Established__c = startDt;
         RD.npe03__Next_Payment_Date__c = null;
         rdlist.add(RD);
 
@@ -1090,20 +1093,23 @@ private with sharing class RD_RecurringDonations_TEST2 {
         for (Opportunity opp : listOpp28th) {
             system.assertEquals(28, opp.CloseDate.Day());
         }
-        
+
+        // All Installments should be on the 30th except for February, which should be on the last day of the month
         list<Opportunity> listOpp30th = [select Id, CloseDate from Opportunity where npe03__Recurring_Donation__r.Name = 'test30th' order by CloseDate];
         system.assertEquals(12, listOpp30th.size());
-        for (Opportunity opp : listOpp30th) {
-            if (iday <= date.daysInMonth(opp.CloseDate.year(), opp.CloseDate.Month()))
-                system.assertEquals(iday, opp.CloseDate.Day());
-            else
-                system.assertEquals(date.daysInMonth(opp.CloseDate.year(), opp.CloseDate.Month()), opp.CloseDate.Day());            
+        for (Opportunity opp : listOpp28th) {
+            if (opp.CloseDate.Month() != 2) {
+                system.assertEquals(28, opp.CloseDate.Day());
+            } else {
+                system.assertEquals(Date.DaysInMonth(opp.CloseDate.Year(), 2), opp.CloseDate.Day());
+            }
         }
 
+        // All Installments should be on the last day of the month
         list<Opportunity> listOppEnd = [select Id, CloseDate from Opportunity where npe03__Recurring_Donation__r.Name = 'testEndOfMonth' order by CloseDate];
         system.assertEquals(12, listOppEnd.size());
         for (Opportunity opp : listOppEnd) {
-            system.assertEquals(opp.CloseDate.addMonths(1).toStartOfMonth().addDays(-1).Day(), opp.CloseDate.Day());
+            system.assertEquals(Date.DaysInMonth(opp.CloseDate.Year(), opp.CloseDate.Month()), opp.CloseDate.Day(), opp.CloseDate);
         }
         
         for (integer i = 0; i < 12; i++) {
@@ -1315,7 +1321,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         o.Name = 'test';
         o.npe03__Recurring_Donation__c = r1.Id;
         RD_ProcessControl.hasRun = false;
-        
+
         //--------------------------------
         // Insert the Opportunity
         Test.startTest();        
@@ -1400,7 +1406,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         o.Name = 'test';
         o.npe03__Recurring_Donation__c = r1.Id;
         RD_ProcessControl.hasRun = false;
-        
+
         //--------------------------------
         // Insert the Opportunity
         Test.startTest();        

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -7,4 +7,14 @@
         <fields>npe03__Installment_Period__c</fields>
         <label>NPSP Recurring Donation Compact Layout</label>
     </compactLayouts>
+    <fields>
+        <fullName>Always_Use_Last_Day_Of_Month__c</fullName>
+        <defaultValue>false</defaultValue>
+        <externalId>false</externalId>
+        <inlineHelpText>When checked, all future donation installments will be set to the last day of the month, regardless of the actual date in the &quot;Next Donation Date&quot; field.</inlineHelpText>
+        <label>Always use last day of month</label>
+        <trackHistory>false</trackHistory>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
 </CustomObject>

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -11,7 +11,7 @@
         <fullName>Always_Use_Last_Day_Of_Month__c</fullName>
         <defaultValue>false</defaultValue>
         <externalId>false</externalId>
-        <inlineHelpText>When checked, all future donation installments will be set to the last day of the month, regardless of the actual date in the &quot;Next Donation Date&quot; field.</inlineHelpText>
+        <inlineHelpText>When checked, all future monthly or quarterly donation installments will be set to the last day of the month, regardless of the actual date in the &quot;Next Donation Date&quot; field. This is ignored when the installment period is not set to Monthly or Quarterly.</inlineHelpText>
         <label>Always use last day of month</label>
         <trackHistory>false</trackHistory>
         <trackTrending>false</trackTrending>

--- a/src/package.xml
+++ b/src/package.xml
@@ -817,6 +817,7 @@
         <members>npe01__Contacts_And_Orgs_Settings__c.Simple_Address_Change_Treated_as_Update__c</members>
         <members>npe01__OppPayment__c.Payment_Acknowledged_Date__c</members>
         <members>npe01__OppPayment__c.Payment_Acknowledgment_Status__c</members>
+        <members>npe03__Recurring_Donation__c.Always_Use_Last_Day_Of_Month__c</members>
         <members>npe4__Relationship_Settings__c.Enable_Custom_Field_Sync__c</members>
         <members>npo02__Household__c.Number_of_Household_Members__c</members>
         <members>npo02__Households_Settings__c.Matched_Donor_Role__c</members>


### PR DESCRIPTION
# Critical Changes

* The Recurring Donations object has a new field called **Always Use Last Day of Month**. To use this new field, administrators need to perform the following setup:
    * In the profiles for all users that need access to this field, edit Recurring Donations object settings and set the **Always Use Last Day of Month** field permission to Read Access and Edit Access.
    * Add the **Always Use Last Day of Month** field to the Recurring Donations page layout.



# Changes

* When the **Always Use Last Day of Month** field is checked on a Recurring Donation, monthly and quarterly installment Opportunities will be created with the Close Date set to the last day of the month. 
* When the **Always Use Last Day of Month** field is NOT checked on a Recurring Donation and the Next Payment date is the 28th, 29th, or 30th day of the month, new Installment Opportunities will be created with the Close Date set to that specific day. 
* A Next Payment or Date Established date of the 31st (of any month) is equivalent to having the **Always Use Last Day of Month** field checked. This new change only affects Recurring Donations with an Installment Period of either Monthly or Quarterly.

# Issues Closed

Fixes #2034 