### PR TITLE
If Automatic Household Naming is disabled and existing naming rules have syntax error, exception is thrown

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -86,7 +86,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             map<Id, Contact> mapContactIdContactOwnerChange = new map<Id, Contact>();
             map<Id, Id> mapContactIdAccountIdOldMoveOpps = new map<Id, Id>();
             map<Id, Id> mapContactIdAccountIdNewMoveOpps = new map<Id, Id>();
-            Set<String> hhNamingFields = HH_HouseholdNaming.iNaming.setHouseholdNameFieldsOnContact();
+            Set<String> hhNamingFields = getHouseholdNamingContactFields();
 
             
             if (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) {                    
@@ -105,10 +105,9 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 if (ADDR_Addresses_TDTM.isStateCountryPicklistsEnabled)
                     strSoql += 'MailingCountryCode, MailingStateCode, OtherCountryCode, OtherStateCode, ';
                 
-                if (hhNamingFields.size() > 0) {
-                    for (String hhNameField : hhNamingFields) {
-                        if (!strSoql.containsIgnoreCase(hhNameField))
-                            strSoql += hhNameField + ',';
+                for (String hhNameField : hhNamingFields) {
+                    if (!strSoql.containsIgnoreCase(hhNameField)) {
+                        strSoql += hhNameField + ',';
                     }
                 }
 
@@ -317,6 +316,15 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             }
             
     return dmlWrapper;
+    }
+
+    private Set<String> getHouseholdNamingContactFields() {
+        npo02__Households_Settings__c hhNamingConfig = UTIL_CustomSettingsFacade.getHouseholdsSettings();
+        Boolean isHHNamingAutomated = hhNamingConfig.npo02__Advanced_Household_Naming__c == true;
+
+        return isHHNamingAutomated
+            ? HH_HouseholdNaming.iNaming.setHouseholdNameFieldsOnContact()
+            : new Set<String>();
     }
 
     /*******************************************************************************************************

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -86,7 +86,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             map<Id, Contact> mapContactIdContactOwnerChange = new map<Id, Contact>();
             map<Id, Id> mapContactIdAccountIdOldMoveOpps = new map<Id, Id>();
             map<Id, Id> mapContactIdAccountIdNewMoveOpps = new map<Id, Id>();
-            Set<String> hhNamingFields = getHouseholdNamingContactFields();
+            Set<String> hhNamingFields = new HH_HouseholdNaming().getHouseholdNamingContactFields();
 
             
             if (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) {                    
@@ -315,16 +315,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 deleteContactAccountsIfEmpty(listContactAccountDelete, dmlWrapper);
             }
             
-    return dmlWrapper;
-    }
-
-    private Set<String> getHouseholdNamingContactFields() {
-        npo02__Households_Settings__c hhNamingConfig = UTIL_CustomSettingsFacade.getHouseholdsSettings();
-        Boolean isHHNamingAutomated = hhNamingConfig.npo02__Advanced_Household_Naming__c == true;
-
-        return isHHNamingAutomated
-            ? HH_HouseholdNaming.iNaming.setHouseholdNameFieldsOnContact()
-            : new Set<String>();
+        return dmlWrapper;
     }
 
     /*******************************************************************************************************

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -1292,6 +1292,32 @@ private class ACCT_IndividualAccounts_TEST {
         Test.stopTest();
     }
 
+    /*********************************************************************************************************
+    @description 
+        Test insert and update of a Contact when Household Naming Settings is invalid
+        and the Automatic Household Naming is turned off 
+    verify:
+        The Contact is created and updated successfully
+    **********************************************************************************************************/ 
+    private static testMethod void contactDmlShouldSucceedWhenHHNamingSettingsIsInvalidAndAutomaticHouseholdNamingIsTurnedOff() {
+        UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_and_Orgs_Settings__c(
+                npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR
+            )            
+        );
+
+        turnOffAutomaticHHNaming();
+        setupInvalidHHNamingSettings();
+
+        Contact contact = new Contact(LastName = 'AutoHHNamingTurnedOff');
+        Test.startTest();
+        insert contact;
+        Test.stopTest();
+
+        contact.FirstName = 'John';
+        update contact;
+    }
+
     // Helpers
     ////////////
 
@@ -1329,5 +1355,53 @@ private class ACCT_IndividualAccounts_TEST {
         }
         
         return newRecTypeId;
+    }
+
+    /*********************************************************************************************************
+    * @description Turns on Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOnAutomaticHHNaming() {
+        setupAutomaticHHNaming(true);
+    }
+
+    /*********************************************************************************************************
+    * @description Turns off Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOffAutomaticHHNaming() {
+        setupAutomaticHHNaming(false);
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Settings' Automatic Household Naming field
+    * @param isOn Automatic Household Naming is turned on when parameter is true, otherwise, the settings is turned off
+    * @return void
+    **********************************************************************************************************/
+    private static void setupAutomaticHHNaming(Boolean isOn) {
+        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
+            new npo02__Households_Settings__c (
+                npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
+                npo02__Advanced_Household_Naming__c = isOn
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with invalid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupInvalidHHNamingSettings() {
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+        	new Household_Naming_Settings__c(
+                Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household', 
+        		Formal_Greeting_Format__c = '{!{!Title} {!FirstName}}}{!LastName}',
+                Informal_Greeting_Format__c = '{!{!FirstName}}}',
+        		Name_Connector__c = label.npo02.HouseholdNameConnector,
+       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+        		Contact_Overrun_Count__c = 9,
+        		Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
     }
 }

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -1300,24 +1300,26 @@ private class ACCT_IndividualAccounts_TEST {
         The Contact is created and updated successfully
     **********************************************************************************************************/ 
     private static testMethod void contactDmlShouldSucceedWhenHHNamingSettingsIsInvalidAndAutomaticHouseholdNamingIsTurnedOff() {
-        UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_and_Orgs_Settings__c(
-                npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR
-            )            
-        );
-
         turnOffAutomaticHHNaming();
         setupInvalidHHNamingSettings();
 
-        Contact contact = new Contact(LastName = 'AutoHHNamingTurnedOff');
-        Test.startTest();
-        insert contact;
-        Test.stopTest();
+        Contact contact = new Contact(LastName = 'Smith');
+        try {
+            insert contact;
 
-        contact.FirstName = 'John';
-        update contact;
+        } catch (Exception e) {
+            System.assert(false, 'Unexpected error on Contact insert: ' + e.getMessage());
+        }
 
-        System.assertEquals('John', [SELECT FirstName FROM Contact WHERE Id = :contact.Id][0].FirstName);
+        try {
+            contact.FirstName = 'John';
+            update contact;
+
+        } catch (Exception e) {
+            System.assert(false, 'Unexpected error on Contact update: ' + e.getMessage());
+        }
+
+        System.assertEquals('John', [SELECT FirstName FROM Contact WHERE Id = :contact.Id][0].FirstName, 'Contact update should succeed');
     }
 
     // Helpers

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls
@@ -1294,7 +1294,7 @@ private class ACCT_IndividualAccounts_TEST {
 
     /*********************************************************************************************************
     @description 
-        Test insert and update of a Contact when Household Naming Settings is invalid
+        Test Contact insert and update when Household Naming Settings is invalid
         and the Automatic Household Naming is turned off 
     verify:
         The Contact is created and updated successfully
@@ -1316,6 +1316,8 @@ private class ACCT_IndividualAccounts_TEST {
 
         contact.FirstName = 'John';
         update contact;
+
+        System.assertEquals('John', [SELECT FirstName FROM Contact WHERE Id = :contact.Id][0].FirstName);
     }
 
     // Helpers
@@ -1392,15 +1394,34 @@ private class ACCT_IndividualAccounts_TEST {
     * @return void
     **********************************************************************************************************/
     private static void setupInvalidHHNamingSettings() {
+        setupHHNamingSettings('{!{!FirstName}} {!LastName}} Household', '{!{!Title} {!FirstName}}}{!LastName}', '{!{!FirstName}}}');
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with valid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings() {
+        setupHHNamingSettings('{!LastName} Household', '{!{!Salutation} {!FirstName}} {!LastName}', '{!{!FirstName}}');
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings 
+    * @param hhNameFormat Household Naming Format
+    * @param formalGreetingFormat Formal Greeting Format
+    * @param informalGreetingFormat Informal Greeting Format
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
         UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
-        	new Household_Naming_Settings__c(
-                Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household', 
-        		Formal_Greeting_Format__c = '{!{!Title} {!FirstName}}}{!LastName}',
-                Informal_Greeting_Format__c = '{!{!FirstName}}}',
-        		Name_Connector__c = label.npo02.HouseholdNameConnector,
-       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
-        		Contact_Overrun_Count__c = 9,
-        		Implementing_Class__c = 'HH_NameSpec'
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = hhNameFormat,
+                Formal_Greeting_Format__c = formalGreetingFormat,
+                Informal_Greeting_Format__c = informalGreetingFormat,
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
             )
         );
     }

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -242,13 +242,20 @@ public with sharing class HH_Container_LCTRL {
                     strSoql += ', MailingCountryCode, MailingStateCode ';
                 ******/
             
-            setContactFields.addAll(HH_HouseholdNaming.iNaming.setHouseholdNameFieldsOnContact());
+            setContactFields.addAll(getHouseholdNamingContactFields());
 
             return new list<String>(setContactFields);
         } catch (Exception ex) {
             throw new AuraHandledException(ex.getMessage());
         }
     }
+
+    private static Set<String> getHouseholdNamingContactFields() {
+        return isHHNamingAutomated()
+            ? HH_HouseholdNaming.iNaming.setHouseholdNameFieldsOnContact()
+            : new Set<String>();
+    }
+
 
     /*******************************************************************************************************
     * @description returns a set of Contact Fields (developer name) that must be editable
@@ -504,23 +511,35 @@ public with sharing class HH_Container_LCTRL {
     public static SObject getHHNamesGreetings(SObject hh, list<Contact> listCon) {
         try {
             // update naming exclusions field based on exclusion checkboxes
-            for (Contact con : listCon)
+            for (Contact con : listCon) {
                 HH_Households_TDTM.copyNamingExclusionsFromCheckboxes(con);
+            }
 
-            HH_HouseholdNaming hn = new HH_HouseholdNaming();
-            String strExclusions = (String)hh.get('npo02__SYSTEM_CUSTOM_NAMING__c');
+            if (!isHHNamingAutomated()) {
+                return hh;
+            }
+
+            HH_HouseholdNaming hhNaming = new HH_HouseholdNaming();
+            String strExclusions = (String) hh.get('npo02__SYSTEM_CUSTOM_NAMING__c');
             if (strExclusions == null)
                 strExclusions = '';
+                
             if (!strExclusions.contains('Name'))
-                hh.put('Name', hn.getHHName(listCon));
+                hh.put('Name', hhNaming.getHHName(listCon));
             if (!strExclusions.contains('Formal_Greeting__c'))
-                hh.put('npo02__Formal_Greeting__c', hn.getFormalName(listCon));
+                hh.put('npo02__Formal_Greeting__c', hhNaming.getFormalName(listCon));
             if (!strExclusions.contains('Informal_Greeting__c'))
-                hh.put('npo02__Informal_Greeting__c', hn.getInformalName(listCon));
+                hh.put('npo02__Informal_Greeting__c', hhNaming.getInformalName(listCon));
+
             return hh;
         } catch (Exception ex) {
             throw new AuraHandledException(ex.getMessage());
         }
+    }
+
+    private static Boolean isHHNamingAutomated() {
+        npo02__Households_Settings__c hhNamingConfig = UTIL_CustomSettingsFacade.getHouseholdsSettings();
+        return hhNamingConfig.npo02__Advanced_Household_Naming__c == true;
     }
 
     /*******************************************************************************************************

--- a/src/classes/HH_Container_LCTRL.cls
+++ b/src/classes/HH_Container_LCTRL.cls
@@ -242,18 +242,12 @@ public with sharing class HH_Container_LCTRL {
                     strSoql += ', MailingCountryCode, MailingStateCode ';
                 ******/
             
-            setContactFields.addAll(getHouseholdNamingContactFields());
+            setContactFields.addAll(new HH_HouseholdNaming().getHouseholdNamingContactFields());
 
             return new list<String>(setContactFields);
         } catch (Exception ex) {
             throw new AuraHandledException(ex.getMessage());
         }
-    }
-
-    private static Set<String> getHouseholdNamingContactFields() {
-        return isHHNamingAutomated()
-            ? HH_HouseholdNaming.iNaming.setHouseholdNameFieldsOnContact()
-            : new Set<String>();
     }
 
 
@@ -515,11 +509,12 @@ public with sharing class HH_Container_LCTRL {
                 HH_Households_TDTM.copyNamingExclusionsFromCheckboxes(con);
             }
 
-            if (!isHHNamingAutomated()) {
+            HH_HouseholdNaming hhNaming = new HH_HouseholdNaming();
+
+            if (!hhNaming.isAutomaticNaming()) {
                 return hh;
             }
 
-            HH_HouseholdNaming hhNaming = new HH_HouseholdNaming();
             String strExclusions = (String) hh.get('npo02__SYSTEM_CUSTOM_NAMING__c');
             if (strExclusions == null)
                 strExclusions = '';
@@ -535,11 +530,6 @@ public with sharing class HH_Container_LCTRL {
         } catch (Exception ex) {
             throw new AuraHandledException(ex.getMessage());
         }
-    }
-
-    private static Boolean isHHNamingAutomated() {
-        npo02__Households_Settings__c hhNamingConfig = UTIL_CustomSettingsFacade.getHouseholdsSettings();
-        return hhNamingConfig.npo02__Advanced_Household_Naming__c == true;
     }
 
     /*******************************************************************************************************

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -98,12 +98,12 @@ private class HH_Container_TEST {
         Test.startTest();
 
         Contact[] contacts = HH_Container_LCTRL.getContacts(hhA.Id);
-        System.assert(contacts != null && contacts.size() == 1, contacts);
-        System.assertEquals(conA.Id, contacts[0].Id);
+        System.assert(contacts != null && contacts.size() == 1, 'Only one contact should be in the Household Account: ' + contacts);
+        System.assertEquals(conA.Id, contacts[0].Id, 'Contact should not change in the Household Account');
 
         contacts = HH_Container_LCTRL.getContacts(hhO.Id);
-        System.assert(contacts != null && contacts.size() == 1, contacts);
-        System.assertEquals(conO.Id, contacts[0].Id);
+        System.assert(contacts != null && contacts.size() == 1, 'Only one contact should be in the Household Object: ' + contacts);
+        System.assertEquals(conO.Id, contacts[0].Id, 'Contact should not change in the Household Object');
 
         Test.stopTest();
     }  
@@ -373,9 +373,9 @@ private class HH_Container_TEST {
 
         Account actual = (Account) HH_Container_LCTRL.getHHNamesGreetings(hhA, new Contact[]{ conA, conO });
 
-        System.assertEquals(hhA.Name, actual.Name);
-        System.assertEquals(hhA.npo02__Formal_Greeting__c, actual.npo02__Formal_Greeting__c);
-        System.assertEquals(hhA.npo02__Informal_Greeting__c, actual.npo02__Informal_Greeting__c);
+        System.assertEquals(hhA.Name, actual.Name, 'Household Name should not change');
+        System.assertEquals(hhA.npo02__Formal_Greeting__c, actual.npo02__Formal_Greeting__c, 'Formal Greeting should not change');
+        System.assertEquals(hhA.npo02__Informal_Greeting__c, actual.npo02__Informal_Greeting__c, 'Informal Greeting should not change');
         
         Test.stopTest();        
     }
@@ -395,9 +395,9 @@ private class HH_Container_TEST {
 
         hhA = (Account) HH_Container_LCTRL.getHHNamesGreetings(hhA, new Contact[]{ conA, conO });
 
-        system.assertEquals('conA and conO Household', hhA.Name);
-        system.assertEquals('cA conA and cO conO', hhA.npo02__Formal_Greeting__c );
-        system.assertEquals('cA and cO', hhA.npo02__Informal_Greeting__c );
+        system.assertEquals('conA and conO Household', hhA.Name, 'Household Name should correspond to the format');
+        system.assertEquals('cA conA and cO conO', hhA.npo02__Formal_Greeting__c, 'Formal Greeting should correspond to the format');
+        system.assertEquals('cA and cO', hhA.npo02__Informal_Greeting__c, 'Informal Greeting should correspond to the format');
         
         Test.stopTest();        
     }
@@ -503,7 +503,7 @@ private class HH_Container_TEST {
                 'MailingLatitude', 'MailingLongitude', 'CreatedDate'
             }
         ) {
-            System.assert(fieldNames.contains(fieldName), fieldName + ' is not in : ' + fieldNames);
+            System.assert(fieldNames.contains(fieldName), fieldName + ' should be in: ' + fieldNames);
         }
     }
     

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -329,17 +329,44 @@ private class HH_Container_TEST {
             }     
         } 
     }    
-    
+
     /*********************************************************************************************************
-    * @description Tests getHHNamesGreetings()
-    */
-    public static testMethod void testGetHHNamesGreetings() { 
+    @description
+        Test getHHNamesGreetings() method when Household Naming Settings is invalid 
+        and the Automatic Household Naming is turned off 
+    verify:
+        Name and Formal/Informal Greetings are not modified on the Household
+    **********************************************************************************************************/  
+    static testMethod void getHHNamesGreetingsShouldNotModifyNameAndGreetingsOnHouseholdWhenHHNamingSettingsIsInvalidAndAutomaticHouseholdNamingIsTurnedOff() {
+        turnOffAutomaticHHNaming();
+        setupInvalidHHNamingSettings();
+
         initTestData();
-        list<Contact> listCon = new list<Contact>{conA, conO};
  
         Test.startTest();
 
-        hhA = (Account)HH_Container_LCTRL.getHHNamesGreetings(hhA, listCon);
+        Account actual = (Account) HH_Container_LCTRL.getHHNamesGreetings(hhA, new Contact[]{ conA, conO });
+        System.assertEquals(hhA.Name, actual.Name);
+        System.assertEquals(hhA.npo02__Formal_Greeting__c, actual.npo02__Formal_Greeting__c);
+        System.assertEquals(hhA.npo02__Informal_Greeting__c, actual.npo02__Informal_Greeting__c);
+        
+        Test.stopTest();        
+    }
+
+    /*********************************************************************************************************
+    @description
+        Test getHHNamesGreetings() method when Household Naming Settings is valid
+        and the Automatic Household Naming is turned on 
+    verify:
+        Name and Formal/Informal Greetings are set on the Household
+    **********************************************************************************************************/  
+    static testMethod void getHHNamesGreetingsShouldModifyNameAndGreetingsOnHouseholdWhenAutomaticHouseholdNamingIsTurnedOn() {
+        turnOnAutomaticHHNaming();
+        initTestData();
+ 
+        Test.startTest();
+
+        hhA = (Account)HH_Container_LCTRL.getHHNamesGreetings(hhA, new Contact[]{ conA, conO });
         system.assertEquals('conA and conO Household', hhA.Name);
         system.assertEquals('cA conA and cO conO', hhA.npo02__Formal_Greeting__c );
         system.assertEquals('cA and cO', hhA.npo02__Informal_Greeting__c );
@@ -473,10 +500,84 @@ private class HH_Container_TEST {
         }
     }
 
+    /*********************************************************************************************************
+    @description
+        Test getContacts() method when Household Naming Settings is invalid
+        and the Automatic Household Naming is turned off 
+    verify:
+        Contacts are retrieved successfully
+    **********************************************************************************************************/  
+    static testMethod void getContactsShouldReturnContactsWhenHHNamingSettingsIsInvalidAndAutomaticHouseholdNamingIsTurnedOff() {
+        turnOffAutomaticHHNaming();
+        setupInvalidHHNamingSettings();
+
+        initTestData();
+
+        Test.startTest();
+
+        Contact[] contacts = HH_Container_LCTRL.getContacts(hhA.Id);
+        System.assert(contacts != null && contacts.size() == 1, contacts);
+        System.assertEquals(conA.Id, contacts[0].Id);
+
+        contacts = HH_Container_LCTRL.getContacts(hhO.Id);
+        System.assert(contacts != null && contacts.size() == 1, contacts);
+        System.assertEquals(conO.Id, contacts[0].Id);
+
+        Test.stopTest();
+    }
+    
     
 
     // Helpers
     ////////////
+
+    /*********************************************************************************************************
+    * @description Turns on Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOnAutomaticHHNaming() {
+        setupAutomaticHHNaming(true);
+    }
+
+    /*********************************************************************************************************
+    * @description Turns off Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOffAutomaticHHNaming() {
+        setupAutomaticHHNaming(false);
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Settings' Automatic Household Naming field
+    * @param isOn Automatic Household Naming is turned on when parameter is true, otherwise, the settings is turned off
+    * @return void
+    **********************************************************************************************************/
+    private static void setupAutomaticHHNaming(Boolean isOn) {
+        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
+            new npo02__Households_Settings__c (
+                npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
+                npo02__Advanced_Household_Naming__c = isOn
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with invalid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupInvalidHHNamingSettings() {
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+        	new Household_Naming_Settings__c(
+                Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household', 
+        		Formal_Greeting_Format__c = '{!{!Title} {!FirstName}}}{!LastName}',
+                Informal_Greeting_Format__c = '{!{!FirstName}}}',
+        		Name_Connector__c = label.npo02.HouseholdNameConnector,
+       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+        		Contact_Overrun_Count__c = 9,
+        		Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
+    }
 
     /*********************************************************************************************************
     * @description Builds Accounts with Household Account Type

--- a/src/classes/HH_Container_TEST.cls
+++ b/src/classes/HH_Container_TEST.cls
@@ -81,6 +81,32 @@ private class HH_Container_TEST {
                 
         Test.stopTest();
     }
+    
+    /*********************************************************************************************************
+    @description
+        Test getContacts() method when Household Naming Settings is invalid
+        and the Automatic Household Naming is turned off 
+    verify:
+        Contacts are retrieved successfully
+    **********************************************************************************************************/  
+    static testMethod void getContactsShouldReturnContactsWhenHHNamingSettingsIsInvalidAndAutomaticHouseholdNamingIsTurnedOff() {
+        turnOffAutomaticHHNaming();
+        setupInvalidHHNamingSettings();
+
+        initTestData();
+
+        Test.startTest();
+
+        Contact[] contacts = HH_Container_LCTRL.getContacts(hhA.Id);
+        System.assert(contacts != null && contacts.size() == 1, contacts);
+        System.assertEquals(conA.Id, contacts[0].Id);
+
+        contacts = HH_Container_LCTRL.getContacts(hhO.Id);
+        System.assert(contacts != null && contacts.size() == 1, contacts);
+        System.assertEquals(conO.Id, contacts[0].Id);
+
+        Test.stopTest();
+    }  
 
     /*********************************************************************************************************
     * @description Tests getAddresses()
@@ -346,6 +372,7 @@ private class HH_Container_TEST {
         Test.startTest();
 
         Account actual = (Account) HH_Container_LCTRL.getHHNamesGreetings(hhA, new Contact[]{ conA, conO });
+
         System.assertEquals(hhA.Name, actual.Name);
         System.assertEquals(hhA.npo02__Formal_Greeting__c, actual.npo02__Formal_Greeting__c);
         System.assertEquals(hhA.npo02__Informal_Greeting__c, actual.npo02__Informal_Greeting__c);
@@ -366,7 +393,8 @@ private class HH_Container_TEST {
  
         Test.startTest();
 
-        hhA = (Account)HH_Container_LCTRL.getHHNamesGreetings(hhA, new Contact[]{ conA, conO });
+        hhA = (Account) HH_Container_LCTRL.getHHNamesGreetings(hhA, new Contact[]{ conA, conO });
+
         system.assertEquals('conA and conO Household', hhA.Name);
         system.assertEquals('cA conA and cO conO', hhA.npo02__Formal_Greeting__c );
         system.assertEquals('cA and cO', hhA.npo02__Informal_Greeting__c );
@@ -440,17 +468,7 @@ private class HH_Container_TEST {
             - Contact fields specified in Household Naming configuration
     **********************************************************************************************************/  
     static testMethod void getContactFieldsShouldReturnExpectedFieldNames() {
-        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
-            new Household_Naming_Settings__c(
-                Household_Name_Format__c = '{!LastName} Household',
-                Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}} {!LastName}',
-                Informal_Greeting_Format__c = '{!{!FirstName}}',
-                Name_Connector__c = label.npo02.HouseholdNameConnector,
-                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
-                Contact_Overrun_Count__c = 9,
-                Implementing_Class__c = 'HH_NameSpec'
-            )
-        );
+        setupHHNamingSettings();
 
         List<String> lsFieldNames = HH_Container_LCTRL.getContactFields();
         Set<String> fieldNames = new Set<String>(lsFieldNames);
@@ -471,113 +489,27 @@ private class HH_Container_TEST {
 
         //verify main mandatory fields are included in the output
         for (String fieldName : new String[] {
-                'Id', 
-                'npo02__Household_Naming_Order__c', 
-                'FirstName', 
-                'LastName', 
-                'Salutation', 
-                'Name',
-                'npo02__Naming_Exclusions__c', 
-                'AccountId', 
+                'Id', 'npo02__Household_Naming_Order__c', 
+                'FirstName', 'LastName', 'Salutation', 
+                'Name', 'npo02__Naming_Exclusions__c', 'AccountId', 
                 UTIL_Namespace.StrTokenNSPrefix('HHId__c'),
                 UTIL_Namespace.StrTokenNSPrefix('Exclude_from_Household_Name__c'), 
                 UTIL_Namespace.StrTokenNSPrefix('Exclude_from_Household_Formal_Greeting__c'), 
                 UTIL_Namespace.StrTokenNSPrefix('Exclude_from_Household_Informal_Greeting__c'),
                 UTIL_Namespace.StrTokenNSPrefix('is_Address_Override__c'), 
                 UTIL_Namespace.StrTokenNSPrefix('Current_Address__c'), 
-                'npe01__Primary_Address_Type__c',
-                'MailingStreet', 
-                'MailingCity', 
-                'MailingState', 
-                'MailingPostalCode', 
-                'MailingCountry', 
-                'MailingLatitude', 
-                'MailingLongitude', 
-                'CreatedDate'
+                'npe01__Primary_Address_Type__c','MailingStreet', 'MailingCity', 
+                'MailingState', 'MailingPostalCode', 'MailingCountry', 
+                'MailingLatitude', 'MailingLongitude', 'CreatedDate'
             }
         ) {
             System.assert(fieldNames.contains(fieldName), fieldName + ' is not in : ' + fieldNames);
         }
     }
-
-    /*********************************************************************************************************
-    @description
-        Test getContacts() method when Household Naming Settings is invalid
-        and the Automatic Household Naming is turned off 
-    verify:
-        Contacts are retrieved successfully
-    **********************************************************************************************************/  
-    static testMethod void getContactsShouldReturnContactsWhenHHNamingSettingsIsInvalidAndAutomaticHouseholdNamingIsTurnedOff() {
-        turnOffAutomaticHHNaming();
-        setupInvalidHHNamingSettings();
-
-        initTestData();
-
-        Test.startTest();
-
-        Contact[] contacts = HH_Container_LCTRL.getContacts(hhA.Id);
-        System.assert(contacts != null && contacts.size() == 1, contacts);
-        System.assertEquals(conA.Id, contacts[0].Id);
-
-        contacts = HH_Container_LCTRL.getContacts(hhO.Id);
-        System.assert(contacts != null && contacts.size() == 1, contacts);
-        System.assertEquals(conO.Id, contacts[0].Id);
-
-        Test.stopTest();
-    }
-    
     
 
     // Helpers
-    ////////////
-
-    /*********************************************************************************************************
-    * @description Turns on Automatic Household Naming
-    * @return void
-    **********************************************************************************************************/
-    private static void turnOnAutomaticHHNaming() {
-        setupAutomaticHHNaming(true);
-    }
-
-    /*********************************************************************************************************
-    * @description Turns off Automatic Household Naming
-    * @return void
-    **********************************************************************************************************/
-    private static void turnOffAutomaticHHNaming() {
-        setupAutomaticHHNaming(false);
-    }
-
-    /*********************************************************************************************************
-    * @description Configures Household Settings' Automatic Household Naming field
-    * @param isOn Automatic Household Naming is turned on when parameter is true, otherwise, the settings is turned off
-    * @return void
-    **********************************************************************************************************/
-    private static void setupAutomaticHHNaming(Boolean isOn) {
-        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
-            new npo02__Households_Settings__c (
-                npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
-                npo02__Advanced_Household_Naming__c = isOn
-            )
-        );
-    }
-
-    /*********************************************************************************************************
-    * @description Configures Household Naming Settings with invalid Name and Greetings formats
-    * @return void
-    **********************************************************************************************************/
-    private static void setupInvalidHHNamingSettings() {
-        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
-        	new Household_Naming_Settings__c(
-                Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household', 
-        		Formal_Greeting_Format__c = '{!{!Title} {!FirstName}}}{!LastName}',
-                Informal_Greeting_Format__c = '{!{!FirstName}}}',
-        		Name_Connector__c = label.npo02.HouseholdNameConnector,
-       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
-        		Contact_Overrun_Count__c = 9,
-        		Implementing_Class__c = 'HH_NameSpec'
-            )
-        );
-    }
+    ////////////    
 
     /*********************************************************************************************************
     * @description Builds Accounts with Household Account Type
@@ -702,5 +634,72 @@ private class HH_Container_TEST {
                 BillingState, BillingPostalCode, BillingCountry
             FROM Account
         ];
+    }
+
+    /*********************************************************************************************************
+    * @description Turns on Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOnAutomaticHHNaming() {
+        setupAutomaticHHNaming(true);
+    }
+
+    /*********************************************************************************************************
+    * @description Turns off Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOffAutomaticHHNaming() {
+        setupAutomaticHHNaming(false);
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Settings' Automatic Household Naming field
+    * @param isOn Automatic Household Naming is turned on when parameter is true, otherwise, the settings is turned off
+    * @return void
+    **********************************************************************************************************/
+    private static void setupAutomaticHHNaming(Boolean isOn) {
+        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
+            new npo02__Households_Settings__c (
+                npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
+                npo02__Advanced_Household_Naming__c = isOn
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with invalid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupInvalidHHNamingSettings() {
+        setupHHNamingSettings('{!{!FirstName}} {!LastName}} Household', '{!{!Title} {!FirstName}}}{!LastName}', '{!{!FirstName}}}');
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with valid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings() {
+        setupHHNamingSettings('{!LastName} Household', '{!{!Salutation} {!FirstName}} {!LastName}', '{!{!FirstName}}');
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings 
+    * @param hhNameFormat Household Naming Format
+    * @param formalGreetingFormat Formal Greeting Format
+    * @param informalGreetingFormat Informal Greeting Format
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = hhNameFormat,
+                Formal_Greeting_Format__c = formalGreetingFormat,
+                Informal_Greeting_Format__c = informalGreetingFormat,
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
     }
 }

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -100,14 +100,12 @@ public without sharing class HH_HouseholdNaming {
             }
         }
 
-        npo02__Households_Settings__c hs = UTIL_CustomSettingsFacade.getHouseholdsSettings();
-
         //loop through the households needing name changes, if necessary, make them.
         for (SObject h : hhupdatelist){
             ID hhId = string.valueOf(h.get('Id'));
             list<Contact> listCon = hhIDContactMap.get(hhId);
 
-            if (hs.npo02__Advanced_Household_Naming__c == true) {
+            if (isAutomaticNaming()) {
 	            string customnameparam = '';
 	            if (h.get('npo02__SYSTEM_CUSTOM_NAMING__c') != null){
 	                customnameparam = string.valueOf(h.get('npo02__SYSTEM_CUSTOM_NAMING__c'));
@@ -136,6 +134,18 @@ public without sharing class HH_HouseholdNaming {
         HH_ProcessControl.inFutureContext = false;
     }
 
+
+    /*******************************************************************************************************
+    * @description Returns Automatic Household Naming setting
+    * @return Boolean True if the Automatic Household Naming is checked, false otherwise
+    */
+    public Boolean isAutomaticNaming() {
+        npo02__Households_Settings__c settings = UTIL_CustomSettingsFacade.getHouseholdsSettings();
+
+        return settings == null
+			? false
+			: settings.npo02__Advanced_Household_Naming__c == true;
+    }
 
     /*******************************************************************************************************
     * @description our cached copy of the Household Naming Settings
@@ -218,6 +228,16 @@ public without sharing class HH_HouseholdNaming {
     }
 
     /*******************************************************************************************************
+    * @description Returns Contact field names specified in the Household Naming Settings 
+    * @return Set<String> Set of Contact field names if the Automatic Household Naming is enabled; otherwise, an empty set
+    */
+    public Set<String> getHouseholdNamingContactFields() {
+        return isAutomaticNaming()
+            ? iNaming.setHouseholdNameFieldsOnContact()
+            : new Set<String>();
+    }
+
+    /*******************************************************************************************************
     * @description executes the batch job to update all household names
     * @param isActivation whether this is being called when npo02__Advanced_Household_Naming__c is being turned on
     * @return void
@@ -275,15 +295,6 @@ public without sharing class HH_HouseholdNaming {
         private set;
     }
 
-    private Set<String> getHouseholdNamingContactFields() {
-        npo02__Households_Settings__c hhNamingConfig = UTIL_CustomSettingsFacade.getHouseholdsSettings();
-        Boolean isHHNamingAutomated = hhNamingConfig.npo02__Advanced_Household_Naming__c == true;
-
-        return isHHNamingAutomated
-            ? iNaming.setHouseholdNameFieldsOnContact()
-            : new Set<String>();
-    }
-
     /*******************************************************************************************************
     * @description pseudo-trigger handler for dealing with changes to the system name fields on the Household
     * in case they are changed and require recalculating the Household name and greetings.
@@ -312,7 +323,8 @@ public without sharing class HH_HouseholdNaming {
             // no need to do any of this name checking if we aren't using auto household naming.
             // even though UpdateNames() keeps Number of Household Members updated, there is no need
             // to call it from here which is just trying to detect manual hh name changes.
-            if (hs != null && hs.npo02__Advanced_Household_Naming__c == true ) {
+            
+            if (hs != null && hs.npo02__Advanced_Household_Naming__c == true) {
                 // AfterUpdate data
                 list<id> hhlist = new list<id>();
 

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -261,17 +261,27 @@ public without sharing class HH_HouseholdNaming {
 		        //we use dynamic soql so we can include all contact fields, since custom naming may refer to any field.
 		        string strSoql = 'SELECT Id, HHId__c, npo02__Naming_Exclusions__c';
 		        
-		        set<string> setStrField = iNaming.setHouseholdNameFieldsOnContact();
+		        set<string> setStrField = getHouseholdNamingContactFields();
 		        for (string strF : setStrField) {
                     if (strF == 'Salutation') strF = 'toLabel(Salutation)';
                     strSoql += ', ' + strF;
 		        }
+
 		        strSoql += ' FROM Contact ';
 		        strContactSelectStmtAllNamingFields = strSoql;
 	        }
 	        return strContactSelectStmtAllNamingFields;
         }
         private set;
+    }
+
+    private Set<String> getHouseholdNamingContactFields() {
+        npo02__Households_Settings__c hhNamingConfig = UTIL_CustomSettingsFacade.getHouseholdsSettings();
+        Boolean isHHNamingAutomated = hhNamingConfig.npo02__Advanced_Household_Naming__c == true;
+
+        return isHHNamingAutomated
+            ? iNaming.setHouseholdNameFieldsOnContact()
+            : new Set<String>();
     }
 
     /*******************************************************************************************************

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -143,8 +143,8 @@ public without sharing class HH_HouseholdNaming {
         npo02__Households_Settings__c settings = UTIL_CustomSettingsFacade.getHouseholdsSettings();
 
         return settings == null
-			? false
-			: settings.npo02__Advanced_Household_Naming__c == true;
+            ? false
+            : settings.npo02__Advanced_Household_Naming__c == true;
     }
 
     /*******************************************************************************************************

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls
@@ -1,0 +1,63 @@
+public with sharing class HH_HouseholdNamingSettingValidator {
+	public HH_HouseholdNamingSettingValidator() {
+	}
+
+	public Notification validate(Household_Naming_Settings__c settings) {
+		Notification notification = new Notification();
+
+		validateImplementingClass(notification);
+		validateFormat(notification);
+
+		return notification;
+	}
+
+	@TestVisible
+	private void validateImplementingClass(Notification notification) {
+
+	}
+
+	@TestVisible
+	private void validateFormat(Notification notification) {
+		validateFormat('Household_Name_Format__c', notification);
+		validateFormat('Formal_Greeting_Format__c', notification);
+		validateFormat('Informal_Greeting_Format__c', notification);
+
+		validateContactFieldsApiName(notification);
+	}
+
+	private void validateFormat(String fieldName, Notification notification) {
+
+	}
+
+	private void validateContactFieldsApiName(Notification notification) {
+
+	}
+
+	public class Notification {
+		private String[] errors = new String[0];
+		
+		public Notification addErrors(String[] errors) {
+			if (errors != null) {
+				this.errors.addAll(errors);
+			}
+
+			return this;
+		}
+
+		public Notification addError(String error) {
+			if (!String.isBlank(error)) {
+				errors.add(error);
+			}
+
+			return this;
+		}
+
+		public String[] getErrors() {
+			return errors;
+		}
+
+		public Boolean isSuccess() {
+			return errors.isEmpty();
+		}
+	}
+}

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls
@@ -1,41 +1,214 @@
+/*
+    Copyright (c) 2017, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2017
+* @group Households
+* @description Validates Household Naming Settings fields. Collects errors (if any) in the Notification.
+*/
 public with sharing class HH_HouseholdNamingSettingValidator {
+
+    /*********************************************************************************************************
+    * @description List of example Contacts
+    */
+	private static Contact[] exampleContacts {
+        get {
+			return exampleContacts = exampleContacts == null
+				? buildExampleContacts()
+				: exampleContacts;
+		}
+        set;
+    }
+
+    /*********************************************************************************************************
+    * @description The validator's constructor 
+    */
 	public HH_HouseholdNamingSettingValidator() {
 	}
 
+    /*********************************************************************************************************
+    * @description Validates Household Naming Settings
+    * @param settings Household Naming Settings
+    * @return Notification Contains reported validation errors
+    */
 	public Notification validate(Household_Naming_Settings__c settings) {
 		Notification notification = new Notification();
 
-		validateImplementingClass(notification);
-		validateFormat(notification);
+		HH_INaming hhNaming = validateImplementingClass(settings, notification);
+
+		validateFormatFields(settings, hhNaming, notification);
 
 		return notification;
 	}
 
-	@TestVisible
-	private void validateImplementingClass(Notification notification) {
+    /*********************************************************************************************************
+    * @description Validates Household Naming Settings Implementing Class. Returns its instance if valid. 
+    * @param settings Household Naming Settings
+    * @param notification Contains reported validation errors
+    * @return HH_INaming An instance of a valid Implementing Class; null if the instance cannot be created.
+    */
+	public HH_INaming validateImplementingClass(Household_Naming_Settings__c settings, Notification notification) {
+		String className = settings.Implementing_Class__c;  
+        className = String.isBlank(className) ? 'HH_NameSpec' : className; 
 
+        Type classType = Type.forName(className);
+        if (classType == null) {   
+			notification.addError(Label.stgErrorInvalidClass);
+			return null;  
+		}
+
+		Object classInstance = classType.newInstance();
+		if (classInstance instanceof HH_INaming) {
+			return (HH_INaming) classInstance;
+		} 
+		
+		notification.addError(Label.stgErrorINaming);
+		return null;  
 	}
 
-	@TestVisible
-	private void validateFormat(Notification notification) {
-		validateFormat('Household_Name_Format__c', notification);
-		validateFormat('Formal_Greeting_Format__c', notification);
-		validateFormat('Informal_Greeting_Format__c', notification);
+    /*********************************************************************************************************
+    * @description Validates Household Naming Settings format fields
+    * @param settings Household Naming Settings
+    * @param hhNaming An instance of the settings' Implementing Class
+    * @param notification Contains reported validation errors
+    * @return void
+    */
+	private void validateFormatFields(Household_Naming_Settings__c settings, HH_INaming hhNaming, Notification notification) {
+		if (hhNaming == null) {
+			return;
+		}
 
-		validateContactFieldsApiName(notification);
+		validateFormat('Household_Name_Format__c', settings, hhNaming, notification);
+		validateFormat('Formal_Greeting_Format__c', settings, hhNaming, notification);
+		validateFormat('Informal_Greeting_Format__c', settings, hhNaming, notification);
+
+		if (!notification.isSuccess()) {
+			//the rest of validation will run only if the format is correct
+			return; 
+		}
+		
+		validateContactFieldsApiName(hhNaming, notification);
 	}
 
-	private void validateFormat(String fieldName, Notification notification) {
+    /*********************************************************************************************************
+    * @description Validates format of a field
+    * @param fieldName Household Naming Settings field Name
+    * @param settings Household Naming Settings
+    * @param hhNaming An instance of the settings' Implementing Class
+    * @param notification Contains reported validation errors
+    * @return void
+    */
+	private void validateFormat(
+		String fieldName, Household_Naming_Settings__c settings,
+		HH_INaming hhNaming, Notification notification
+	) {
+		String fieldLabel = UTIL_Describe.getFieldLabel(
+            UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
+            UTIL_Namespace.StrTokenNSPrefix(fieldName)
+        );
+        
+        try {
+			hhNaming.getExampleName(settings, fieldName, exampleContacts);
 
+        } catch (Exception ex) {
+            notification.addError(
+                String.format(Label.stgErrorInvalidNameFormat, new String[]{ fieldLabel, ex.getMessage() })
+            );       
+        } 
+	} 
+
+    /*********************************************************************************************************
+    * @description Validates whether Household Naming Settings format fields are correct case-sensitive API Names
+    * @param hhNaming An instance of the settings' Implementing Class
+    * @param notification Contains reported validation errors
+    * @return void
+    */
+	private void validateContactFieldsApiName(HH_INaming hhNaming, Notification notification) {
+		Set<String> fieldApiNames = new Set<String>();
+        for (Schema.SObjectField field : Schema.SObjectType.Contact.fields.getMap().values()) {
+            fieldApiNames.add(field.getDescribe().getName());
+        }
+
+        Set<String> fieldNames = hhNaming.setHouseholdNameFieldsOnContact();
+
+        for (String fieldName : fieldNames) {
+            if (!fieldApiNames.contains(fieldName)) {
+                notification.addError( 
+                    String.format(Label.stgErrorInvalidApiName, new String[]{ fieldName })
+                );
+            }
+        }
 	}
 
-	private void validateContactFieldsApiName(Notification notification) {
+    /*********************************************************************************************************
+    * @description Builds list of example Contacts used to validate settings' format fields
+    * @return Contact[]
+    */
+	private static Contact[] buildExampleContacts() {
+		Account acc = new Account(
+			Name = 'Sample',
+			BillingCity = 'Seattle'
+		);
 
+		Contact c1 = new Contact();
+		c1.Account = acc;
+		c1.FirstName = 'Sam';
+		c1.LastName = 'Smith';
+		c1.Salutation = 'Dr.';
+		c1.MailingCity = 'Seattle';
+
+		acc.npe01__One2OneContact__r = c1;
+		
+		Contact c2 = new Contact();
+		c2.Account = acc;
+		c2.FirstName = 'Sally';
+		c2.LastName = 'Smith';
+		c2.Salutation = 'Mrs.';
+		c2.MailingCity = 'Seattle';
+		
+		return new Contact[] { c1, c2 };
 	}
 
+	/*********************************************************************************************************
+	* @description Notification class containing Household Naming Settings validation errors 
+	*/
 	public class Notification {
+		/*********************************************************************************************************
+		* @description Contains validation errors 
+		*/
 		private String[] errors = new String[0];
 		
+		/*********************************************************************************************************
+		* @description Adds specified errors into the list of all errors
+		* @return Notification The instance of itself
+		*/
 		public Notification addErrors(String[] errors) {
 			if (errors != null) {
 				this.errors.addAll(errors);
@@ -44,6 +217,10 @@ public with sharing class HH_HouseholdNamingSettingValidator {
 			return this;
 		}
 
+		/*********************************************************************************************************
+		* @description Adds specified error into the list of all errors
+		* @return Notification The instance of itself
+		*/
 		public Notification addError(String error) {
 			if (!String.isBlank(error)) {
 				errors.add(error);
@@ -52,10 +229,18 @@ public with sharing class HH_HouseholdNamingSettingValidator {
 			return this;
 		}
 
+		/*********************************************************************************************************
+		* @description Returns errors
+		* @return String[] List of errors
+		*/
 		public String[] getErrors() {
-			return errors;
+			return errors.clone();
 		}
 
+		/*********************************************************************************************************
+		* @description Specifies if the Notification contains no error
+		* @return Boolean True if there are no errors, false otherwise
+		*/
 		public Boolean isSuccess() {
 			return errors.isEmpty();
 		}

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls
@@ -38,20 +38,20 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     /*********************************************************************************************************
     * @description List of example Contacts
     */
-	private static Contact[] exampleContacts {
+    private static Contact[] exampleContacts {
         get {
-			return exampleContacts = exampleContacts == null
-				? buildExampleContacts()
-				: exampleContacts;
-		}
+            return exampleContacts = exampleContacts == null
+                ? buildExampleContacts()
+                : exampleContacts;
+        }
         set;
     }
 
     /*********************************************************************************************************
     * @description The validator's constructor 
     */
-	public HH_HouseholdNamingSettingValidator() {
-	}
+    public HH_HouseholdNamingSettingValidator() {
+    }
 
     /*********************************************************************************************************
     * @description Validates Household Naming Settings
@@ -59,13 +59,13 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @return Notification Contains reported validation errors
     */
 	public Notification validate(Household_Naming_Settings__c settings) {
-		Notification notification = new Notification();
+        Notification notification = new Notification();
 
-		HH_INaming hhNaming = validateImplementingClass(settings, notification);
+        HH_INaming hhNaming = validateImplementingClass(settings, notification);
 
-		validateFormatFields(settings, hhNaming, notification);
+        validateFormatFields(settings, hhNaming, notification);
 
-		return notification;
+        return notification;
 	}
 
     /*********************************************************************************************************
@@ -75,22 +75,22 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @return HH_INaming An instance of a valid Implementing Class; null if the instance cannot be created.
     */
 	public HH_INaming validateImplementingClass(Household_Naming_Settings__c settings, Notification notification) {
-		String className = settings.Implementing_Class__c;  
+        String className = settings.Implementing_Class__c;  
         className = String.isBlank(className) ? 'HH_NameSpec' : className; 
 
         Type classType = Type.forName(className);
         if (classType == null) {   
-			notification.addError(Label.stgErrorInvalidClass);
-			return null;  
-		}
+        	notification.addError(Label.stgErrorInvalidClass);
+        	return null;  
+        }
 
-		Object classInstance = classType.newInstance();
-		if (classInstance instanceof HH_INaming) {
-			return (HH_INaming) classInstance;
-		} 
-		
-		notification.addError(Label.stgErrorINaming);
-		return null;  
+        Object classInstance = classType.newInstance();
+        if (classInstance instanceof HH_INaming) {
+        	return (HH_INaming) classInstance;
+        } 
+        
+        notification.addError(Label.stgErrorINaming);
+        return null;  
 	}
 
     /*********************************************************************************************************
@@ -100,21 +100,21 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @param notification Contains reported validation errors
     * @return void
     */
-	private void validateFormatFields(Household_Naming_Settings__c settings, HH_INaming hhNaming, Notification notification) {
-		if (hhNaming == null) {
-			return;
-		}
+    private void validateFormatFields(Household_Naming_Settings__c settings, HH_INaming hhNaming, Notification notification) {
+        if (hhNaming == null) {
+        	return;
+        }
 
-		validateFormat('Household_Name_Format__c', settings, hhNaming, notification);
-		validateFormat('Formal_Greeting_Format__c', settings, hhNaming, notification);
-		validateFormat('Informal_Greeting_Format__c', settings, hhNaming, notification);
+        validateFormat('Household_Name_Format__c', settings, hhNaming, notification);
+        validateFormat('Formal_Greeting_Format__c', settings, hhNaming, notification);
+        validateFormat('Informal_Greeting_Format__c', settings, hhNaming, notification);
 
-		if (!notification.isSuccess()) {
-			//the rest of validation will run only if the format is correct
-			return; 
-		}
-		
-		validateContactFieldsApiName(hhNaming, notification);
+        if (!notification.isSuccess()) {
+        	//the rest of validation will run only if the format is correct
+        	return; 
+        }
+        
+        validateContactFieldsApiName(hhNaming, notification);
 	}
 
     /*********************************************************************************************************
@@ -125,17 +125,17 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @param notification Contains reported validation errors
     * @return void
     */
-	private void validateFormat(
-		String fieldName, Household_Naming_Settings__c settings,
-		HH_INaming hhNaming, Notification notification
+    private void validateFormat(
+        String fieldName, Household_Naming_Settings__c settings,
+        HH_INaming hhNaming, Notification notification
 	) {
-		String fieldLabel = UTIL_Describe.getFieldLabel(
+        String fieldLabel = UTIL_Describe.getFieldLabel(
             UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
             UTIL_Namespace.StrTokenNSPrefix(fieldName)
         );
         
         try {
-			hhNaming.getExampleName(settings, fieldName, exampleContacts);
+            hhNaming.getExampleName(settings, fieldName, exampleContacts);
 
         } catch (Exception ex) {
             notification.addError(
@@ -150,8 +150,8 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @param notification Contains reported validation errors
     * @return void
     */
-	private void validateContactFieldsApiName(HH_INaming hhNaming, Notification notification) {
-		Set<String> fieldApiNames = new Set<String>();
+    private void validateContactFieldsApiName(HH_INaming hhNaming, Notification notification) {
+        Set<String> fieldApiNames = new Set<String>();
         for (Schema.SObjectField field : Schema.SObjectType.Contact.fields.getMap().values()) {
             fieldApiNames.add(field.getDescribe().getName());
         }
@@ -171,78 +171,78 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @description Builds list of example Contacts used to validate settings' format fields
     * @return Contact[]
     */
-	private static Contact[] buildExampleContacts() {
-		Account acc = new Account(
-			Name = 'Sample',
-			BillingCity = 'Seattle'
-		);
+    private static Contact[] buildExampleContacts() {
+        Account acc = new Account(
+            Name = 'Sample',
+            BillingCity = 'Seattle'
+        );
 
-		Contact c1 = new Contact();
-		c1.Account = acc;
-		c1.FirstName = 'Sam';
-		c1.LastName = 'Smith';
-		c1.Salutation = 'Dr.';
-		c1.MailingCity = 'Seattle';
+        Contact c1 = new Contact();
+        c1.Account = acc;
+        c1.FirstName = 'Sam';
+        c1.LastName = 'Smith';
+        c1.Salutation = 'Dr.';
+        c1.MailingCity = 'Seattle';
 
-		acc.npe01__One2OneContact__r = c1;
-		
-		Contact c2 = new Contact();
-		c2.Account = acc;
-		c2.FirstName = 'Sally';
-		c2.LastName = 'Smith';
-		c2.Salutation = 'Mrs.';
-		c2.MailingCity = 'Seattle';
-		
-		return new Contact[] { c1, c2 };
+        acc.npe01__One2OneContact__r = c1;
+        
+        Contact c2 = new Contact();
+        c2.Account = acc;
+        c2.FirstName = 'Sally';
+        c2.LastName = 'Smith';
+        c2.Salutation = 'Mrs.';
+        c2.MailingCity = 'Seattle';
+        
+        return new Contact[] { c1, c2 };
 	}
 
 	/*********************************************************************************************************
 	* @description Notification class containing Household Naming Settings validation errors 
 	*/
 	public class Notification {
-		/*********************************************************************************************************
-		* @description Contains validation errors 
-		*/
-		private String[] errors = new String[0];
-		
-		/*********************************************************************************************************
-		* @description Adds specified errors into the list of all errors
-		* @return Notification The instance of itself
-		*/
-		public Notification addErrors(String[] errors) {
-			if (errors != null) {
-				this.errors.addAll(errors);
-			}
+        /*********************************************************************************************************
+        * @description Contains validation errors 
+        */
+	    private String[] errors = new String[0];
+        
+        /*********************************************************************************************************
+        * @description Adds specified errors into the list of all errors
+        * @return Notification The instance of itself
+        */
+        public Notification addErrors(String[] errors) {
+        	if (errors != null) {
+                this.errors.addAll(errors);
+        	}
 
-			return this;
-		}
+        	return this;
+        }
 
-		/*********************************************************************************************************
-		* @description Adds specified error into the list of all errors
-		* @return Notification The instance of itself
-		*/
-		public Notification addError(String error) {
-			if (!String.isBlank(error)) {
-				errors.add(error);
-			}
+        /*********************************************************************************************************
+        * @description Adds specified error into the list of all errors
+        * @return Notification The instance of itself
+        */
+        public Notification addError(String error) {
+        	if (!String.isBlank(error)) {
+                errors.add(error);
+        	}
 
-			return this;
-		}
+        	return this;
+        }
 
-		/*********************************************************************************************************
-		* @description Returns errors
-		* @return String[] List of errors
-		*/
-		public String[] getErrors() {
-			return errors.clone();
-		}
+        /*********************************************************************************************************
+        * @description Returns errors
+        * @return String[] List of errors
+        */
+        public String[] getErrors() {
+            return errors.clone();
+        }
 
-		/*********************************************************************************************************
-		* @description Specifies if the Notification contains no error
-		* @return Boolean True if there are no errors, false otherwise
-		*/
-		public Boolean isSuccess() {
-			return errors.isEmpty();
-		}
+        /*********************************************************************************************************
+        * @description Specifies if the Notification contains no error
+        * @return Boolean True if there are no errors, false otherwise
+        */
+        public Boolean isSuccess() {
+            return errors.isEmpty();
+        }
 	}
 }

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls
@@ -151,21 +151,91 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @return void
     */
     private void validateContactFieldsApiName(HH_INaming hhNaming, Notification notification) {
-        Set<String> fieldApiNames = new Set<String>();
-        for (Schema.SObjectField field : Schema.SObjectType.Contact.fields.getMap().values()) {
-            fieldApiNames.add(field.getDescribe().getName());
-        }
+		Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = getFieldResultsByName(Contact.SObjectType);
+		Set<String> fieldNames = hhNaming.setHouseholdNameFieldsOnContact();
 
-        Set<String> fieldNames = hhNaming.setHouseholdNameFieldsOnContact();
-
-        for (String fieldName : fieldNames) {
-            if (!fieldApiNames.contains(fieldName)) {
-                notification.addError( 
+		for (String fieldName : fieldNames) {
+			if (!isValidApiName(fieldName, contactFieldResultsByName)) {
+				notification.addError( 
                     String.format(Label.stgErrorInvalidApiName, new String[]{ fieldName })
                 );
-            }
-        }
+			}
+		}
     }
+
+    /*********************************************************************************************************
+    * @description Validates if field name is a valid API Name for an Sobject 
+    * @param fieldName Field name
+    * @param fieldResultsByFieldName The Sobject's field results mapped by a field name or a relationship name
+    * @return Boolean
+    */
+	@TestVisible
+	private Boolean isValidApiName(String fieldName, Map<String, Schema.DescribeFieldResult> fieldResultsByFieldName) {
+		if (String.isBlank(fieldName)) {
+			return false;
+		}
+
+		if (fieldResultsByFieldName.keySet().contains(fieldName)) {
+			return true;
+		}
+
+		String[] nameParts = fieldName.split('\\.');
+		Boolean isReferenceField = nameParts.size() > 1;
+
+		if (!isReferenceField) { 
+			return false;
+		}
+		
+		String relationshipName = nameParts[0];
+
+		return isValidApiName(fieldName.substringAfter('.'), fieldResultsByFieldName.get(relationshipName));
+	}
+
+    /*********************************************************************************************************
+    * @description Validates if field name is a valid API Name for the referenced Sobject 
+    * @param fieldName Field name
+    * @param referenceFieldResult The reference (Lookup, M-D) field result
+    * @return Boolean
+    */
+	private Boolean isValidApiName(String fieldName, Schema.DescribeFieldResult referenceFieldResult) {
+		Schema.SObjectType[] references = referenceFieldResult == null 
+			? null 
+			: referenceFieldResult.getReferenceTo();
+
+		if (String.isBlank(fieldName) || references == null) { 
+			return false; 
+		}
+
+		for (Schema.SObjectType referenceTo : references) {
+			if (isValidApiName(fieldName, getFieldResultsByName(referenceTo))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+	
+    /*********************************************************************************************************
+    * @description Returns Sobject field results mapped by a field name or a relationship name
+    * @param sobjectType Schema.SobjectType
+    * @return Map<String, Schema.DescribeFieldResult>
+    */
+	@TestVisible
+	private Map<String, Schema.DescribeFieldResult> getFieldResultsByName(Schema.SobjectType sobjectType) {
+		Map<String, Schema.DescribeFieldResult> fieldResults = new Map<String, Schema.DescribeFieldResult>();
+
+		for (Schema.SObjectField field : sobjectType.getDescribe().fields.getMap().values()) {
+			Schema.DescribeFieldResult fieldResult = field.getDescribe();
+
+			fieldResults.put(fieldResult.getName(), fieldResult);
+
+			if (String.isNotBlank(fieldResult.getRelationshipName())) {
+				fieldResults.put(fieldResult.getRelationshipName(), fieldResult);
+			}
+		}
+
+		return fieldResults;
+	}
 
     /*********************************************************************************************************
     * @description Builds list of example Contacts used to validate settings' format fields

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls
@@ -151,16 +151,16 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @return void
     */
     private void validateContactFieldsApiName(HH_INaming hhNaming, Notification notification) {
-		Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = getFieldResultsByName(Contact.SObjectType);
-		Set<String> fieldNames = hhNaming.setHouseholdNameFieldsOnContact();
+        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = getFieldResultsByName(Contact.SObjectType);
+        Set<String> fieldNames = hhNaming.setHouseholdNameFieldsOnContact();
 
-		for (String fieldName : fieldNames) {
-			if (!isValidApiName(fieldName, contactFieldResultsByName)) {
-				notification.addError( 
+        for (String fieldName : fieldNames) {
+            if (!isValidApiName(fieldName, contactFieldResultsByName)) {
+                notification.addError( 
                     String.format(Label.stgErrorInvalidApiName, new String[]{ fieldName })
                 );
-			}
-		}
+            }
+        }
     }
 
     /*********************************************************************************************************
@@ -169,27 +169,27 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @param fieldResultsByFieldName The Sobject's field results mapped by a field name or a relationship name
     * @return Boolean
     */
-	@TestVisible
-	private Boolean isValidApiName(String fieldName, Map<String, Schema.DescribeFieldResult> fieldResultsByFieldName) {
-		if (String.isBlank(fieldName)) {
-			return false;
-		}
+    @TestVisible
+    private Boolean isValidApiName(String fieldName, Map<String, Schema.DescribeFieldResult> fieldResultsByFieldName) {
+        if (String.isBlank(fieldName)) {
+            return false;
+        }
 
-		if (fieldResultsByFieldName.keySet().contains(fieldName)) {
-			return true;
-		}
+        if (fieldResultsByFieldName.keySet().contains(fieldName)) {
+            return true;
+        }
 
-		String[] nameParts = fieldName.split('\\.');
-		Boolean isReferenceField = nameParts.size() > 1;
+        String[] nameParts = fieldName.split('\\.');
+        Boolean isReferenceField = nameParts.size() > 1;
 
-		if (!isReferenceField) { 
-			return false;
-		}
-		
-		String relationshipName = nameParts[0];
+        if (!isReferenceField) { 
+            return false;
+        }
+        
+        String relationshipName = nameParts[0];
 
-		return isValidApiName(fieldName.substringAfter('.'), fieldResultsByFieldName.get(relationshipName));
-	}
+        return isValidApiName(fieldName.substringAfter('.'), fieldResultsByFieldName.get(relationshipName));
+    }
 
     /*********************************************************************************************************
     * @description Validates if field name is a valid API Name for the referenced Sobject 
@@ -197,45 +197,45 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @param referenceFieldResult The reference (Lookup, M-D) field result
     * @return Boolean
     */
-	private Boolean isValidApiName(String fieldName, Schema.DescribeFieldResult referenceFieldResult) {
-		Schema.SObjectType[] references = referenceFieldResult == null 
-			? null 
-			: referenceFieldResult.getReferenceTo();
+    private Boolean isValidApiName(String fieldName, Schema.DescribeFieldResult referenceFieldResult) {
+        Schema.SObjectType[] references = referenceFieldResult == null 
+            ? null 
+            : referenceFieldResult.getReferenceTo();
 
-		if (String.isBlank(fieldName) || references == null) { 
-			return false; 
-		}
+        if (String.isBlank(fieldName) || references == null) { 
+            return false; 
+        }
 
-		for (Schema.SObjectType referenceTo : references) {
-			if (isValidApiName(fieldName, getFieldResultsByName(referenceTo))) {
-				return true;
-			}
-		}
+        for (Schema.SObjectType referenceTo : references) {
+            if (isValidApiName(fieldName, getFieldResultsByName(referenceTo))) {
+                return true;
+            }
+        }
 
-		return false;
-	}
-	
+        return false;
+    }
+    
     /*********************************************************************************************************
     * @description Returns Sobject field results mapped by a field name or a relationship name
     * @param sobjectType Schema.SobjectType
     * @return Map<String, Schema.DescribeFieldResult>
     */
-	@TestVisible
-	private Map<String, Schema.DescribeFieldResult> getFieldResultsByName(Schema.SobjectType sobjectType) {
-		Map<String, Schema.DescribeFieldResult> fieldResults = new Map<String, Schema.DescribeFieldResult>();
+    @TestVisible
+    private Map<String, Schema.DescribeFieldResult> getFieldResultsByName(Schema.SobjectType sobjectType) {
+        Map<String, Schema.DescribeFieldResult> fieldResults = new Map<String, Schema.DescribeFieldResult>();
 
-		for (Schema.SObjectField field : sobjectType.getDescribe().fields.getMap().values()) {
-			Schema.DescribeFieldResult fieldResult = field.getDescribe();
+        for (Schema.SObjectField field : sobjectType.getDescribe().fields.getMap().values()) {
+            Schema.DescribeFieldResult fieldResult = field.getDescribe();
 
-			fieldResults.put(fieldResult.getName(), fieldResult);
+            fieldResults.put(fieldResult.getName(), fieldResult);
 
-			if (String.isNotBlank(fieldResult.getRelationshipName())) {
-				fieldResults.put(fieldResult.getRelationshipName(), fieldResult);
-			}
-		}
+            if (String.isNotBlank(fieldResult.getRelationshipName())) {
+                fieldResults.put(fieldResult.getRelationshipName(), fieldResult);
+            }
+        }
 
-		return fieldResults;
-	}
+        return fieldResults;
+    }
 
     /*********************************************************************************************************
     * @description Builds list of example Contacts used to validate settings' format fields

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls
@@ -151,90 +151,16 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @return void
     */
     private void validateContactFieldsApiName(HH_INaming hhNaming, Notification notification) {
-        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = getFieldResultsByName(Contact.SObjectType);
+        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = UTIL_Describe.getFieldResultsByName(Contact.SObjectType);
         Set<String> fieldNames = hhNaming.setHouseholdNameFieldsOnContact();
 
         for (String fieldName : fieldNames) {
-            if (!isValidApiName(fieldName, contactFieldResultsByName)) {
+            if (!UTIL_Describe.isValidApiName(fieldName, contactFieldResultsByName)) {
                 notification.addError( 
                     String.format(Label.stgErrorInvalidApiName, new String[]{ fieldName })
                 );
             }
         }
-    }
-
-    /*********************************************************************************************************
-    * @description Validates if field name is a valid API Name for an Sobject 
-    * @param fieldName Field name
-    * @param fieldResultsByFieldName The Sobject's field results mapped by a field name or a relationship name
-    * @return Boolean
-    */
-    @TestVisible
-    private Boolean isValidApiName(String fieldName, Map<String, Schema.DescribeFieldResult> fieldResultsByFieldName) {
-        if (String.isBlank(fieldName)) {
-            return false;
-        }
-
-        if (fieldResultsByFieldName.keySet().contains(fieldName)) {
-            return true;
-        }
-
-        String[] nameParts = fieldName.split('\\.');
-        Boolean isReferenceField = nameParts.size() > 1;
-
-        if (!isReferenceField) { 
-            return false;
-        }
-        
-        String relationshipName = nameParts[0];
-
-        return isValidApiName(fieldName.substringAfter('.'), fieldResultsByFieldName.get(relationshipName));
-    }
-
-    /*********************************************************************************************************
-    * @description Validates if field name is a valid API Name for the referenced Sobject 
-    * @param fieldName Field name
-    * @param referenceFieldResult The reference (Lookup, M-D) field result
-    * @return Boolean
-    */
-    private Boolean isValidApiName(String fieldName, Schema.DescribeFieldResult referenceFieldResult) {
-        Schema.SObjectType[] references = referenceFieldResult == null 
-            ? null 
-            : referenceFieldResult.getReferenceTo();
-
-        if (String.isBlank(fieldName) || references == null) { 
-            return false; 
-        }
-
-        for (Schema.SObjectType referenceTo : references) {
-            if (isValidApiName(fieldName, getFieldResultsByName(referenceTo))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-    
-    /*********************************************************************************************************
-    * @description Returns Sobject field results mapped by a field name or a relationship name
-    * @param sobjectType Schema.SobjectType
-    * @return Map<String, Schema.DescribeFieldResult>
-    */
-    @TestVisible
-    private Map<String, Schema.DescribeFieldResult> getFieldResultsByName(Schema.SobjectType sobjectType) {
-        Map<String, Schema.DescribeFieldResult> fieldResults = new Map<String, Schema.DescribeFieldResult>();
-
-        for (Schema.SObjectField field : sobjectType.getDescribe().fields.getMap().values()) {
-            Schema.DescribeFieldResult fieldResult = field.getDescribe();
-
-            fieldResults.put(fieldResult.getName(), fieldResult);
-
-            if (String.isNotBlank(fieldResult.getRelationshipName())) {
-                fieldResults.put(fieldResult.getRelationshipName(), fieldResult);
-            }
-        }
-
-        return fieldResults;
     }
 
     /*********************************************************************************************************

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls
@@ -58,7 +58,7 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @param settings Household Naming Settings
     * @return Notification Contains reported validation errors
     */
-	public Notification validate(Household_Naming_Settings__c settings) {
+    public Notification validate(Household_Naming_Settings__c settings) {
         Notification notification = new Notification();
 
         HH_INaming hhNaming = validateImplementingClass(settings, notification);
@@ -66,7 +66,7 @@ public with sharing class HH_HouseholdNamingSettingValidator {
         validateFormatFields(settings, hhNaming, notification);
 
         return notification;
-	}
+    }
 
     /*********************************************************************************************************
     * @description Validates Household Naming Settings Implementing Class. Returns its instance if valid. 
@@ -74,24 +74,24 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     * @param notification Contains reported validation errors
     * @return HH_INaming An instance of a valid Implementing Class; null if the instance cannot be created.
     */
-	public HH_INaming validateImplementingClass(Household_Naming_Settings__c settings, Notification notification) {
+    public HH_INaming validateImplementingClass(Household_Naming_Settings__c settings, Notification notification) {
         String className = settings.Implementing_Class__c;  
         className = String.isBlank(className) ? 'HH_NameSpec' : className; 
 
         Type classType = Type.forName(className);
         if (classType == null) {   
-        	notification.addError(Label.stgErrorInvalidClass);
-        	return null;  
+            notification.addError(Label.stgErrorInvalidClass);
+            return null;  
         }
 
         Object classInstance = classType.newInstance();
         if (classInstance instanceof HH_INaming) {
-        	return (HH_INaming) classInstance;
+            return (HH_INaming) classInstance;
         } 
         
         notification.addError(Label.stgErrorINaming);
         return null;  
-	}
+    }
 
     /*********************************************************************************************************
     * @description Validates Household Naming Settings format fields
@@ -102,7 +102,7 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     */
     private void validateFormatFields(Household_Naming_Settings__c settings, HH_INaming hhNaming, Notification notification) {
         if (hhNaming == null) {
-        	return;
+            return;
         }
 
         validateFormat('Household_Name_Format__c', settings, hhNaming, notification);
@@ -110,12 +110,12 @@ public with sharing class HH_HouseholdNamingSettingValidator {
         validateFormat('Informal_Greeting_Format__c', settings, hhNaming, notification);
 
         if (!notification.isSuccess()) {
-        	//the rest of validation will run only if the format is correct
-        	return; 
+            //the rest of validation will run only if the format is correct
+            return; 
         }
         
         validateContactFieldsApiName(hhNaming, notification);
-	}
+    }
 
     /*********************************************************************************************************
     * @description Validates format of a field
@@ -128,7 +128,7 @@ public with sharing class HH_HouseholdNamingSettingValidator {
     private void validateFormat(
         String fieldName, Household_Naming_Settings__c settings,
         HH_INaming hhNaming, Notification notification
-	) {
+    ) {
         String fieldLabel = UTIL_Describe.getFieldLabel(
             UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
             UTIL_Namespace.StrTokenNSPrefix(fieldName)
@@ -142,7 +142,7 @@ public with sharing class HH_HouseholdNamingSettingValidator {
                 String.format(Label.stgErrorInvalidNameFormat, new String[]{ fieldLabel, ex.getMessage() })
             );       
         } 
-	} 
+    } 
 
     /*********************************************************************************************************
     * @description Validates whether Household Naming Settings format fields are correct case-sensitive API Names
@@ -165,7 +165,7 @@ public with sharing class HH_HouseholdNamingSettingValidator {
                 );
             }
         }
-	}
+    }
 
     /*********************************************************************************************************
     * @description Builds list of example Contacts used to validate settings' format fields
@@ -194,27 +194,27 @@ public with sharing class HH_HouseholdNamingSettingValidator {
         c2.MailingCity = 'Seattle';
         
         return new Contact[] { c1, c2 };
-	}
+    }
 
-	/*********************************************************************************************************
-	* @description Notification class containing Household Naming Settings validation errors 
-	*/
-	public class Notification {
+    /*********************************************************************************************************
+    * @description Notification class containing Household Naming Settings validation errors 
+    */
+    public class Notification {
         /*********************************************************************************************************
         * @description Contains validation errors 
         */
-	    private String[] errors = new String[0];
+        private String[] errors = new String[0];
         
         /*********************************************************************************************************
         * @description Adds specified errors into the list of all errors
         * @return Notification The instance of itself
         */
         public Notification addErrors(String[] errors) {
-        	if (errors != null) {
+            if (errors != null) {
                 this.errors.addAll(errors);
-        	}
+            }
 
-        	return this;
+            return this;
         }
 
         /*********************************************************************************************************
@@ -222,11 +222,11 @@ public with sharing class HH_HouseholdNamingSettingValidator {
         * @return Notification The instance of itself
         */
         public Notification addError(String error) {
-        	if (!String.isBlank(error)) {
+            if (!String.isBlank(error)) {
                 errors.add(error);
-        	}
+            }
 
-        	return this;
+            return this;
         }
 
         /*********************************************************************************************************
@@ -244,5 +244,5 @@ public with sharing class HH_HouseholdNamingSettingValidator {
         public Boolean isSuccess() {
             return errors.isEmpty();
         }
-	}
+    }
 }

--- a/src/classes/HH_HouseholdNamingSettingValidator.cls-meta.xml
+++ b/src/classes/HH_HouseholdNamingSettingValidator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
@@ -51,54 +51,54 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     /*********************************************************************************************************
     * @description Notification used to store and verify errors (if any) reported during validation
     */
-	private static HH_HouseholdNamingSettingValidator.Notification notification;
+    private static HH_HouseholdNamingSettingValidator.Notification notification;
     /*********************************************************************************************************
     * @description Validator used to validate Household Naming Settings
     */
-	private static HH_HouseholdNamingSettingValidator validator;
+    private static HH_HouseholdNamingSettingValidator validator;
 
 
     /*********************************************************************************************************
     * @description Static method to initialize variables before each unit test
     */
-	static {
-		validator = new HH_HouseholdNamingSettingValidator();
-		notification = new HH_HouseholdNamingSettingValidator.Notification();
-	}
-	
+    static {
+        validator = new HH_HouseholdNamingSettingValidator();
+        notification = new HH_HouseholdNamingSettingValidator.Notification();
+    }
+    
     /*********************************************************************************************************
     @description
         Test validation of Implementing Class when specified class does not exist
     verify:
         The notification contains an error
     **********************************************************************************************************/  
-	private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotExist() {
-		Household_Naming_Settings__c settings = setupHHNamingSettings();
+    private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotExist() {
+    Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Implementing_Class__c = 'foo'; 
 
-		HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
+        HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
 
         System.assertEquals(null, hhNaming);
 
         assertError(Label.stgErrorInvalidClass, notification);
-	}
-	
+    }
+    
     /*********************************************************************************************************
     @description
         Test validation of Implementing Class when specified class does not implement INaming interface
     verify:
         The notification contains an error
     **********************************************************************************************************/  
-	private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotImplementINamingInterface() {
+    private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotImplementINamingInterface() {
         Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Implementing_Class__c = 'HH_HouseholdNaming'; 
 
-		HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
+        HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
 
         System.assertEquals(null, hhNaming);
         
         assertError(Label.stgErrorINaming, notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -106,16 +106,16 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification does not contain any error. Returned object is a HH_NameSpec instance.
     **********************************************************************************************************/  
-	private static testMethod void validateImplementingClassShouldNotAddErrorWhenClassIsNotSpecified() {
+    private static testMethod void validateImplementingClassShouldNotAddErrorWhenClassIsNotSpecified() {
         Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Implementing_Class__c = null; 
 
-		HH_NameSpec hhNaming = (HH_NameSpec) validator.validateImplementingClass(settings, notification);
+        HH_NameSpec hhNaming = (HH_NameSpec) validator.validateImplementingClass(settings, notification);
 
         System.assertNotEquals(null, hhNaming);
 
         assertSuccess(notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -123,15 +123,15 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification does not contain any error
     **********************************************************************************************************/  
-	private static testMethod void validateImplementingClassShouldNotAddErrorWhenClassImplementsINamingInterface() {
+    private static testMethod void validateImplementingClassShouldNotAddErrorWhenClassImplementsINamingInterface() {
         Household_Naming_Settings__c settings = setupHHNamingSettings(); 
 
         HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
 
         System.assertNotEquals(null, hhNaming);
-		
+    
         assertSuccess(notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -139,14 +139,14 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification contains an error
     **********************************************************************************************************/  
-	private static testMethod void validateShouldAddErrorWhenHHNameFormatIsInvalid() {
+    private static testMethod void validateShouldAddErrorWhenHHNameFormatIsInvalid() {
         Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Household_Name_Format__c = INVALID_HHNAME_FORMAT; 
 
-		notification = validator.validate(settings);
+        notification = validator.validate(settings);
 
         assertErrorContainsInvalidFieldMessage('Household_Name_Format__c', notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -154,14 +154,14 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification contains an error
     **********************************************************************************************************/ 
-	private static testMethod void validateShouldAddErrorWhenFormalGreetingFormatIsInvalid() {
+    private static testMethod void validateShouldAddErrorWhenFormalGreetingFormatIsInvalid() {
         Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Formal_Greeting_Format__c = INVALID_FORMAL_GREETING_FORMAT; 
 
-		notification = validator.validate(settings);
+        notification = validator.validate(settings);
 
         assertErrorContainsInvalidFieldMessage('Formal_Greeting_Format__c', notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -169,14 +169,14 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification contains an error
     **********************************************************************************************************/ 
-	private static testMethod void validateShouldAddErrorWhenInformalGreetingFormatIsInvalid() {
+    private static testMethod void validateShouldAddErrorWhenInformalGreetingFormatIsInvalid() {
         Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Informal_Greeting_Format__c = INVALID_INFORMAL_GREETING_FORMAT; 
 
-		notification = validator.validate(settings);
+        notification = validator.validate(settings);
 
         assertErrorContainsInvalidFieldMessage('Informal_Greeting_Format__c', notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -184,18 +184,18 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification contains an error for each field that is not correct case-sensitive API Name
     **********************************************************************************************************/ 
-	private static testMethod void validateShouldAddErrorWhenContactFieldsApiNameIsInvalid() {
+    private static testMethod void validateShouldAddErrorWhenContactFieldsApiNameIsInvalid() {
         Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Household_Name_Format__c = 'The {!lastname}, {!{!FirstName} {!npe01__workemail__c}} Family'; 
 
-		notification = validator.validate(settings);
+        notification = validator.validate(settings);
 
         String[] expectedErrors = new String[] {
             String.format(Label.stgErrorInvalidApiName, new String[]{ 'lastname' }),
             String.format(Label.stgErrorInvalidApiName, new String[]{ 'npe01__workemail__c' })
         };
         assertErrors(expectedErrors, notification); 
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -203,14 +203,14 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification does not contain any error
     **********************************************************************************************************/ 
-	private static testMethod void validateShouldNotAddErrorWhenAFormatFieldIsNull() {
+    private static testMethod void validateShouldNotAddErrorWhenAFormatFieldIsNull() {
         Household_Naming_Settings__c settings = setupHHNamingSettings();
         settings.Household_Name_Format__c = null;
 
-		notification = validator.validate(settings);
-		
+        notification = validator.validate(settings);
+    
         assertSuccess(notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -219,14 +219,14 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification contains an error
     **********************************************************************************************************/ 
-	private static testMethod void validateShouldAddInvalidClassErrorWhenClassAndFormatFieldsAreInvalid() {
+    private static testMethod void validateShouldAddInvalidClassErrorWhenClassAndFormatFieldsAreInvalid() {
         Household_Naming_Settings__c settings = setupInvalidHHNamingSettings(); 
         settings.Implementing_Class__c = 'foo';
 
-		notification = validator.validate(settings);
+        notification = validator.validate(settings);
 
         assertError(Label.stgErrorInvalidClass, notification);
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -234,18 +234,18 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification contains errors for all format fields
     **********************************************************************************************************/ 
-	private static testMethod void validateShouldAddErrorsWhenAllThreeFormatFieldsAreInvalid() {
+    private static testMethod void validateShouldAddErrorsWhenAllThreeFormatFieldsAreInvalid() {
         Household_Naming_Settings__c settings = setupInvalidHHNamingSettings();
 
-		notification = validator.validate(settings);
+        notification = validator.validate(settings);
 
         System.assert(!notification.isSuccess());
 
-		String[] actualErrors = notification.getErrors();
+        String[] actualErrors = notification.getErrors();
 
         System.assertEquals(3, actualErrors.size(), actualErrors);
         System.assertEquals(3, new Set<String>(actualErrors).size());
-	}
+    }
 
     /*********************************************************************************************************
     @description
@@ -253,18 +253,18 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     verify:
         The notification does not contain any error
     **********************************************************************************************************/ 
-	private static testMethod void validateShouldNotAddErrorWhenAllHHSettingsFieldsAreValid() {
+    private static testMethod void validateShouldNotAddErrorWhenAllHHSettingsFieldsAreValid() {
         Household_Naming_Settings__c settings = setupHHNamingSettings(); 
 
-		notification = validator.validate(settings);
+        notification = validator.validate(settings);
         
         assertSuccess(notification);
-	}
+    }
 
-	// Helpers
-	////////////
+    // Helpers
+    ////////////
 
-	/*********************************************************************************************************
+    /*********************************************************************************************************
     * @description Configures Household Naming Settings with invalid Name and Greetings formats
     * @return Household_Naming_Settings__c Household Naming Settings
     **********************************************************************************************************/
@@ -282,7 +282,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     **********************************************************************************************************/
     private static Household_Naming_Settings__c setupHHNamingSettings() {
         return setupHHNamingSettings(            
-			'The {!LastName}, {!{!FirstName} {!npe01__WorkEmail__c}} Family',
+            'The {!LastName}, {!{!FirstName} {!npe01__WorkEmail__c}} Family',
             '{!{!Title} {!FirstName}}{!LastName}',
             '{!{!FirstName}}'
         );
@@ -316,8 +316,8 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     **********************************************************************************************************/
     private static void assertSuccess(HH_HouseholdNamingSettingValidator.Notification n) {
         System.assert(n.isSuccess(), n.getErrors());
-		
-		System.assert(n.getErrors().isEmpty(), n.getErrors());
+    
+        System.assert(n.getErrors().isEmpty(), n.getErrors());
     }
 
     /*********************************************************************************************************
@@ -338,16 +338,16 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     **********************************************************************************************************/
     private static void assertErrors(String[] expectedErrors, HH_HouseholdNamingSettingValidator.Notification n) {
         System.assert(!n.isSuccess());
-		
-		String[] actualErrors = n.getErrors();
+    
+        String[] actualErrors = n.getErrors();
 
-		System.assertEquals(expectedErrors.size(), actualErrors.size(), actualErrors);
+        System.assertEquals(expectedErrors.size(), actualErrors.size(), actualErrors);
 
         Set<String> expected = new Set<String>(expectedErrors);
         Set<String> actual = new Set<String>(actualErrors);
 
-		System.assertEquals(expected.size(), actual.size(), actual);
-		System.assert(expected.containsAll(actual), actual);
+        System.assertEquals(expected.size(), actual.size(), actual);
+        System.assert(expected.containsAll(actual), actual);
     }
 
     /*********************************************************************************************************
@@ -364,10 +364,10 @@ private class HH_HouseholdNamingSettingValidator_TEST {
 
         System.assert(!n.isSuccess());
 
-		String[] actualErrors = n.getErrors();
+        String[] actualErrors = n.getErrors();
 
         System.assertEquals(1, actualErrors.size(), actualErrors);
-		
+    
         for (String error : actualErrors) {
             if (error.contains(fieldLabel) && error.contains('Invalid field')) {
                 return;

--- a/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
@@ -78,7 +78,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
 
         HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
 
-        System.assertEquals(null, hhNaming);
+        System.assertEquals(null, hhNaming, 'HH_INaming should be null');
 
         assertError(Label.stgErrorInvalidClass, notification);
     }
@@ -95,7 +95,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
 
         HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
 
-        System.assertEquals(null, hhNaming);
+        System.assertEquals(null, hhNaming, 'HH_INaming should be null');
         
         assertError(Label.stgErrorINaming, notification);
     }
@@ -112,7 +112,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
 
         HH_NameSpec hhNaming = (HH_NameSpec) validator.validateImplementingClass(settings, notification);
 
-        System.assertNotEquals(null, hhNaming);
+        System.assertNotEquals(null, hhNaming, 'HH_INaming should be an HH_NameSpec instance');
 
         assertSuccess(notification);
     }
@@ -128,7 +128,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
 
         HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
 
-        System.assertNotEquals(null, hhNaming);
+        System.assertNotEquals(null, hhNaming, 'HH_INaming instance should be returned');
     
         assertSuccess(notification);
     }
@@ -239,7 +239,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
 
         notification = validator.validate(settings);
 
-        System.assert(!notification.isSuccess());
+        System.assert(!notification.isSuccess(), 'Notification should contain validation errors');
 
         String[] actualErrors = notification.getErrors();
 
@@ -261,47 +261,6 @@ private class HH_HouseholdNamingSettingValidator_TEST {
         assertSuccess(notification);
     }
 
-    /*********************************************************************************************************
-    @description
-        Test isValidApiName() when a field is valid case sensitive API Name for the Sobject
-    verify:
-        The method returns true
-    **********************************************************************************************************/ 
-    private static testMethod void isValidApiNameShouldReturnTrueWhenFieldNameIsValid() {
-        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = validator.getFieldResultsByName(Contact.SObjectType);
-
-        for (String fieldName : new String[] {
-            'Name', 'FirstName', 'LastName',
-            'AccountId', 'Account.Id', 'Account.Name', 
-            'Account.BillingCity', 'Account.npe01__One2OneContact__c',
-            'Account.npe01__One2OneContact__r.LastName',
-            'OwnerId', 'Owner.Name'
-        }) {
-            System.assert(validator.isValidApiName(fieldName, contactFieldResultsByName), 'Expected valid field result: ' + fieldName);
-        }
-    }
-
-    /*********************************************************************************************************
-    @description
-        Test isValidApiName() when a field name is invalid case sensitive API Name for the Sobject
-    verify:
-        The method returns false
-    **********************************************************************************************************/ 
-    private static testMethod void isValidApiNameShouldReturnFalseWhenFieldNameIsInvalid() {
-        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = validator.getFieldResultsByName(Contact.SObjectType);
-
-        for (String fieldName : new String[] {
-            null, '', ' ',
-            'firstname', 'Firstname', 'FirstName__c',
-            'foo', 'Account.foo', 
-            'Account.npe01__One2OneContact__r.foo',
-            'Account.npe01__One2OneContact__r.',
-            'Account.npe01__One2OneContact__c.foo',
-            'Owner.foo'
-        }) {
-            System.assert(!validator.isValidApiName(fieldName, contactFieldResultsByName), 'Expected invalid field result: ' + fieldName);
-        }
-    }
 
     // Helpers
     ////////////
@@ -359,7 +318,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     private static void assertSuccess(HH_HouseholdNamingSettingValidator.Notification n) {
         System.assert(n.isSuccess(), n.getErrors());
     
-        System.assert(n.getErrors().isEmpty(), n.getErrors());
+        System.assert(n.getErrors().isEmpty(), 'Notification should not contain any error: ' + n.getErrors());
     }
 
     /*********************************************************************************************************
@@ -383,13 +342,13 @@ private class HH_HouseholdNamingSettingValidator_TEST {
     
         String[] actualErrors = n.getErrors();
 
-        System.assertEquals(expectedErrors.size(), actualErrors.size(), actualErrors);
+        System.assertEquals(expectedErrors.size(), actualErrors.size(), 'Expected and actual errors size should be the same. Expected: ' + expectedErrors + '; Actual: ' + actualErrors);
 
         Set<String> expected = new Set<String>(expectedErrors);
         Set<String> actual = new Set<String>(actualErrors);
 
-        System.assertEquals(expected.size(), actual.size(), actual);
-        System.assert(expected.containsAll(actual), actual);
+        System.assertEquals(expected.size(), actual.size(), 'Expected and actual unique errors size should be the same. Expected: ' + expected + '; Actual: ' + actual);
+        System.assert(expected.containsAll(actual), 'Expected and actual errors should be the same. Expected: ' + expected + '; Actual: ' + actual);
     }
 
     /*********************************************************************************************************
@@ -408,7 +367,7 @@ private class HH_HouseholdNamingSettingValidator_TEST {
 
         String[] actualErrors = n.getErrors();
 
-        System.assertEquals(1, actualErrors.size(), actualErrors);
+        System.assertEquals(1, actualErrors.size(), 'Only one error should exist in: ' + actualErrors);
     
         for (String error : actualErrors) {
             if (error.contains(fieldLabel) && error.contains('Invalid field')) {
@@ -416,6 +375,6 @@ private class HH_HouseholdNamingSettingValidator_TEST {
             }
         }
 
-        System.assert(false, actualErrors);
+        System.assert(false, fieldName + ' should be in: ' + actualErrors);
     }
 }

--- a/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
@@ -1,40 +1,379 @@
+/*
+    Copyright (c) 2017 Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2017
+* @group Households
+* @description Unit tests for HH_HouseholdNamingSettingValidator class
+*/
 @isTest
 private class HH_HouseholdNamingSettingValidator_TEST {
+    /*********************************************************************************************************
+    * @description Constant containing invalid Household Name Format 
+    */
+    private static final String INVALID_HHNAME_FORMAT = 'The {!LastName}, {!{!FirstName}} {!npe01__WorkEmail__c}} Family';
+    /*********************************************************************************************************
+    * @description Constant containing invalid Formal Greeting Format 
+    */
+    private static final String INVALID_FORMAL_GREETING_FORMAT = '{!{!Title} {!FirstName}}}{!LastName}';
+    /*********************************************************************************************************
+    * @description Constant containing invalid Informal Greeting Format 
+    */
+    private static final String INVALID_INFORMAL_GREETING_FORMAT = '{!{!FirstName}}}';
+
+    /*********************************************************************************************************
+    * @description Notification used to store and verify errors (if any) reported during validation
+    */
+	private static HH_HouseholdNamingSettingValidator.Notification notification;
+    /*********************************************************************************************************
+    * @description Validator used to validate Household Naming Settings
+    */
+	private static HH_HouseholdNamingSettingValidator validator;
+
+
+    /*********************************************************************************************************
+    * @description Static method to initialize variables before each unit test
+    */
+	static {
+		validator = new HH_HouseholdNamingSettingValidator();
+		notification = new HH_HouseholdNamingSettingValidator.Notification();
+	}
 	
+    /*********************************************************************************************************
+    @description
+        Test validation of Implementing Class when specified class does not exist
+    verify:
+        The notification contains an error
+    **********************************************************************************************************/  
 	private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotExist() {
+		Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Implementing_Class__c = 'foo'; 
+
+		HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
+
+        System.assertEquals(null, hhNaming);
+
+        assertError(Label.stgErrorInvalidClass, notification);
 	}
 	
+    /*********************************************************************************************************
+    @description
+        Test validation of Implementing Class when specified class does not implement INaming interface
+    verify:
+        The notification contains an error
+    **********************************************************************************************************/  
 	private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotImplementINamingInterface() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Implementing_Class__c = 'HH_HouseholdNaming'; 
+
+		HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
+
+        System.assertEquals(null, hhNaming);
+        
+        assertError(Label.stgErrorINaming, notification);
 	}
 
-	private static testMethod void validateImplementingClassShouldNotAddErrorWhenInstanceCanBeCreated() {
+    /*********************************************************************************************************
+    @description
+        Test validation of Implementing Class when it is empty
+    verify:
+        The notification does not contain any error. Returned object is a HH_NameSpec instance.
+    **********************************************************************************************************/  
+	private static testMethod void validateImplementingClassShouldNotAddErrorWhenClassIsNotSpecified() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Implementing_Class__c = null; 
+
+		HH_NameSpec hhNaming = (HH_NameSpec) validator.validateImplementingClass(settings, notification);
+
+        System.assertNotEquals(null, hhNaming);
+
+        assertSuccess(notification);
 	}
 
-	private static testMethod void validateFormatShouldNotAddErrorWhenAFormatFieldIsNull() {
+    /*********************************************************************************************************
+    @description
+        Test validation of Implementing Class when specified class implements INaming interface
+    verify:
+        The notification does not contain any error
+    **********************************************************************************************************/  
+	private static testMethod void validateImplementingClassShouldNotAddErrorWhenClassImplementsINamingInterface() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings(); 
+
+        HH_INaming hhNaming = validator.validateImplementingClass(settings, notification);
+
+        System.assertNotEquals(null, hhNaming);
+		
+        assertSuccess(notification);
 	}
 
-	private static testMethod void validateFormatShouldAddErrorWhenHHNameFormatIsInvalid() {
+    /*********************************************************************************************************
+    @description
+        Test validation of Household Name Format field when the value is invalid
+    verify:
+        The notification contains an error
+    **********************************************************************************************************/  
+	private static testMethod void validateShouldAddErrorWhenHHNameFormatIsInvalid() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Household_Name_Format__c = INVALID_HHNAME_FORMAT; 
+
+		notification = validator.validate(settings);
+
+        assertErrorContainsInvalidFieldMessage('Household_Name_Format__c', notification);
 	}
 
-	private static testMethod void validateFormatShouldAddErrorWhenFormalGreetingFormatIsInvalid() {
+    /*********************************************************************************************************
+    @description
+        Test validation of Formal Greeting Format field when the value is invalid
+    verify:
+        The notification contains an error
+    **********************************************************************************************************/ 
+	private static testMethod void validateShouldAddErrorWhenFormalGreetingFormatIsInvalid() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Formal_Greeting_Format__c = INVALID_FORMAL_GREETING_FORMAT; 
+
+		notification = validator.validate(settings);
+
+        assertErrorContainsInvalidFieldMessage('Formal_Greeting_Format__c', notification);
 	}
 
-	private static testMethod void validateFormatShouldAddErrorWhenInformalGreetingFormatIsInvalid() {
+    /*********************************************************************************************************
+    @description
+        Test validation of Informal Greeting Format field when the value is invalid
+    verify:
+        The notification contains an error
+    **********************************************************************************************************/ 
+	private static testMethod void validateShouldAddErrorWhenInformalGreetingFormatIsInvalid() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Informal_Greeting_Format__c = INVALID_INFORMAL_GREETING_FORMAT; 
+
+		notification = validator.validate(settings);
+
+        assertErrorContainsInvalidFieldMessage('Informal_Greeting_Format__c', notification);
 	}
 
-	private static testMethod void validateFormatShouldAddErrorWhenContactFieldsApiNameIsInvalid() {
+    /*********************************************************************************************************
+    @description
+        Test validation of API Names for Contact fields specified in all format fields. 
+    verify:
+        The notification contains an error for each field that is not correct case-sensitive API Name
+    **********************************************************************************************************/ 
+	private static testMethod void validateShouldAddErrorWhenContactFieldsApiNameIsInvalid() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Household_Name_Format__c = 'The {!lastname}, {!{!FirstName} {!npe01__workemail__c}} Family'; 
+
+		notification = validator.validate(settings);
+
+        String[] expectedErrors = new String[] {
+            String.format(Label.stgErrorInvalidApiName, new String[]{ 'lastname' }),
+            String.format(Label.stgErrorInvalidApiName, new String[]{ 'npe01__workemail__c' })
+        };
+        assertErrors(expectedErrors, notification); 
 	}
 
-	private static testMethod void validateFormatShouldNotAddErrorWhenHHSettingsFieldsAreValid() {
+    /*********************************************************************************************************
+    @description
+        Test validation when a format field is empty
+    verify:
+        The notification does not contain any error
+    **********************************************************************************************************/ 
+	private static testMethod void validateShouldNotAddErrorWhenAFormatFieldIsNull() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Household_Name_Format__c = null;
+
+		notification = validator.validate(settings);
+		
+        assertSuccess(notification);
 	}
 
-	private static testMethod void validateShouldAddUniqueErrorsWhenImplementingClassIsInvalid() {
+    /*********************************************************************************************************
+    @description
+        Test validation when Implementing Class cannot be instantiated. Ensure no exception is raised when 
+        format fields, expecting the Implementing Class instance, are validated.
+    verify:
+        The notification contains an error
+    **********************************************************************************************************/ 
+	private static testMethod void validateShouldAddInvalidClassErrorWhenClassAndFormatFieldsAreInvalid() {
+        Household_Naming_Settings__c settings = setupInvalidHHNamingSettings(); 
+        settings.Implementing_Class__c = 'foo';
+
+		notification = validator.validate(settings);
+
+        assertError(Label.stgErrorInvalidClass, notification);
 	}
 
-	private static testMethod void validateShouldAddUniqueErrorsWhenAllHHSettingsFieldsAreInvalid() {
+    /*********************************************************************************************************
+    @description
+        Test validation when all Household Naming Settings format fields are invalid
+    verify:
+        The notification contains errors for all format fields
+    **********************************************************************************************************/ 
+	private static testMethod void validateShouldAddErrorsWhenAllThreeFormatFieldsAreInvalid() {
+        Household_Naming_Settings__c settings = setupInvalidHHNamingSettings();
+
+		notification = validator.validate(settings);
+
+        System.assert(!notification.isSuccess());
+
+		String[] actualErrors = notification.getErrors();
+
+        System.assertEquals(3, actualErrors.size(), actualErrors);
+        System.assertEquals(3, new Set<String>(actualErrors).size());
 	}
 
+    /*********************************************************************************************************
+    @description
+        Test validation when all fields are valid
+    verify:
+        The notification does not contain any error
+    **********************************************************************************************************/ 
 	private static testMethod void validateShouldNotAddErrorWhenAllHHSettingsFieldsAreValid() {
+        Household_Naming_Settings__c settings = setupHHNamingSettings(); 
+
+		notification = validator.validate(settings);
+        
+        assertSuccess(notification);
 	}
-	
+
+	// Helpers
+	////////////
+
+	/*********************************************************************************************************
+    * @description Configures Household Naming Settings with invalid Name and Greetings formats
+    * @return Household_Naming_Settings__c Household Naming Settings
+    **********************************************************************************************************/
+    private static Household_Naming_Settings__c setupInvalidHHNamingSettings() {
+        return setupHHNamingSettings(
+            INVALID_HHNAME_FORMAT,
+            INVALID_FORMAL_GREETING_FORMAT,
+            INVALID_INFORMAL_GREETING_FORMAT
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with valid Name and Greetings formats
+    * @return Household_Naming_Settings__c Household Naming Settings
+    **********************************************************************************************************/
+    private static Household_Naming_Settings__c setupHHNamingSettings() {
+        return setupHHNamingSettings(            
+			'The {!LastName}, {!{!FirstName} {!npe01__WorkEmail__c}} Family',
+            '{!{!Title} {!FirstName}}{!LastName}',
+            '{!{!FirstName}}'
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings 
+    * @param hhNameFormat Household Name Format
+    * @param formalGreetingFormat Formal Greeting Format
+    * @param informalGreetingFormat Informal Greeting Format
+    * @return Household_Naming_Settings__c Household Naming Settings
+    **********************************************************************************************************/
+    private static Household_Naming_Settings__c setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
+        return UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = hhNameFormat,
+                Formal_Greeting_Format__c = formalGreetingFormat,
+                Informal_Greeting_Format__c = informalGreetingFormat,
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Asserts the notification does not contain any error
+    * @param n Notification
+    * @return void
+    **********************************************************************************************************/
+    private static void assertSuccess(HH_HouseholdNamingSettingValidator.Notification n) {
+        System.assert(n.isSuccess(), n.getErrors());
+		
+		System.assert(n.getErrors().isEmpty(), n.getErrors());
+    }
+
+    /*********************************************************************************************************
+    * @description Asserts the notification contains expected error only
+    * @param expectedError Expected error
+    * @param n Notification
+    * @return void
+    **********************************************************************************************************/
+    private static void assertError(String expectedError, HH_HouseholdNamingSettingValidator.Notification n) {
+        assertErrors(new String[]{ expectedError }, n);
+    }
+
+    /*********************************************************************************************************
+    * @description Asserts the notification contains expected errors 
+    * @param expectedErrors List of expected errors
+    * @param n Notification
+    * @return void
+    **********************************************************************************************************/
+    private static void assertErrors(String[] expectedErrors, HH_HouseholdNamingSettingValidator.Notification n) {
+        System.assert(!n.isSuccess());
+		
+		String[] actualErrors = n.getErrors();
+
+		System.assertEquals(expectedErrors.size(), actualErrors.size(), actualErrors);
+
+        Set<String> expected = new Set<String>(expectedErrors);
+        Set<String> actual = new Set<String>(actualErrors);
+
+		System.assertEquals(expected.size(), actual.size(), actual);
+		System.assert(expected.containsAll(actual), actual);
+    }
+
+    /*********************************************************************************************************
+    * @description Asserts the notification contains an "Invalid field" error message for the specified field  
+    * @param fieldName Household Naming Settings field name
+    * @param n Notification
+    * @return void
+    **********************************************************************************************************/
+    private static void assertErrorContainsInvalidFieldMessage(String fieldName, HH_HouseholdNamingSettingValidator.Notification n) {
+        String fieldLabel = UTIL_Describe.getFieldLabel(
+            UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
+            UTIL_Namespace.StrTokenNSPrefix(fieldName)
+        );
+
+        System.assert(!n.isSuccess());
+
+		String[] actualErrors = n.getErrors();
+
+        System.assertEquals(1, actualErrors.size(), actualErrors);
+		
+        for (String error : actualErrors) {
+            if (error.contains(fieldLabel) && error.contains('Invalid field')) {
+                return;
+            }
+        }
+
+        System.assert(false, actualErrors);
+    }
 }

--- a/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
@@ -1,0 +1,40 @@
+@isTest
+private class HH_HouseholdNamingSettingValidator_TEST {
+	
+	private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotExist() {
+	}
+	
+	private static testMethod void validateImplementingClassShouldAddErrorWhenClassDoesNotImplementINamingInterface() {
+	}
+
+	private static testMethod void validateImplementingClassShouldNotAddErrorWhenInstanceCanBeCreated() {
+	}
+
+	private static testMethod void validateFormatShouldNotAddErrorWhenAFormatFieldIsNull() {
+	}
+
+	private static testMethod void validateFormatShouldAddErrorWhenHHNameFormatIsInvalid() {
+	}
+
+	private static testMethod void validateFormatShouldAddErrorWhenFormalGreetingFormatIsInvalid() {
+	}
+
+	private static testMethod void validateFormatShouldAddErrorWhenInformalGreetingFormatIsInvalid() {
+	}
+
+	private static testMethod void validateFormatShouldAddErrorWhenContactFieldsApiNameIsInvalid() {
+	}
+
+	private static testMethod void validateFormatShouldNotAddErrorWhenHHSettingsFieldsAreValid() {
+	}
+
+	private static testMethod void validateShouldAddUniqueErrorsWhenImplementingClassIsInvalid() {
+	}
+
+	private static testMethod void validateShouldAddUniqueErrorsWhenAllHHSettingsFieldsAreInvalid() {
+	}
+
+	private static testMethod void validateShouldNotAddErrorWhenAllHHSettingsFieldsAreValid() {
+	}
+	
+}

--- a/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
+++ b/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls
@@ -261,6 +261,48 @@ private class HH_HouseholdNamingSettingValidator_TEST {
         assertSuccess(notification);
     }
 
+    /*********************************************************************************************************
+    @description
+        Test isValidApiName() when a field is valid case sensitive API Name for the Sobject
+    verify:
+        The method returns true
+    **********************************************************************************************************/ 
+    private static testMethod void isValidApiNameShouldReturnTrueWhenFieldNameIsValid() {
+        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = validator.getFieldResultsByName(Contact.SObjectType);
+
+        for (String fieldName : new String[] {
+            'Name', 'FirstName', 'LastName',
+            'AccountId', 'Account.Id', 'Account.Name', 
+            'Account.BillingCity', 'Account.npe01__One2OneContact__c',
+            'Account.npe01__One2OneContact__r.LastName',
+            'OwnerId', 'Owner.Name'
+        }) {
+            System.assert(validator.isValidApiName(fieldName, contactFieldResultsByName), 'Expected valid field result: ' + fieldName);
+        }
+    }
+
+    /*********************************************************************************************************
+    @description
+        Test isValidApiName() when a field name is invalid case sensitive API Name for the Sobject
+    verify:
+        The method returns false
+    **********************************************************************************************************/ 
+    private static testMethod void isValidApiNameShouldReturnFalseWhenFieldNameIsInvalid() {
+        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = validator.getFieldResultsByName(Contact.SObjectType);
+
+        for (String fieldName : new String[] {
+            null, '', ' ',
+            'firstname', 'Firstname', 'FirstName__c',
+            'foo', 'Account.foo', 
+            'Account.npe01__One2OneContact__r.foo',
+            'Account.npe01__One2OneContact__r.',
+            'Account.npe01__One2OneContact__c.foo',
+            'Owner.foo'
+        }) {
+            System.assert(!validator.isValidApiName(fieldName, contactFieldResultsByName), 'Expected invalid field result: ' + fieldName);
+        }
+    }
+
     // Helpers
     ////////////
 

--- a/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls-meta.xml
+++ b/src/classes/HH_HouseholdNamingSettingValidator_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/HH_HouseholdNaming_TEST.cls
+++ b/src/classes/HH_HouseholdNaming_TEST.cls
@@ -431,19 +431,21 @@ public class HH_HouseholdNaming_TEST {
 
         String soql = new HH_HouseholdNaming().strContactSelectStmtAllNamingFields;
 
-        System.assert(soql.contains('Id'), soql);
-        System.assert(soql.contains('HHId__c'), soql);
-        System.assert(soql.contains('npo02__Naming_Exclusions__c'), soql);
-
-        //verify HH Naming settings fields are included
-        System.assert(soql.contains('LastName'), soql);
-        System.assert(soql.contains('FirstName'), soql);
-        System.assert(soql.contains('Salutation'), soql);
-        System.assert(soql.contains('npe01__WorkEmail__c'), soql);
+        for (String fieldName : new String[] { 
+            'Id', 'HHId__c', 'npo02__Naming_Exclusions__c', // mandatory fields
+            'LastName', 'FirstName', 'Salutation', 'npe01__WorkEmail__c' //HH Naming fields
+        }) {
+            System.assert(soql.contains(fieldName), fieldName + ' should be in the SOQL: ' + soql);
+        }
         
         //verify the soql is valid and will not raise exceptions
-        System.assert(!soql.contains('}'), soql);
-        List<Contact> contacts = Database.Query(soql);
+        System.assert(!soql.contains('}'), 'SOQL should be correct: ' + soql);
+        
+        try {
+            List<Contact> contacts = Database.Query(soql);
+        } catch (Exception e) {
+            System.assert(false, 'Unexpected error raised for SOQL: ' + soql);
+        }
     }
 
     /*********************************************************************************************************
@@ -460,19 +462,26 @@ public class HH_HouseholdNaming_TEST {
 
         String soql = new HH_HouseholdNaming().strContactSelectStmtAllNamingFields;
 
-        System.assert(soql.contains('Id'), soql);
-        System.assert(soql.contains('HHId__c'), soql);
-        System.assert(soql.contains('npo02__Naming_Exclusions__c'), soql);
+        for (String fieldName : new String[] { 
+            'Id', 'HHId__c', 'npo02__Naming_Exclusions__c' // mandatory fields
+        }) {
+            System.assert(soql.contains(fieldName), fieldName + ' should be in the SOQL: ' + soql);
+        }
 
-        //verify HH Naming settings fields are not included
-        System.assert(!soql.contains('LastName'), soql);
-        System.assert(!soql.contains('FirstName'), soql);
-        System.assert(!soql.contains('Salutation'), soql);
-        System.assert(!soql.contains('npe01__WorkEmail__c'), soql);
+        for (String fieldName : new String[] { 
+            'LastName', 'FirstName', 'Salutation', 'npe01__WorkEmail__c' //HH Naming fields
+        }) {
+            System.assert(!soql.contains(fieldName), fieldName + ' should not be in the SOQL: ' + soql);
+        }
         
         //verify the soql is valid and will not raise exceptions
-        System.assert(!soql.contains('}'), soql);
-        List<Contact> contacts = Database.Query(soql);
+        System.assert(!soql.contains('}'), 'SOQL should be correct: ' + soql);
+
+        try {
+            List<Contact> contacts = Database.Query(soql);
+        } catch (Exception e) {
+            System.assert(false, 'Unexpected error raised for SOQL: ' + soql);
+        }
     }
 
     /*********************************************************************************************************
@@ -488,7 +497,7 @@ public class HH_HouseholdNaming_TEST {
 
         Set<String> fieldNames = new HH_HouseholdNaming().getHouseholdNamingContactFields();
 
-        System.assert(fieldNames.isEmpty(), fieldNames);
+        System.assert(fieldNames.isEmpty(), 'No field name should be returned: ' + fieldNames);
     }
     
     /*********************************************************************************************************
@@ -506,10 +515,11 @@ public class HH_HouseholdNaming_TEST {
 
         System.assertEquals(4, fieldNames.size(), fieldNames);  
         
-        System.assert(fieldNames.contains('LastName'), fieldNames);
-        System.assert(fieldNames.contains('FirstName'), fieldNames);
-        System.assert(fieldNames.contains('Salutation'), fieldNames);
-        System.assert(fieldNames.contains('npe01__WorkEmail__c'), fieldNames);     
+        for (String fieldName : new String[] {
+            'LastName', 'FirstName', 'Salutation', 'npe01__WorkEmail__c' //HH Naming fields
+        }) {
+            System.assert(fieldNames.contains(fieldName), fieldName + ' should be in: ' + fieldNames);
+        }    
     }
 
     /*********************************************************************************************************
@@ -521,7 +531,7 @@ public class HH_HouseholdNaming_TEST {
     private static testMethod void isAutomaticNamingShouldReturnFalseWhenAutomaticHouseholdNamingIsTurnedOff() {
         turnOffAutomaticHHNaming();
 
-        System.assert(!new HH_HouseholdNaming().isAutomaticNaming());
+        System.assert(!new HH_HouseholdNaming().isAutomaticNaming(), 'Automatic Household Naming should be turned off');
     }
 
     /*********************************************************************************************************
@@ -533,7 +543,7 @@ public class HH_HouseholdNaming_TEST {
     private static testMethod void isAutomaticNamingShouldReturnTrueWhenAutomaticHouseholdNamingIsTurnedOn() {
         turnOnAutomaticHHNaming();
 
-        System.assert(new HH_HouseholdNaming().isAutomaticNaming());
+        System.assert(new HH_HouseholdNaming().isAutomaticNaming(), 'Automatic Household Naming should be turned on');
     }
 
     // Helpers

--- a/src/classes/HH_HouseholdNaming_TEST.cls
+++ b/src/classes/HH_HouseholdNaming_TEST.cls
@@ -475,6 +475,67 @@ public class HH_HouseholdNaming_TEST {
         List<Contact> contacts = Database.Query(soql);
     }
 
+    /*********************************************************************************************************
+    @description
+        Test getHouseholdNamingContactFields() method when Household Naming Settings is invalid
+        and the Automatic Household Naming is turned off
+    verify:
+        Returned set is empty.
+    **********************************************************************************************************/  
+    private static testMethod void getHouseholdNamingContactFieldsShouldReturnEmptySetWhenAutomaticHouseholdNamingIsTurnedOff() {
+        turnOffAutomaticHHNaming();
+        setupInvalidHHNamingSettings();
+
+        Set<String> fieldNames = new HH_HouseholdNaming().getHouseholdNamingContactFields();
+
+        System.assert(fieldNames.isEmpty(), fieldNames);
+    }
+    
+    /*********************************************************************************************************
+    @description
+        Test getHouseholdNamingContactFields() method when Household Naming Settings is valid
+        and the Automatic Household Naming is turned on
+    verify:
+        Returned set contains Contact field names specified in the Household Naming Settings.
+    **********************************************************************************************************/  
+    private static testMethod void getHouseholdNamingContactFieldsShouldReturnContactFieldNamesWhenAutomaticHouseholdNamingIsTurnedOn() {
+        turnOnAutomaticHHNaming();
+        setupHHNamingSettings();
+
+        Set<String> fieldNames = new HH_HouseholdNaming().getHouseholdNamingContactFields();
+
+        System.assertEquals(4, fieldNames.size(), fieldNames);  
+        
+        System.assert(fieldNames.contains('LastName'), fieldNames);
+        System.assert(fieldNames.contains('FirstName'), fieldNames);
+        System.assert(fieldNames.contains('Salutation'), fieldNames);
+        System.assert(fieldNames.contains('npe01__WorkEmail__c'), fieldNames);     
+    }
+
+    /*********************************************************************************************************
+    @description
+        Test isAutomaticNaming() method when the Automatic Household Naming is turned off
+    verify:
+        The method returns false.
+    **********************************************************************************************************/  
+    private static testMethod void isAutomaticNamingShouldReturnFalseWhenAutomaticHouseholdNamingIsTurnedOff() {
+        turnOffAutomaticHHNaming();
+
+        System.assert(!new HH_HouseholdNaming().isAutomaticNaming());
+    }
+
+    /*********************************************************************************************************
+    @description
+        Test isAutomaticNaming() method when the Automatic Household Naming is turned on
+    verify:
+        The method returns true.
+    **********************************************************************************************************/  
+    private static testMethod void isAutomaticNamingShouldReturnTrueWhenAutomaticHouseholdNamingIsTurnedOn() {
+        turnOnAutomaticHHNaming();
+
+        System.assert(new HH_HouseholdNaming().isAutomaticNaming());
+    }
+
     // Helpers
     ////////////
     

--- a/src/classes/HH_HouseholdNaming_TEST.cls
+++ b/src/classes/HH_HouseholdNaming_TEST.cls
@@ -230,46 +230,9 @@ public class HH_HouseholdNaming_TEST {
         //update our newly updated contact's households
         HH_HouseholdNaming hn = new HH_HouseholdNaming();
         test.startTest();
-        hn.UpdateNames(newhhids);
+        hn.UpdateNames(newhhids);        
         
-        //take teh list of contacts in each of the households in newhhids, and run them
-        //back through the public string calls to test them - this never quite worked -
-        // i think something about how HHs are created, with the contact re-update is causing
-        //an issue in testing
-       /* 
-        map<id, npo02__Household__c> hhmap = new map<id, npo02__Household__c>([select npo02__SYSTEM_CUSTOM_NAMING__c, Name, npo02__Informal_greeting__c, npo02__Formal_greeting__c from npo02__Household__c where id IN :newhhids]);
-        
-        list<Contact> lc = new list<contact>([select npo02__household__r.id, 
-        npo02__household__r.name, npo02__household__r.npo02__Informal_Greeting__c, FirstName, Salutation, LastName, 
-        npo02__Naming_Exclusions__c, npo02__household__r.npo02__SYSTEM_CUSTOM_NAMING__c,
-        npo02__household__r.npo02__Formal_Greeting__c from Contact where npo02__household__r.id IN :newhhids]);
-        
-        map<id,list <Contact>> hhidContactMap = new map<id, list <Contact>>();
-        for (Contact c : lc){
-            if(!hhIDContactMap.containskey(c.npo02__household__r.id)){
-                hhIDContactMap.put(c.npo02__household__r.id, new list<Contact>{c});
-            }
-            else{
-                list<Contact> conlist = hhIDContactMap.get(c.npo02__household__r.id);
-                conlist.add(c);                
-            }
-        }
-        
-        //for each one, run its contact through the  test methods
-        //and compare it with the household values from teh first contact
-        //record              
-        for (id HHID : hhidContactMap.keySet()){
-            if (hhidcontactmap.get(hhid)[0].npo02__household__r.npo02__SYSTEM_CUSTOM_NAMING__c != null){
-                system.assert(!hhidcontactmap.get(hhid)[0].npo02__household__r.npo02__SYSTEM_CUSTOM_NAMING__c.contains('Name'));
-                system.assert(!hhidcontactmap.get(hhid)[0].npo02__household__r.npo02__SYSTEM_CUSTOM_NAMING__c.contains('npo02__Informal_Greeting__c'));
-                system.assert(!hhidcontactmap.get(hhid)[0].npo02__household__r.npo02__SYSTEM_CUSTOM_NAMING__c.contains('npo02__Formal_Greeting__c'));
-            } 
-            system.assertEquals(hhMap.get(hhid).Name, hn.getHHName(hhidcontactmap.get(hhid)));
-            system.assertEquals(hhidcontactmap.get(hhid)[0].npo02__household__r.npo02__Informal_Greeting__c, hn.getInformalName(hhidcontactmap.get(hhid)));
-            system.assertEquals(hhidcontactmap.get(hhid)[0].npo02__household__r.npo02__Formal_Greeting__c, hn.getFormalName(hhidcontactmap.get(hhid)));
-        }       
-        */
-    test.stopTest();        
+        test.stopTest();        
     }
     
     /*********************************************************************************************************
@@ -454,7 +417,6 @@ public class HH_HouseholdNaming_TEST {
   
     }
 
-
     /*********************************************************************************************************
     @description
         Test strContactSelectStmtAllNamingFields property when Household Naming Settings is valid
@@ -465,18 +427,7 @@ public class HH_HouseholdNaming_TEST {
     **********************************************************************************************************/  
     private static testMethod void contactSoqlShouldContainHHNamingFieldsWhenAutomaticHouseholdNamingIsTurnedOn() {
         turnOnAutomaticHHNaming();
-
-        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
-            new Household_Naming_Settings__c(
-                Household_Name_Format__c = 'The {!LastName}, {!{!FirstName} {!npe01__WorkEmail__c}} Family',
-                Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}} {!LastName}',
-                Informal_Greeting_Format__c = '{!{!FirstName}}',
-                Name_Connector__c = label.npo02.HouseholdNameConnector,
-                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
-                Contact_Overrun_Count__c = 9,
-                Implementing_Class__c = 'HH_NameSpec'
-            )
-        );
+        setupHHNamingSettings();
 
         String soql = new HH_HouseholdNaming().strContactSelectStmtAllNamingFields;
 
@@ -505,19 +456,7 @@ public class HH_HouseholdNaming_TEST {
     **********************************************************************************************************/  
     private static testMethod void contactSoqlShouldNotContainHHNamingFieldsWhenAutomaticHouseholdNamingIsTurnedOff() {
         turnOffAutomaticHHNaming();
-
-        //specify invalid name and greetings' formats
-        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
-            new Household_Naming_Settings__c(
-                Household_Name_Format__c = 'The {!LastName}, {!{!FirstName}}} {!npe01__WorkEmail__c}} Family',
-                Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}}} {!LastName}',
-                Informal_Greeting_Format__c = '{!{!FirstName}}}',
-                Name_Connector__c = label.npo02.HouseholdNameConnector,
-                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
-                Contact_Overrun_Count__c = 9,
-                Implementing_Class__c = 'HH_NameSpec'
-            )
-        );
+        setupInvalidHHNamingSettings();
 
         String soql = new HH_HouseholdNaming().strContactSelectStmtAllNamingFields;
 
@@ -565,6 +504,50 @@ public class HH_HouseholdNaming_TEST {
             new npo02__Households_Settings__c (
                 npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
                 npo02__Advanced_Household_Naming__c = isOn
+            )
+        );
+    }
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with invalid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupInvalidHHNamingSettings() {
+        setupHHNamingSettings(
+            'The {!LastName}, {!{!FirstName}}} {!npe01__WorkEmail__c}} Family',
+            '{!{!Salutation} {!FirstName}}} {!LastName}',
+            '{!{!FirstName}}}'
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with valid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings() {
+        setupHHNamingSettings(
+            'The {!LastName}, {!{!FirstName} {!npe01__WorkEmail__c}} Family',
+            '{!{!Salutation} {!FirstName}} {!LastName}',
+            '{!{!FirstName}}'
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings 
+    * @param hhNameFormat Household Naming Format
+    * @param formalGreetingFormat Formal Greeting Format
+    * @param informalGreetingFormat Informal Greeting Format
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = hhNameFormat,
+                Formal_Greeting_Format__c = formalGreetingFormat,
+                Informal_Greeting_Format__c = informalGreetingFormat,
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
             )
         );
     }

--- a/src/classes/HH_HouseholdNaming_TEST.cls
+++ b/src/classes/HH_HouseholdNaming_TEST.cls
@@ -423,7 +423,7 @@ public class HH_HouseholdNaming_TEST {
         and the Automatic Household Naming is turned on 
     verify:
         Household Naming Settings fields are included in the SOQL.
-        No error is raised whent the SOQL is executed.
+        No error is raised when the SOQL is executed.
     **********************************************************************************************************/  
     private static testMethod void contactSoqlShouldContainHHNamingFieldsWhenAutomaticHouseholdNamingIsTurnedOn() {
         turnOnAutomaticHHNaming();
@@ -452,7 +452,7 @@ public class HH_HouseholdNaming_TEST {
         and the Automatic Household Naming is turned off
     verify:
         Household Naming Settings fields are not included in the SOQL.
-        No error is raised whent the SOQL is executed.
+        No error is raised when the SOQL is executed.
     **********************************************************************************************************/  
     private static testMethod void contactSoqlShouldNotContainHHNamingFieldsWhenAutomaticHouseholdNamingIsTurnedOff() {
         turnOffAutomaticHHNaming();

--- a/src/classes/HH_HouseholdNaming_TEST.cls
+++ b/src/classes/HH_HouseholdNaming_TEST.cls
@@ -453,4 +453,119 @@ public class HH_HouseholdNaming_TEST {
         system.assertEquals('c1, c0 and c2', hh.npo02__Informal_greeting__c);
   
     }
+
+
+    /*********************************************************************************************************
+    @description
+        Test strContactSelectStmtAllNamingFields property when Household Naming Settings is valid
+        and the Automatic Household Naming is turned on 
+    verify:
+        Household Naming Settings fields are included in the SOQL.
+        No error is raised whent the SOQL is executed.
+    **********************************************************************************************************/  
+    private static testMethod void contactSoqlShouldContainHHNamingFieldsWhenAutomaticHouseholdNamingIsTurnedOn() {
+        turnOnAutomaticHHNaming();
+
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = 'The {!LastName}, {!{!FirstName} {!npe01__WorkEmail__c}} Family',
+                Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}} {!LastName}',
+                Informal_Greeting_Format__c = '{!{!FirstName}}',
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
+
+        String soql = new HH_HouseholdNaming().strContactSelectStmtAllNamingFields;
+
+        System.assert(soql.contains('Id'), soql);
+        System.assert(soql.contains('HHId__c'), soql);
+        System.assert(soql.contains('npo02__Naming_Exclusions__c'), soql);
+
+        //verify HH Naming settings fields are included
+        System.assert(soql.contains('LastName'), soql);
+        System.assert(soql.contains('FirstName'), soql);
+        System.assert(soql.contains('Salutation'), soql);
+        System.assert(soql.contains('npe01__WorkEmail__c'), soql);
+        
+        //verify the soql is valid and will not raise exceptions
+        System.assert(!soql.contains('}'), soql);
+        List<Contact> contacts = Database.Query(soql);
+    }
+
+    /*********************************************************************************************************
+    @description
+        Test strContactSelectStmtAllNamingFields property when Household Naming Settings is invalid
+        and the Automatic Household Naming is turned off
+    verify:
+        Household Naming Settings fields are not included in the SOQL.
+        No error is raised whent the SOQL is executed.
+    **********************************************************************************************************/  
+    private static testMethod void contactSoqlShouldNotContainHHNamingFieldsWhenAutomaticHouseholdNamingIsTurnedOff() {
+        turnOffAutomaticHHNaming();
+
+        //specify invalid name and greetings' formats
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = 'The {!LastName}, {!{!FirstName}}} {!npe01__WorkEmail__c}} Family',
+                Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}}} {!LastName}',
+                Informal_Greeting_Format__c = '{!{!FirstName}}}',
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
+
+        String soql = new HH_HouseholdNaming().strContactSelectStmtAllNamingFields;
+
+        System.assert(soql.contains('Id'), soql);
+        System.assert(soql.contains('HHId__c'), soql);
+        System.assert(soql.contains('npo02__Naming_Exclusions__c'), soql);
+
+        //verify HH Naming settings fields are not included
+        System.assert(!soql.contains('LastName'), soql);
+        System.assert(!soql.contains('FirstName'), soql);
+        System.assert(!soql.contains('Salutation'), soql);
+        System.assert(!soql.contains('npe01__WorkEmail__c'), soql);
+        
+        //verify the soql is valid and will not raise exceptions
+        System.assert(!soql.contains('}'), soql);
+        List<Contact> contacts = Database.Query(soql);
+    }
+
+    // Helpers
+    ////////////
+    
+    /*********************************************************************************************************
+    * @description Turns on Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOnAutomaticHHNaming() {
+        setupAutomaticHHNaming(true);
+    }
+
+    /*********************************************************************************************************
+    * @description Turns off Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOffAutomaticHHNaming() {
+        setupAutomaticHHNaming(false);
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Settings' Automatic Household Naming field
+    * @param isOn Automatic Household Naming is turned on when parameter is true, otherwise, the settings is turned off
+    * @return void
+    **********************************************************************************************************/
+    private static void setupAutomaticHHNaming(Boolean isOn) {
+        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
+            new npo02__Households_Settings__c (
+                npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
+                npo02__Advanced_Household_Naming__c = isOn
+            )
+        );
+    }
 }

--- a/src/classes/HH_Households_TDTM.cls
+++ b/src/classes/HH_Households_TDTM.cls
@@ -175,7 +175,7 @@ public without sharing class HH_Households_TDTM extends TDTM_Runnable {
                     
                     if (c.npo02__household__c != null) {
                         if (hhNamingFields == null)
-                            hhNamingFields = HH_HouseholdNaming.iNaming.setHouseholdNameFieldsOnContact();
+                            hhNamingFields = new HH_HouseholdNaming().getHouseholdNamingContactFields();
                             
                         for (String fieldName : hhNamingFields) {
                             // make sure to use case sensitive comparison

--- a/src/classes/HH_Households_TEST.cls
+++ b/src/classes/HH_Households_TEST.cls
@@ -150,7 +150,36 @@ public with sharing class HH_Households_TEST {
 
         Contact[] updatedContacts = [select npo02__household__r.npo02__Formal_Greeting__c  from Contact where id=:con.id];
         system.assertEquals('Handy Man '+CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,updatedContacts[0].npo02__household__r.npo02__Formal_Greeting__c  );
-    }    
+    } 
+
+    /*********************************************************************************************************
+    @description
+        Test Contact insert and update when Household Naming Settings is invalid
+        and the Automatic Household Naming is turned off 
+    verify:
+        The Contact is created and updated successfully
+    **********************************************************************************************************/  
+    static testMethod void contactDmlShouldSucceedWhenHHNamingSettingsIsInvalidAndAutomaticHouseholdNamingIsTurnedOff() {  
+        setupContactSettingsOneToOneProcessor();         
+        turnOffAutomaticHHNamingForAllHouseholdProcessor();
+        setupInvalidHHNamingSettings();
+        
+        Contact contact = new Contact(FirstName = 'John', LastName = 'Smith');
+        insert contact;
+  
+        npo02__Household__c hh = getHouseholdForContact(contact.id);
+    
+        System.assertEquals('Smith ' + system.label.npo02.DefaultHouseholdName, hh.Name);
+        System.assertEquals(null, hh.npo02__Formal_Greeting__c);
+        System.assertEquals(null, hh.npo02__Informal_Greeting__c);
+
+        contact.LastName = 'Smith Jones';
+        Test.startTest();
+        update contact;
+        Test.stopTest();
+
+        System.assertEquals('Smith Jones', [SELECT LastName FROM Contact WHERE Id = :contact.Id][0].LastName);
+    }  
     
     /*********************************************************************************************************
     * @description Tests insert private individual with all contacts processor
@@ -427,7 +456,6 @@ public with sharing class HH_Households_TEST {
         
         npo02__Households_Settings__c householdSettingsForTests = UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(new npo02__Households_Settings__c (npo02__Household_Rules__c = HH_Households.ALL_INDIVIDUALS_PROCESSOR));
         
-        String lastname = 'SmithForTest99';
         Contact con = new Contact(
             FirstName=CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
             LastName=CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,
@@ -487,121 +515,6 @@ public with sharing class HH_Households_TEST {
         system.assert(remainingHousehold.size()==1);
         system.assertEquals(1, remainingHousehold[0].Number_Of_Household_Members__c);
     }
-
-/************************************ Not Used ***************************************
-    /*********************************************************************************************************
-    * @description 
-
-    static testMethod void getHouseholdTransactionTotal_test()
-    {
-        npo02__Household__c h = new npo02__Household__c(Name='Test Household');
-        insert h;
-        Contact c = new Contact(
-            FirstName=CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
-            LastName=CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,
-            npe01__WorkEmail__c = CAO_Constants.CONTACT_EMAIL_FOR_TESTS, 
-            npe01__Preferred_Email__c = CAO_Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
-            npe01__WorkPhone__c = CAO_Constants.CONTACT_PHONE_FOR_TESTS,
-            npe01__PreferredPhone__c = CAO_Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS,
-            npo02__Household__c=h.Id
-        );
-        insert c;
-        Opportunity o = new Opportunity(Name='test oppty',CloseDate=System.Today(),StageName=UTIL_UnitTestData_TEST.getClosedWonStage(),Amount=100);
-        insert o;
-        OpportunityContactRole ocr = new OpportunityContactRole(OpportunityId=o.Id,ContactId=c.Id,Role='Test');
-        insert ocr;
-        system.assertEquals(system.label.npo02.DefaultHouseholdTransactionCurrency + '100.00',HH_Households.getHouseholdTransactionTotal(h.id));
-    }
-    
-    /*********************************************************************************************************
-    * @description 
-    static testMethod void getHouseholdLastTransaction_test()
-    {
-        Integer year = 2005;
-        Integer month = 10;
-        Integer day = 10;
-        npo02__Household__c h = new npo02__Household__c(Name='Test Household');
-        insert h;
-        Contact c = new Contact(
-            FirstName=CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
-            LastName=CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,
-            npe01__WorkEmail__c = CAO_Constants.CONTACT_EMAIL_FOR_TESTS, 
-            npe01__Preferred_Email__c = CAO_Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
-            npe01__WorkPhone__c = CAO_Constants.CONTACT_PHONE_FOR_TESTS,
-            npe01__PreferredPhone__c = CAO_Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS,
-            npo02__Household__c=h.Id
-        );
-        insert c;
-        Opportunity o = new Opportunity(Name='test oppty',CloseDate=date.newInstance(year,month,day),StageName=UTIL_UnitTestData_TEST.getClosedWonStage(),Amount=100);
-        insert o;
-        OpportunityContactRole ocr = new OpportunityContactRole(OpportunityId=o.Id,ContactId=c.Id,Role='Test');
-        insert ocr;
-        system.assertEquals(String.valueOf(year)+'-'+String.valueOf(month)+'-'+String.valueOf(day),HH_Households.getHouseholdLastTransaction(h.id));
-    }
-*****************************************/
-    
-/**** deprecated in Cumulus
-     /// visualforce and apex methods for totals
-    static testMethod void getHouseholdTransactionAmount_test()
-    {
-        
-        npo02__Household__c h = new npo02__Household__c(Name='Test Household');
-        insert h;
-        Contact c = new Contact(
-            FirstName=CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
-            LastName=CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,
-            npe01__WorkEmail__c = CAO_Constants.CONTACT_EMAIL_FOR_TESTS, 
-            npe01__Preferred_Email__c = CAO_Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
-            npe01__WorkPhone__c = CAO_Constants.CONTACT_PHONE_FOR_TESTS,
-            npe01__PreferredPhone__c = CAO_Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS,
-            npo02__Household__c=h.Id
-        );
-        insert c;
-        Opportunity o = new Opportunity(Name='test oppty',CloseDate=date.newInstance(2007,3,3),StageName=UTIL_UnitTestData_TEST.getClosedWonStage(),Amount=100);
-        insert o;
-        OpportunityContactRole ocr = new OpportunityContactRole(OpportunityId=o.Id,ContactId=c.Id,Role='Test');
-        insert ocr;
-        
-        //pass contact into the controller
-        ApexPages.StandardController sc = new ApexPages.standardController(h);
-        //pass the controller into the extension
-        HouseholdTransactionHistory_EXT ext = new HouseholdTransactionHistory_EXT(sc);  
-        
-        system.assertEquals(system.label.npo02.DefaultHouseholdTransactionCurrency + '100.00',ext.getHouseholdTransactionTotal());
-    }
-    
-    /// visualforce and apex methods for totals
-    static testMethod void getHouseholdLastTransactionDate_test()
-    {
-        Integer year = 2005;
-        Integer month = 10;
-        Integer day = 10;
-        
-        npo02__Household__c h = new npo02__Household__c(Name='Test Household');
-        insert h;
-        Contact c = new Contact(
-            FirstName=CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
-            LastName=CAO_Constants.CONTACT_LASTNAME_FOR_TESTS,
-            npe01__WorkEmail__c = CAO_Constants.CONTACT_EMAIL_FOR_TESTS, 
-            npe01__Preferred_Email__c = CAO_Constants.CONTACT_PREFERRED_EMAIL_FOR_TESTS,
-            npe01__WorkPhone__c = CAO_Constants.CONTACT_PHONE_FOR_TESTS,
-            npe01__PreferredPhone__c = CAO_Constants.CONTACT_PREFERRED_PHONE_FOR_TESTS,
-            npo02__Household__c=h.Id
-        );
-        insert c;
-        Opportunity o = new Opportunity(Name='test oppty',CloseDate=date.newInstance(year,month,day),StageName=UTIL_UnitTestData_TEST.getClosedWonStage(),Amount=100);
-        insert o;
-        OpportunityContactRole ocr = new OpportunityContactRole(OpportunityId=o.Id,ContactId=c.Id,Role='Test');
-        insert ocr;
-        
-        //pass contact into the controller
-        ApexPages.StandardController sc = new ApexPages.standardController(h);
-        //pass the controller into the extension
-        HouseholdTransactionHistory_EXT ext = new HouseholdTransactionHistory_EXT(sc);
-        
-        system.assertEquals(String.valueOf(day) + '/' + String.valueOf(month) + '/' + String.valueOf(year),ext.getLastTransactionDate());
-    }
-****/
     
     /*********************************************************************************************************
     * @description Tests moving a contact from one household to another, leaving the old household empty.
@@ -825,5 +738,108 @@ public with sharing class HH_Households_TEST {
         system.assertEquals('Smith ' + system.label.npo02.DefaultHouseholdName, hh.Name);
         system.assertEquals('Joe Smith', hh.npo02__Formal_greeting__c);
         system.assertEquals('Joe', hh.npo02__Informal_greeting__c);
+    } 
+
+    // Helpers
+    ////////////
+
+    /*********************************************************************************************************
+    * @description Turns on Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOnAutomaticHHNamingForAllHouseholdProcessor() {
+        setupAutomaticHHNamingForAllHouseholdProcessor(true);
+    }
+
+    /*********************************************************************************************************
+    * @description Turns off Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOffAutomaticHHNamingForAllHouseholdProcessor() {
+        setupAutomaticHHNamingForAllHouseholdProcessor(false);
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Settings' Automatic Household Naming field
+    * @param isOn Automatic Household Naming is turned on when parameter is true, otherwise, the settings is turned off
+    * @return void
+    **********************************************************************************************************/
+    private static void setupAutomaticHHNamingForAllHouseholdProcessor(Boolean isOn) {
+        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
+            new npo02__Households_Settings__c (
+                npo02__Household_Rules__c = HH_Households.ALL_PROCESSOR,
+                npo02__Advanced_Household_Naming__c = isOn
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with invalid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupInvalidHHNamingSettings() {
+        setupHHNamingSettings('{!{!FirstName}} {!LastName}} Household', '{!{!Title} {!FirstName}}}{!LastName}', '{!{!FirstName}}}');
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with valid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings() {
+        setupHHNamingSettings('{!LastName} Household', '{!{!Title}} {!LastName}', '{!{!FirstName}}');
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings 
+    * @param hhNameFormat Household Naming Format
+    * @param formalGreetingFormat Formal Greeting Format
+    * @param informalGreetingFormat Informal Greeting Format
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = hhNameFormat,
+                Formal_Greeting_Format__c = formalGreetingFormat,
+                Informal_Greeting_Format__c = informalGreetingFormat,
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Sets up Contact Settings with Account Processor = CAO_Constants.ONE_TO_ONE_PROCESSOR
+    * @return void
+    **********************************************************************************************************/
+    private static void setupContactSettingsOneToOneProcessor() {
+        UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_and_Orgs_Settings__c(
+                npe01__Account_Processor__c = CAO_Constants.ONE_TO_ONE_PROCESSOR
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Retrieves Household object referenced by the Contact 
+    * @param contactId Id of the Contact
+    * @return npo02__Household__c Household object or null if the Contact has no Household reference
+    **********************************************************************************************************/
+    private static npo02__Household__c getHouseholdForContact(Id contactId) {
+        Contact[] contacts = [
+            SELECT npo02__Household__c, 
+                npo02__Household__r.Id, npo02__Household__r.Name, 
+                npo02__Household__r.npo02__Formal_greeting__c, 
+                npo02__Household__r.npo02__Informal_greeting__c 
+            FROM Contact 
+            WHERE Id = :contactId
+        ];
+        System.assert(contacts != null);
+        
+        return contacts[0].npo02__Household__c == null
+            ? null
+            : contacts[0].npo02__Household__r;
     }
 }

--- a/src/classes/HH_Households_TEST.cls
+++ b/src/classes/HH_Households_TEST.cls
@@ -165,20 +165,28 @@ public with sharing class HH_Households_TEST {
         setupInvalidHHNamingSettings();
         
         Contact contact = new Contact(FirstName = 'John', LastName = 'Smith');
-        insert contact;
+        try {
+            insert contact;
+        } catch (Exception e) {
+            System.assert(false, 'Unexpected error on Contact insert: ' + e.getMessage());
+        }
   
         npo02__Household__c hh = getHouseholdForContact(contact.id);
     
-        System.assertEquals('Smith ' + system.label.npo02.DefaultHouseholdName, hh.Name);
-        System.assertEquals(null, hh.npo02__Formal_Greeting__c);
-        System.assertEquals(null, hh.npo02__Informal_Greeting__c);
+        System.assertEquals('Smith ' + system.label.npo02.DefaultHouseholdName, hh.Name, 'Household Name should be default household name');
+        System.assertEquals(null, hh.npo02__Formal_Greeting__c, 'Formal Greeting should not be populated');
+        System.assertEquals(null, hh.npo02__Informal_Greeting__c, 'Informal Greeting should not be populated');
 
         contact.LastName = 'Smith Jones';
         Test.startTest();
-        update contact;
+        try {
+            update contact;
+        } catch (Exception e) {
+            System.assert(false, 'Unexpected error on Contact update: ' + e.getMessage());
+        }
         Test.stopTest();
 
-        System.assertEquals('Smith Jones', [SELECT LastName FROM Contact WHERE Id = :contact.Id][0].LastName);
+        System.assertEquals('Smith Jones', [SELECT LastName FROM Contact WHERE Id = :contact.Id][0].LastName, 'Household Name should be the same as Contact LastName');
     }  
     
     /*********************************************************************************************************

--- a/src/classes/STG_PanelHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls
@@ -60,24 +60,21 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
     * @return boolean 
     */
     public boolean isValidNameFormats() {
-        // make sure any custom name formats are valid.
-        if (STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c) {
-            string strSetting;        
-            try {
-                strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Household_Name_Format__c'));
-                strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2); 
-                strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Formal_Greeting_Format__c'));
-                strNameSpecExample(STG_Panel.stgService.stgHN, 'Formal_Greeting_Format__c', 2); 
-                strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Informal_Greeting_Format__c'));     
-                strNameSpecExample(STG_Panel.stgService.stgHN, 'Informal_Greeting_Format__c', 2);
-                return true; 
-            } catch (Exception ex) {
-                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, 
-                    string.format(label.stgErrorInvalidNameFormat, new string[]{strSetting, ex.getMessage()})));
-                return false;           
-            }        
-        } 
-        return true;    
+        string strSetting;        
+        try {
+            strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Household_Name_Format__c'));
+            strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2); 
+            strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Formal_Greeting_Format__c'));
+            strNameSpecExample(STG_Panel.stgService.stgHN, 'Formal_Greeting_Format__c', 2); 
+            strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Informal_Greeting_Format__c'));     
+            strNameSpecExample(STG_Panel.stgService.stgHN, 'Informal_Greeting_Format__c', 2);
+            
+            return true; 
+        } catch (Exception ex) {
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, 
+                string.format(label.stgErrorInvalidNameFormat, new string[]{strSetting, ex.getMessage()})));
+            return false;           
+        }      
     }
 
     /*********************************************************************************************************

--- a/src/classes/STG_PanelHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls
@@ -34,6 +34,11 @@
 * @description Controller for the Households panel.
 */
 public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
+
+    /*******************************************************************************************************
+    * @description Exception raised by the household panel.
+    */
+    public class STG_PanelHouseholdsException extends Exception {} 
     
     /*********************************************************************************************************
     * @description The panel's constructor 
@@ -53,28 +58,79 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
     public override PageReference editSettings() {
         return super.editSettings();
     }
+
+    public Boolean isValidHouseholdNamingSettings() {
+        if (STG_Panel.stgService.stgHH.npo02__Household_Rules__c != HH_Households.NO_HOUSEHOLDS_PROCESSOR &&
+           STG_Panel.stgService.stgCon.npe01__Account_Processor__c == CAO_Constants.HH_ACCOUNT_PROCESSOR
+        ) {
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, system.Label.stgValidationHHAccountHHRules));
+            return false;
+        }
+
+        return isValidNameFormats();
+    }
     
     /*********************************************************************************************************
-    * @description Returns wwhether the custom name formats are valid or not, and adds a Page Message for
-    * any errors.
+    * @description Returns whether the custom name formats are valid or not.
+    * Adds an error Page Message for any errors.
     * @return boolean 
     */
     public boolean isValidNameFormats() {
-        string strSetting;        
         try {
-            strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Household_Name_Format__c'));
-            strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2); 
-            strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Formal_Greeting_Format__c'));
-            strNameSpecExample(STG_Panel.stgService.stgHN, 'Formal_Greeting_Format__c', 2); 
-            strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Informal_Greeting_Format__c'));     
-            strNameSpecExample(STG_Panel.stgService.stgHN, 'Informal_Greeting_Format__c', 2);
+            validateFormat('Household_Name_Format__c');
+            validateFormat('Formal_Greeting_Format__c');
+            validateFormat('Informal_Greeting_Format__c');
+
+            validateHouseholdNamingContactFields();
             
             return true; 
         } catch (Exception ex) {
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, 
-                string.format(label.stgErrorInvalidNameFormat, new string[]{strSetting, ex.getMessage()})));
+            ApexPages.addMessage(
+                new ApexPages.Message(ApexPages.Severity.ERROR, ex.getMessage())
+            );
             return false;           
         }      
+    }
+
+    /*********************************************************************************************************
+    * @description Validates format of the specified Household Naming Settings field
+    * @param fieldName API name of the Household Naming Settings field
+    * @return void 
+    */
+    private void validateFormat(String fieldName) {
+        String fieldLabel = UTIL_Describe.getFieldLabel(
+            UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
+            UTIL_Namespace.StrTokenNSPrefix(fieldName)
+        );
+        
+        try {
+            strNameSpecExample(STG_Panel.stgService.stgHN, fieldName, 2); 
+
+        } catch (Exception ex) {
+            throw new STG_PanelHouseholdsException( 
+                String.format(label.stgErrorInvalidNameFormat, new String[]{ fieldLabel, ex.getMessage() })
+            );       
+        }  
+    }
+
+    /*********************************************************************************************************
+    * @description Validates a class implementing HH_Naming interface returns valid case sensitive field API Names
+    * @return void 
+    */
+    private void validateHouseholdNamingContactFields() {
+        Set<String> fieldApiNames = new Set<String>();
+        for (Schema.SObjectField field : Schema.SObjectType.Contact.fields.getMap().values()) {
+            fieldApiNames.add(field.getDescribe().getName());
+        }
+
+        Set<String> fieldNames = HH_HouseholdNaming.INaming.setHouseholdNameFieldsOnContact();
+        for (String fieldName : fieldNames) {
+            if (!fieldApiNames.contains(fieldName)) {
+                throw new STG_PanelHouseholdsException( 
+                    String.format(Label.stgErrorInvalidFieldApiName, new String[]{ fieldName })
+                );
+            }
+        }
     }
 
     /*********************************************************************************************************
@@ -82,16 +138,7 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
     * @return null 
     */
     public override PageReference saveSettings() {
-        
-        // add some extra error detection
-        if (STG_Panel.stgService.stgHH.npo02__Household_Rules__c != HH_Households.NO_HOUSEHOLDS_PROCESSOR &&
-           STG_Panel.stgService.stgCon.npe01__Account_Processor__c == CAO_Constants.HH_ACCOUNT_PROCESSOR) {
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, system.Label.stgValidationHHAccountHHRules));
-            return null;
-        }
-
-        // make sure any custom name formats are valid.
-        if (!isValidNameFormats())
+        if (!isValidHouseholdNamingSettings())
             return null;        
                 
         return super.saveSettings();
@@ -247,6 +294,17 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
         for (integer i = 0; i < cContact && i < listConExamples.size(); i++)
             listCon.add(listConExamples[i]);
             
+        // TO FIX? There is code duplication. Why don't we use HH_HouseholdNaming.iNaming 
+        // instead of determining the class and creating object every time this method is called?
+        /*
+        HH_INaming hhNaming = HH_HouseholdNaming.INaming;
+        if (hhNaming == null) {
+            return 'Implementing Class must exist and implement interface HH_INaming';//to create a custom label
+        }
+
+        return hhNaming.getExampleName(hns, strField, listCon);
+        */
+
         // call INaming interface dynamically  
         string strClass = hns.Implementing_Class__c;  
         if (strClass == null || strClass == '') strClass = 'HH_NameSpec';   

--- a/src/classes/STG_PanelHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls
@@ -34,11 +34,6 @@
 * @description Controller for the Households panel.
 */
 public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
-
-    /*******************************************************************************************************
-    * @description Exception raised by the household panel.
-    */
-    public class STG_PanelHouseholdsException extends Exception {} 
     
     /*********************************************************************************************************
     * @description The panel's constructor 
@@ -59,87 +54,65 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
         return super.editSettings();
     }
 
-    public Boolean isValidHouseholdNamingSettings() {
-        if (STG_Panel.stgService.stgHH.npo02__Household_Rules__c != HH_Households.NO_HOUSEHOLDS_PROCESSOR &&
-           STG_Panel.stgService.stgCon.npe01__Account_Processor__c == CAO_Constants.HH_ACCOUNT_PROCESSOR
-        ) {
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, system.Label.stgValidationHHAccountHHRules));
-            return false;
-        }
-
-        return isValidNameFormats();
-    }
-    
     /*********************************************************************************************************
-    * @description Returns whether the custom name formats are valid or not.
+    * @description Returns whether all relevant Settings fields are correct or not.
     * Adds an error Page Message for any errors.
     * @return boolean 
     */
-    public boolean isValidNameFormats() {
-        try {
-            validateFormat('Household_Name_Format__c');
-            validateFormat('Formal_Greeting_Format__c');
-            validateFormat('Informal_Greeting_Format__c');
-
-            validateHouseholdNamingContactFields();
-            
-            return true; 
-        } catch (Exception ex) {
-            ApexPages.addMessage(
-                new ApexPages.Message(ApexPages.Severity.ERROR, ex.getMessage())
-            );
-            return false;           
-        }      
-    }
-
-    /*********************************************************************************************************
-    * @description Validates format of the specified Household Naming Settings field
-    * @param fieldName API name of the Household Naming Settings field
-    * @return void 
-    */
-    private void validateFormat(String fieldName) {
-        String fieldLabel = UTIL_Describe.getFieldLabel(
-            UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
-            UTIL_Namespace.StrTokenNSPrefix(fieldName)
-        );
-        
-        try {
-            strNameSpecExample(STG_Panel.stgService.stgHN, fieldName, 2); 
-
-        } catch (Exception ex) {
-            throw new STG_PanelHouseholdsException( 
-                String.format(label.stgErrorInvalidNameFormat, new String[]{ fieldLabel, ex.getMessage() })
-            );       
-        }  
-    }
-
-    /*********************************************************************************************************
-    * @description Validates a class implementing HH_Naming interface returns valid case sensitive field API Names
-    * @return void 
-    */
-    private void validateHouseholdNamingContactFields() {
-        Set<String> fieldApiNames = new Set<String>();
-        for (Schema.SObjectField field : Schema.SObjectType.Contact.fields.getMap().values()) {
-            fieldApiNames.add(field.getDescribe().getName());
+    public Boolean isValidSettings() {
+        if (STG_Panel.stgService.stgHH.npo02__Household_Rules__c != HH_Households.NO_HOUSEHOLDS_PROCESSOR &&
+           STG_Panel.stgService.stgCon.npe01__Account_Processor__c == CAO_Constants.HH_ACCOUNT_PROCESSOR
+        ) {
+            addPageErrorMessage(system.Label.stgValidationHHAccountHHRules);
+            return false;
         }
 
-        Set<String> fieldNames = HH_HouseholdNaming.INaming.setHouseholdNameFieldsOnContact();
-        for (String fieldName : fieldNames) {
-            if (!fieldApiNames.contains(fieldName)) {
-                throw new STG_PanelHouseholdsException( 
-                    String.format(Label.stgErrorInvalidFieldApiName, new String[]{ fieldName })
-                );
+        return isValidHouseholdNamingSettings();
+    }
+    
+    /*********************************************************************************************************
+    * @description Returns whether the Household Naming Settings fields are correct or not.
+    * Adds an error Page Message for any errors.
+    * @return boolean 
+    */
+    private boolean isValidHouseholdNamingSettings() {
+        try {
+            HH_HouseholdNamingSettingValidator validator = new HH_HouseholdNamingSettingValidator();
+            HH_HouseholdNamingSettingValidator.Notification notification = validator.validate(STG_Panel.stgService.stgHN);
+
+            if (notification.isSuccess()) {
+                return true;
             }
-        }
+
+            // Display the first error only?
+            addPageErrorMessage(notification.getErrors()[0]);
+
+        } catch (Exception ex) {
+            addPageErrorMessage(ex.getMessage());
+        }  
+
+        return false;    
+    }
+
+    /*********************************************************************************************************
+    * @description Adds an error message to the page
+    * @param errorMessage Error message
+    * @return void 
+    */
+    private void addPageErrorMessage(String errorMessage) {
+        ApexPages.addMessage(
+            new ApexPages.Message(ApexPages.Severity.ERROR, errorMessage)
+        ); 
     }
 
     /*********************************************************************************************************
     * @description Action Method to save the current settings
-    * @return null 
+    * @return PageReference The returned PageReference is null 
     */
     public override PageReference saveSettings() {
-        if (!isValidHouseholdNamingSettings())
-            return null;        
+        if (!isValidSettings()) {
+            return null;  
+        }      
                 
         return super.saveSettings();
     }
@@ -293,33 +266,14 @@ public with sharing class STG_PanelHouseholds_CTRL extends STG_Panel {
         list<Contact> listCon = new list<Contact>();
         for (integer i = 0; i < cContact && i < listConExamples.size(); i++)
             listCon.add(listConExamples[i]);
-            
-        // TO FIX? There is code duplication. Why don't we use HH_HouseholdNaming.iNaming 
-        // instead of determining the class and creating object every time this method is called?
-        /*
-        HH_INaming hhNaming = HH_HouseholdNaming.INaming;
-        if (hhNaming == null) {
-            return 'Implementing Class must exist and implement interface HH_INaming';//to create a custom label
-        }
 
-        return hhNaming.getExampleName(hns, strField, listCon);
-        */
+        HH_HouseholdNamingSettingValidator validator = new HH_HouseholdNamingSettingValidator();
+        HH_HouseholdNamingSettingValidator.Notification notification = new HH_HouseholdNamingSettingValidator.Notification();
+        HH_INaming hhNaming = validator.validateImplementingClass(hns, notification);
 
-        // call INaming interface dynamically  
-        string strClass = hns.Implementing_Class__c;  
-        if (strClass == null || strClass == '') strClass = 'HH_NameSpec';   
-        Type classType = Type.forName(strClass);
-        if (classType != null) {     
-            Object classInstance = classType.newInstance();
-            if (classInstance instanceof HH_INaming) {
-                HH_INaming n = (HH_INaming)classInstance;
-                return n.getExampleName(hns, strField, listCon);
-            } else {
-                return label.stgErrorINaming;
-            }
-        } else {
-            return label.stgErrorInvalidClass;
-        }
+        return notification.isSuccess()
+            ? hhNaming.getExampleName(hns, strField, listCon)
+            : notification.getErrors()[0];
     }    
 
     /**

--- a/src/classes/STG_PanelRenameHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelRenameHouseholds_CTRL.cls
@@ -60,7 +60,7 @@ public with sharing class STG_PanelRenameHouseholds_CTRL extends STG_Panel {
         boolean isActivation = UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c == false;
 
         if (isActivation) {
-            if (!new STG_PanelHouseholds_CTRL().isValidNameFormats()) {
+            if (!new STG_PanelHouseholds_CTRL().isValidHouseholdNamingSettings()) {
                 return null;
             }
 

--- a/src/classes/STG_PanelRenameHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelRenameHouseholds_CTRL.cls
@@ -57,12 +57,18 @@ public with sharing class STG_PanelRenameHouseholds_CTRL extends STG_Panel {
     * @return null
     */
     public PageReference runBatch() {
-        boolean isActivation = (UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c == false);
-                
-        STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = true;
-        isRunningBatch = true;
-        super.saveSettings();
+        boolean isActivation = UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c == false;
 
+        if (isActivation) {
+            if (!new STG_PanelHouseholds_CTRL().isValidNameFormats()) {
+                return null;
+            }
+
+            STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = true;
+            super.saveSettings();
+        }
+
+        isRunningBatch = true;
         HH_HouseholdNaming.refreshAllHouseholdNaming(isActivation);
         return null;
     }

--- a/src/classes/STG_PanelRenameHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelRenameHouseholds_CTRL.cls
@@ -60,7 +60,7 @@ public with sharing class STG_PanelRenameHouseholds_CTRL extends STG_Panel {
         boolean isActivation = UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c == false;
 
         if (isActivation) {
-            if (!new STG_PanelHouseholds_CTRL().isValidHouseholdNamingSettings()) {
+            if (!new STG_PanelHouseholds_CTRL().isValidSettings()) {
                 return null;
             }
 

--- a/src/classes/STG_PanelRenameHouseholds_CTRL.cls
+++ b/src/classes/STG_PanelRenameHouseholds_CTRL.cls
@@ -54,7 +54,7 @@ public with sharing class STG_PanelRenameHouseholds_CTRL extends STG_Panel {
     
     /*********************************************************************************************************
     * @description Action Method to run the Refresh Household Names batch process
-    * @return null
+    * @return PageReference The PageReference is null regardless if an error occurs or the batch runs successfully
     */
     public PageReference runBatch() {
         boolean isActivation = UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c == false;

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -286,6 +286,110 @@ public with sharing class STG_SettingsManager_TEST {
 
     /*********************************************************************************************************
     @description 
+        Tests isValidNameFormats() when Household_Name_Format__c field format is invalid
+    verify:
+        The method returns false.    
+        The page contains an error message containing the field label.    
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNameFormatIsInvalid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNameFormatIsInvalid') return;
+
+        setupHHNamingSettings(            
+            '{!{!FirstName}} {!LastName}} Household',//invalid format
+            '{!{!Title} {!FirstName}}{!LastName}',
+            '{!{!FirstName}}'
+        );
+
+        testAndAssertPanelHouseholdPageErrorMessageFor('Household_Name_Format__c'); 
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests isValidNameFormats() when Formal_Greeting_Format__c field format is invalid
+    verify:
+        The method returns false.    
+        The page contains an error message containing the field label.    
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHFormalGreetingFormatIsInvalid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHFormalGreetingFormatIsInvalid') return;
+
+        setupHHNamingSettings(            
+            '{!{!FirstName} {!LastName}} Household',
+            '{!{!Title} {!FirstName}}}{!LastName}',//invalid format
+            '{!{!FirstName}}'
+        );
+        
+        testAndAssertPanelHouseholdPageErrorMessageFor('Formal_Greeting_Format__c'); 
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests isValidNameFormats() when Informal_Greeting_Format__c field format is invalid
+    verify:
+        The method returns false.    
+        The page contains an error message containing the field label.    
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHInformalGreetingFormatIsInvalid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHInformalGreetingFormatIsInvalid') return;
+
+        setupHHNamingSettings(            
+            '{!{!FirstName} {!LastName}} Household',
+            '{!{!Title} {!FirstName}}{!LastName}',
+            '{!{!FirstName}}}'//invalid format 
+        );
+
+        testAndAssertPanelHouseholdPageErrorMessageFor('Informal_Greeting_Format__c'); 
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests isValidNameFormats() when a Household Naming Settings field format is invalid
+    verify:
+        The method returns false.    
+        The page contains an error message containing the field label.    
+    **********************************************************************************************************/ 
+    static void testAndAssertPanelHouseholdPageErrorMessageFor(String fieldName) {
+        Test.setCurrentPage(Page.STG_PanelHouseholds);
+
+        STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
+        System.assertEquals(false, ctrl.isValidNameFormats());      
+        
+        String fieldLabel = UTIL_Describe.getFieldLabel(
+            UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
+            UTIL_Namespace.StrTokenNSPrefix(fieldName)
+        );
+        
+        UTIL_UnitTestData_TEST.assertPageHasError(fieldLabel); 
+        UTIL_UnitTestData_TEST.assertPageHasError('Invalid field'); 
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests isValidNameFormats() when a Household Naming Settings field contains invalid API name 
+    verify:
+        The method returns false.    
+        The page contains an error message containing the user specified field name.    
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNamingContactFieldIsNotCaseSensitiveApiName() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNamingContactFieldIsNotCaseSensitiveApiName') return;
+
+        setupHHNamingSettings(            
+            '{!{!FirstName} {!lastname}} Household', //lastname is not a correct case sensitive API Name
+            '{!{!Title} {!FirstName}}{!LastName}',
+            '{!{!FirstName}}'
+        );
+
+        Test.setCurrentPage(Page.STG_PanelHouseholds);
+
+        STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
+        System.assertEquals(false, ctrl.isValidNameFormats());     
+
+        String expectedMessage = String.format(Label.stgErrorInvalidFieldApiName, new String[]{ 'lastname' }); 
+        UTIL_UnitTestData_TEST.assertPageHasError(expectedMessage); 
+    }
+
+    /*********************************************************************************************************
+    @description 
         Tests Refresh Household Names batch when Automatic Household Naming is turned off 
         and Household Naming Settings is invalid
     verify:
@@ -293,8 +397,8 @@ public with sharing class STG_SettingsManager_TEST {
         Automatic Household Naming field is still turned off.
         The Page contains an error.        
     **********************************************************************************************************/ 
-    private static testMethod void STG_PanelRenameHouseholds_runBatchShouldNotRunBatchWhenHHNamingSettingsIsInvalidAndTurnedOff() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_runBatchShouldNotRunBatchWhenHHNamingSettingsIsInvalidAndTurnedOff') return;
+    private static testMethod void STG_PanelRenameHouseholds_shouldNotRunBatchWhenHHNamingSettingsIsInvalidAndAutomaticHHNamingTurnedOff() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_shouldNotRunBatchWhenHHNamingSettingsIsInvalidAndAutomaticHHNamingTurnedOff') return;
 
         turnOffAutomaticHHNaming();
         setupInvalidHHNamingSettings();
@@ -324,8 +428,8 @@ public with sharing class STG_SettingsManager_TEST {
         Automatic Household Naming field is turned on.
         The Page contains no error.        
     **********************************************************************************************************/ 
-    private static testMethod void STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenHHNamingSettingsIsValidAndTurnedOff() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenHHNamingSettingsIsValidAndTurnedOff') return;
+    private static testMethod void STG_PanelRenameHouseholds_shouldRunBatchWhenHHNamingSettingsIsValidAndAutomaticHHNamingTurnedOff() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_shouldRunBatchWhenHHNamingSettingsIsValidAndAutomaticHHNamingTurnedOff') return;
 
         turnOffAutomaticHHNaming();
 
@@ -352,8 +456,8 @@ public with sharing class STG_SettingsManager_TEST {
         Household Naming batch has been run.
         The Page contains no error.        
     **********************************************************************************************************/ 
-    private static testMethod void STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenAutomaticHHNamingIsTurnedOn() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenAutomaticHHNamingIsTurnedOn') return;
+    private static testMethod void STG_PanelRenameHouseholds_shouldRunBatchWhenAutomaticHHNamingIsTurnedOn() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_shouldRunBatchWhenAutomaticHHNamingIsTurnedOn') return;
 
         turnOnAutomaticHHNaming();
 
@@ -1081,15 +1185,42 @@ public with sharing class STG_SettingsManager_TEST {
     * @return void
     **********************************************************************************************************/
     private static void setupInvalidHHNamingSettings() {
+        setupHHNamingSettings(
+            '{!{!FirstName}} {!LastName}} Household',
+            '{!{!Title} {!FirstName}}}{!LastName}',
+            '{!{!FirstName}}}'
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with valid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings() {
+        setupHHNamingSettings(            
+            '{!{!FirstName} {!LastName}} Household',
+            '{!{!Title} {!FirstName}}{!LastName}',
+            '{!{!FirstName}}'
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings 
+    * @param hhNameFormat Household Naming Format
+    * @param formalGreetingFormat Formal Greeting Format
+    * @param informalGreetingFormat Informal Greeting Format
+    * @return void
+    **********************************************************************************************************/
+    private static void setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
         UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
-        	new Household_Naming_Settings__c(
-                Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household', 
-        		Formal_Greeting_Format__c = '{!{!Title} {!FirstName}}}{!LastName}',
-                Informal_Greeting_Format__c = '{!{!FirstName}}}',
-        		Name_Connector__c = label.npo02.HouseholdNameConnector,
-       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
-        		Contact_Overrun_Count__c = 9,
-        		Implementing_Class__c = 'HH_NameSpec'
+            new Household_Naming_Settings__c(
+                Household_Name_Format__c = hhNameFormat,
+                Formal_Greeting_Format__c = formalGreetingFormat,
+                Informal_Greeting_Format__c = informalGreetingFormat,
+                Name_Connector__c = label.npo02.HouseholdNameConnector,
+                Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+                Contact_Overrun_Count__c = 9,
+                Implementing_Class__c = 'HH_NameSpec'
             )
         );
     }

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -270,7 +270,7 @@ public with sharing class STG_SettingsManager_TEST {
         Test.setCurrentPage(Page.STG_PanelHouseholds);
 
         STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
-        System.assertEquals(false, ctrl.isValidSettings());     
+        System.assertEquals(false, ctrl.isValidSettings(), 'Household Naming Settings should be invalid');     
         
         UTIL_UnitTestData_TEST.assertPageHasError(Label.stgValidationHHAccountHHRules); 
     }
@@ -291,21 +291,21 @@ public with sharing class STG_SettingsManager_TEST {
         for (Boolean isAutomaticHouseholdNaming : new Boolean[] { true, false }) {
             STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = isAutomaticHouseholdNaming;
 
-            system.assertEquals(true, panel.isValidSettings());        
+            system.assertEquals(true, panel.isValidSettings(), 'Household Naming Settings should be valid');        
 
             STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!bogus}}';
-            system.assertEquals(false, panel.isValidSettings());      
+            system.assertEquals(false, panel.isValidSettings(), 'Household Name Format should be invalid');      
 
             STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName}} {!LastName} Family';        
             STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!bogus}}';
-            system.assertEquals(false, panel.isValidSettings());     
+            system.assertEquals(false, panel.isValidSettings(), 'Household Formal Greeting Format should be invalid');     
 
             STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}} {!LastName}';               
             STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!bogus}}';
-            system.assertEquals(false, panel.isValidSettings());     
+            system.assertEquals(false, panel.isValidSettings(), 'Household Informal Greeting Format should be invalid');     
 
             STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!FirstName}}';
-            system.assertEquals(true, panel.isValidSettings());   
+            system.assertEquals(true, panel.isValidSettings(), 'Household Naming Settings should be valid');   
         }     
     }
 
@@ -325,7 +325,7 @@ public with sharing class STG_SettingsManager_TEST {
         Test.setCurrentPage(Page.STG_PanelHouseholds);
 
         STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
-        System.assertEquals(false, ctrl.isValidSettings());      
+        System.assertEquals(false, ctrl.isValidSettings(), 'Household Naming Settings should be invalid');      
         
         String fieldLabel = UTIL_Describe.getFieldLabel(
             UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
@@ -350,14 +350,14 @@ public with sharing class STG_SettingsManager_TEST {
         Test.setCurrentPage(Page.STG_PanelHouseholds);
 
         STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
-        System.assertEquals(true, ctrl.isValidSettings());      
+        System.assertEquals(true, ctrl.isValidSettings(), 'Household Naming Settings should be valid');      
         
         STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household'; //invalid format        
-        System.assertEquals(false, ctrl.isValidSettings());    
+        System.assertEquals(false, ctrl.isValidSettings(), 'Household Naming Settings should be invalid');    
         UTIL_UnitTestData_TEST.assertPageHasError('Invalid field'); 
 
         STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName} {!LastName}} Household'; 
-        System.assertEquals(true, ctrl.isValidSettings());      
+        System.assertEquals(true, ctrl.isValidSettings(), 'Household Naming Settings should be valid');      
     }
 
     /*********************************************************************************************************
@@ -376,7 +376,7 @@ public with sharing class STG_SettingsManager_TEST {
 
             System.assert(false, 'Expected exception for invalid format field');
         } catch(Exception e) {
-            System.assert(e.getMessage().contains('Invalid field'));
+            System.assert(e.getMessage().contains('Invalid field'), 'An exception should contain Invalid Field message instead: ' + e.getMessage());
         }    
     }
 
@@ -393,7 +393,7 @@ public with sharing class STG_SettingsManager_TEST {
 
         String exampleName = STG_PanelHouseholds_CTRL.strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2);
 
-        System.assert(!String.isBlank(exampleName));
+        System.assert(String.isNotBlank(exampleName), 'An example name should be returned');
     }
 
     /*********************************************************************************************************
@@ -410,7 +410,7 @@ public with sharing class STG_SettingsManager_TEST {
 
         String exampleName = STG_PanelHouseholds_CTRL.strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2);
 
-        System.assertEquals(Label.stgErrorInvalidClass, exampleName);
+        System.assertEquals(Label.stgErrorInvalidClass, exampleName, 'Expected error message should be returned');
     }
 
     /*********************************************************************************************************
@@ -431,15 +431,15 @@ public with sharing class STG_SettingsManager_TEST {
         Test.setCurrentPage(Page.STG_PanelRenameHouseholds);
 
         STG_PanelRenameHouseholds_CTRL ctrl = new STG_PanelRenameHouseholds_CTRL();
-        System.assert(!ctrl.isRunningBatch);
+        System.assert(!ctrl.isRunningBatch, 'The batch should not run');
 
         Test.startTest();
         PageReference pg = ctrl.runBatch();
         Test.stopTest();
 
-        System.assertEquals(null, pg);
-        System.assert(!ctrl.isRunningBatch);
-        System.assertEquals(false, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c);        
+        System.assertEquals(null, pg, 'Returned PageReference should be null');
+        System.assert(!ctrl.isRunningBatch, 'The batch should not run');
+        System.assertEquals(false, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c, 'Automatic Household Naming should be turned off');        
         
         UTIL_UnitTestData_TEST.assertPageHasError('Invalid field');
     }
@@ -461,17 +461,17 @@ public with sharing class STG_SettingsManager_TEST {
         Test.setCurrentPage(Page.STG_PanelRenameHouseholds);
 
         STG_PanelRenameHouseholds_CTRL ctrl = new STG_PanelRenameHouseholds_CTRL();
-        System.assert(!ctrl.isRunningBatch);
+        System.assert(!ctrl.isRunningBatch, 'The batch should not run');
 
         Test.startTest();
         PageReference pg = ctrl.runBatch();
         Test.stopTest();
 
-        System.assertEquals(null, pg);
-        System.assert(ctrl.isRunningBatch);
-        System.assertEquals(true, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c);    
+        System.assertEquals(null, pg, 'Returned PageReference should be null');
+        System.assert(ctrl.isRunningBatch, 'The batch should run');
+        System.assertEquals(true, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c, 'Automatic Household Naming should be turned on');    
         
-        System.assertEquals(0, ApexPages.getMessages().size());
+        System.assertEquals(0, ApexPages.getMessages().size(), 'The page should not contain any error: ' + ApexPages.getMessages());
     }
 
     /*********************************************************************************************************
@@ -489,17 +489,17 @@ public with sharing class STG_SettingsManager_TEST {
         Test.setCurrentPage(Page.STG_PanelRenameHouseholds);
 
         STG_PanelRenameHouseholds_CTRL ctrl = new STG_PanelRenameHouseholds_CTRL();
-        System.assert(!ctrl.isRunningBatch);
+        System.assert(!ctrl.isRunningBatch, 'The batch should not run');
 
         Test.startTest();
         PageReference pg = ctrl.runBatch();
         Test.stopTest();
 
-        System.assertEquals(null, pg);
-        System.assert(ctrl.isRunningBatch);    
-        System.assertEquals(true, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c);    
+        System.assertEquals(null, pg, 'Returned PageReference should be null');
+        System.assert(ctrl.isRunningBatch, 'The batch should run');    
+        System.assertEquals(true, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c, 'Automatic Household Naming should be turned on');    
 
-        System.assertEquals(0, ApexPages.getMessages().size());
+        System.assertEquals(0, ApexPages.getMessages().size(), 'The page should not contain any error: ' + ApexPages.getMessages());
     }
 
     /*********************************************************************************************************

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -242,37 +242,135 @@ public with sharing class STG_SettingsManager_TEST {
     */
     public static testMethod void testPanelHouseholds() {
         if (strTestOnly != '*' && strTestOnly != 'testPanelHouseholds') return;
+
         STG_PanelHouseholds_CTRL panel = new STG_PanelHouseholds_CTRL();
         system.assertEquals('idPanelHH', panel.idPanel());
+
         STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = false;
         panel.saveSettings();
         system.assertEquals(false, UTIL_CustomSettingsFacade.getOrgHouseholdsSettings().npo02__Advanced_Household_Naming__c);
     }
 
     /*********************************************************************************************************
-    * @description Tests that the name specs are valid in the Households panel
-    * @return void
-    */
-    public static testMethod void testNameSpecs() {
-        if (strTestOnly != '*' && strTestOnly != 'testNameSpecs') return;
-        STG_PanelHouseholds_CTRL panel = new STG_PanelHouseholds_CTRL();
-        
-        STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = true;
-        system.assertEquals(true, panel.isValidNameFormats());        
+    @description 
+        Tests that the name specs are valid in the Households panel
+    verify:
+        isValidNameFormats() returns false when any Household Naming Settings is invalid.
+        isValidNameFormats() returns true when Household Naming Settings is valid.
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldReturnFalseWhenHHNamingSettingsIsInvalid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldReturnFalseWhenHHNamingSettingsIsInvalid') return;
 
-        STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!bogus}}';
-        system.assertEquals(false, panel.isValidNameFormats());        
-        STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName}} {!LastName} Family';
-        
-        STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!bogus}}';
-        system.assertEquals(false, panel.isValidNameFormats());        
-        STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}} {!LastName}';
-               
-        STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!bogus}}';
-        system.assertEquals(false, panel.isValidNameFormats());        
-        STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!FirstName}}';
+        STG_PanelHouseholds_CTRL panel = new STG_PanelHouseholds_CTRL();        
 
-        system.assertEquals(true, panel.isValidNameFormats());        
+        for (Boolean isAutomaticHouseholdNaming : new Boolean[] { true, false }) {
+            STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = isAutomaticHouseholdNaming;
+
+            system.assertEquals(true, panel.isValidNameFormats());        
+
+            STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!bogus}}';
+            system.assertEquals(false, panel.isValidNameFormats());      
+
+            STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName}} {!LastName} Family';        
+            STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!bogus}}';
+            system.assertEquals(false, panel.isValidNameFormats());     
+
+            STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}} {!LastName}';               
+            STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!bogus}}';
+            system.assertEquals(false, panel.isValidNameFormats());     
+
+            STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!FirstName}}';
+            system.assertEquals(true, panel.isValidNameFormats());   
+        }     
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests Refresh Household Names batch when Automatic Household Naming is turned off 
+        and Household Naming Settings is invalid
+    verify:
+        Household Naming batch has not been run.
+        Automatic Household Naming field is still turned off.
+        The Page contains an error.        
+    **********************************************************************************************************/ 
+    private static testMethod void STG_PanelRenameHouseholds_runBatchShouldNotRunBatchWhenHHNamingSettingsIsInvalidAndTurnedOff() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_runBatchShouldNotRunBatchWhenHHNamingSettingsIsInvalidAndTurnedOff') return;
+
+        turnOffAutomaticHHNaming();
+        setupInvalidHHNamingSettings();
+
+        Test.setCurrentPage(Page.STG_PanelRenameHouseholds);
+
+        STG_PanelRenameHouseholds_CTRL ctrl = new STG_PanelRenameHouseholds_CTRL();
+        System.assert(!ctrl.isRunningBatch);
+
+        Test.startTest();
+        PageReference pg = ctrl.runBatch();
+        Test.stopTest();
+
+        System.assertEquals(null, pg);
+        System.assert(!ctrl.isRunningBatch);
+        System.assertEquals(false, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c);        
+        
+        UTIL_UnitTestData_TEST.assertPageHasError('Invalid field');
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests Refresh Household Names batch when Automatic Household Naming is turned off 
+        and Household Naming Settings is valid
+    verify:
+        Household Naming batch has been run.
+        Automatic Household Naming field is turned on.
+        The Page contains no error.        
+    **********************************************************************************************************/ 
+    private static testMethod void STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenHHNamingSettingsIsValidAndTurnedOff() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenHHNamingSettingsIsValidAndTurnedOff') return;
+
+        turnOffAutomaticHHNaming();
+
+        Test.setCurrentPage(Page.STG_PanelRenameHouseholds);
+
+        STG_PanelRenameHouseholds_CTRL ctrl = new STG_PanelRenameHouseholds_CTRL();
+        System.assert(!ctrl.isRunningBatch);
+
+        Test.startTest();
+        PageReference pg = ctrl.runBatch();
+        Test.stopTest();
+
+        System.assertEquals(null, pg);
+        System.assert(ctrl.isRunningBatch);
+        System.assertEquals(true, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c);    
+        
+        System.assertEquals(0, ApexPages.getMessages().size());
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests Refresh Household Names batch when Automatic Household Naming is turned on
+    verify:
+        Household Naming batch has been run.
+        The Page contains no error.        
+    **********************************************************************************************************/ 
+    private static testMethod void STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenAutomaticHHNamingIsTurnedOn() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelRenameHouseholds_runBatchShouldRunBatchWhenAutomaticHHNamingIsTurnedOn') return;
+
+        turnOnAutomaticHHNaming();
+
+        Test.setCurrentPage(Page.STG_PanelRenameHouseholds);
+
+        STG_PanelRenameHouseholds_CTRL ctrl = new STG_PanelRenameHouseholds_CTRL();
+        System.assert(!ctrl.isRunningBatch);
+
+        Test.startTest();
+        PageReference pg = ctrl.runBatch();
+        Test.stopTest();
+
+        System.assertEquals(null, pg);
+        System.assert(ctrl.isRunningBatch);    
+        System.assertEquals(true, UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Advanced_Household_Naming__c);    
+
+        System.assertEquals(0, ApexPages.getMessages().size());
     }
 
     /*********************************************************************************************************
@@ -943,6 +1041,57 @@ public with sharing class STG_SettingsManager_TEST {
         system.assertEquals(false, panel.isRunningBatch);
         panel.runBatch();
         system.assertEquals(true, panel.isRunningBatch);
+    }
+
+    //Helpers
+    //////////
+
+    /*********************************************************************************************************
+    * @description Turns on Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOnAutomaticHHNaming() {
+        setupAutomaticHHNaming(true);
+    }
+
+    /*********************************************************************************************************
+    * @description Turns off Automatic Household Naming
+    * @return void
+    **********************************************************************************************************/
+    private static void turnOffAutomaticHHNaming() {
+        setupAutomaticHHNaming(false);
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Settings' Automatic Household Naming field
+    * @param isOn Automatic Household Naming is turned on when parameter is true, otherwise, the settings is turned off
+    * @return void
+    **********************************************************************************************************/
+    private static void setupAutomaticHHNaming(Boolean isOn) {
+        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
+            new npo02__Households_Settings__c (
+                npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
+                npo02__Advanced_Household_Naming__c = isOn
+            )
+        );
+    }
+
+    /*********************************************************************************************************
+    * @description Configures Household Naming Settings with invalid Name and Greetings formats
+    * @return void
+    **********************************************************************************************************/
+    private static void setupInvalidHHNamingSettings() {
+        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+        	new Household_Naming_Settings__c(
+                Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household', 
+        		Formal_Greeting_Format__c = '{!{!Title} {!FirstName}}}{!LastName}',
+                Informal_Greeting_Format__c = '{!{!FirstName}}}',
+        		Name_Connector__c = label.npo02.HouseholdNameConnector,
+       			Name_Overrun__c = label.npo02.HouseholdNameOverrun,
+        		Contact_Overrun_Count__c = 9,
+        		Implementing_Class__c = 'HH_NameSpec'
+            )
+        );
     }
 
 }

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -256,7 +256,7 @@ public with sharing class STG_SettingsManager_TEST {
         Tests that the name specs are valid in the Households panel
     verify:
         isValidNameFormats() returns false when any Household Naming Settings is invalid.
-        isValidNameFormats() returns true when Household Naming Settings is valid.
+        isValidNameFormats() returns true when all Household Naming Settings are valid.
     **********************************************************************************************************/ 
     public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldReturnFalseWhenHHNamingSettingsIsInvalid() {
         if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldReturnFalseWhenHHNamingSettingsIsInvalid') return;

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -240,8 +240,8 @@ public with sharing class STG_SettingsManager_TEST {
     * @description Tests the Households panel
     * @return void
     */
-    public static testMethod void testPanelHouseholds() {
-        if (strTestOnly != '*' && strTestOnly != 'testPanelHouseholds') return;
+    public static testMethod void STG_PanelHouseholds_testPanelHouseholds() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_testPanelHouseholds') return;
 
         STG_PanelHouseholds_CTRL panel = new STG_PanelHouseholds_CTRL();
         system.assertEquals('idPanelHH', panel.idPanel());
@@ -253,110 +253,83 @@ public with sharing class STG_SettingsManager_TEST {
 
     /*********************************************************************************************************
     @description 
-        Tests that the name specs are valid in the Households panel
+        Tests isValidSettings() when the Account Model is set to 'Household Account' but 
+        Household Rules are not set to 'No Contacts'
     verify:
-        isValidNameFormats() returns false when any Household Naming Settings is invalid.
-        isValidNameFormats() returns true when all Household Naming Settings are valid.
+        The method returns false.    
+        The page contains an error message.    
     **********************************************************************************************************/ 
-    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldReturnFalseWhenHHNamingSettingsIsInvalid() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldReturnFalseWhenHHNamingSettingsIsInvalid') return;
+    public static testMethod void STG_PanelHouseholds_isValidSettingsShouldAddPageErrorMessageWhenAccountModelIsNotAsExpected() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidSettingsShouldAddPageErrorMessageWhenAccountModelIsNotAsExpected') return;
+
+        setupHHNamingSettings();
+
+        STG_Panel.stgService.stgHH.npo02__Household_Rules__c = HH_Households.ALL_PROCESSOR;
+        STG_Panel.stgService.stgCon.npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR;
+        
+        Test.setCurrentPage(Page.STG_PanelHouseholds);
+
+        STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
+        System.assertEquals(false, ctrl.isValidSettings());     
+        
+        UTIL_UnitTestData_TEST.assertPageHasError(Label.stgValidationHHAccountHHRules); 
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests that the name specs are valid in the Households panel regardless 
+        if the Automatic Household Naming is checked
+    verify:
+        isValidSettings() returns false when any Household Naming Settings field is invalid.
+        isValidSettings() returns true when all Household Naming Settings fields are valid.
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_isValidSettingsShouldValidateHHNamingSettingsRegardlessOfAutomaticHouseholdNaming() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidSettingsShouldValidateHHNamingSettingsRegardlessOfAutomaticHouseholdNaming') return;
 
         STG_PanelHouseholds_CTRL panel = new STG_PanelHouseholds_CTRL();        
 
         for (Boolean isAutomaticHouseholdNaming : new Boolean[] { true, false }) {
             STG_Panel.stgService.stgHH.npo02__Advanced_Household_Naming__c = isAutomaticHouseholdNaming;
 
-            system.assertEquals(true, panel.isValidNameFormats());        
+            system.assertEquals(true, panel.isValidSettings());        
 
             STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!bogus}}';
-            system.assertEquals(false, panel.isValidNameFormats());      
+            system.assertEquals(false, panel.isValidSettings());      
 
             STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName}} {!LastName} Family';        
             STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!bogus}}';
-            system.assertEquals(false, panel.isValidNameFormats());     
+            system.assertEquals(false, panel.isValidSettings());     
 
             STG_Panel.stgService.stgHN.Formal_Greeting_Format__c = '{!{!Salutation} {!FirstName}} {!LastName}';               
             STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!bogus}}';
-            system.assertEquals(false, panel.isValidNameFormats());     
+            system.assertEquals(false, panel.isValidSettings());     
 
             STG_Panel.stgService.stgHN.Informal_Greeting_Format__c = '{!{!FirstName}}';
-            system.assertEquals(true, panel.isValidNameFormats());   
+            system.assertEquals(true, panel.isValidSettings());   
         }     
     }
 
     /*********************************************************************************************************
     @description 
-        Tests isValidNameFormats() when Household_Name_Format__c field format is invalid
+        Tests isValidSettings() when a Household Naming Settings field is invalid
     verify:
         The method returns false.    
         The page contains an error message containing the field label.    
     **********************************************************************************************************/ 
-    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNameFormatIsInvalid() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNameFormatIsInvalid') return;
+    public static testMethod void STG_PanelHouseholds_isValidSettingsShouldAddPageErrorMessageWhenHHNamingSettingsFieldIsInvalid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidSettingsShouldAddPageErrorMessageWhenHHNamingSettingsFieldIsInvalid') return;
 
-        setupHHNamingSettings(            
-            '{!{!FirstName}} {!LastName}} Household',//invalid format
-            '{!{!Title} {!FirstName}}{!LastName}',
-            '{!{!FirstName}}'
-        );
-
-        testAndAssertPanelHouseholdPageErrorMessageFor('Household_Name_Format__c'); 
-    }
-
-    /*********************************************************************************************************
-    @description 
-        Tests isValidNameFormats() when Formal_Greeting_Format__c field format is invalid
-    verify:
-        The method returns false.    
-        The page contains an error message containing the field label.    
-    **********************************************************************************************************/ 
-    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHFormalGreetingFormatIsInvalid() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHFormalGreetingFormatIsInvalid') return;
-
-        setupHHNamingSettings(            
-            '{!{!FirstName} {!LastName}} Household',
-            '{!{!Title} {!FirstName}}}{!LastName}',//invalid format
-            '{!{!FirstName}}'
-        );
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household';//invalid format
         
-        testAndAssertPanelHouseholdPageErrorMessageFor('Formal_Greeting_Format__c'); 
-    }
-
-    /*********************************************************************************************************
-    @description 
-        Tests isValidNameFormats() when Informal_Greeting_Format__c field format is invalid
-    verify:
-        The method returns false.    
-        The page contains an error message containing the field label.    
-    **********************************************************************************************************/ 
-    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHInformalGreetingFormatIsInvalid() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHInformalGreetingFormatIsInvalid') return;
-
-        setupHHNamingSettings(            
-            '{!{!FirstName} {!LastName}} Household',
-            '{!{!Title} {!FirstName}}{!LastName}',
-            '{!{!FirstName}}}'//invalid format 
-        );
-
-        testAndAssertPanelHouseholdPageErrorMessageFor('Informal_Greeting_Format__c'); 
-    }
-
-    /*********************************************************************************************************
-    @description 
-        Tests isValidNameFormats() when a Household Naming Settings field format is invalid
-    verify:
-        The method returns false.    
-        The page contains an error message containing the field label.    
-    **********************************************************************************************************/ 
-    static void testAndAssertPanelHouseholdPageErrorMessageFor(String fieldName) {
         Test.setCurrentPage(Page.STG_PanelHouseholds);
 
         STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
-        System.assertEquals(false, ctrl.isValidNameFormats());      
+        System.assertEquals(false, ctrl.isValidSettings());      
         
         String fieldLabel = UTIL_Describe.getFieldLabel(
             UTIL_Namespace.StrTokenNSPrefix('Household_Naming_Settings__c'), 
-            UTIL_Namespace.StrTokenNSPrefix(fieldName)
+            UTIL_Namespace.StrTokenNSPrefix('Household_Name_Format__c')
         );
         
         UTIL_UnitTestData_TEST.assertPageHasError(fieldLabel); 
@@ -365,27 +338,79 @@ public with sharing class STG_SettingsManager_TEST {
 
     /*********************************************************************************************************
     @description 
-        Tests isValidNameFormats() when a Household Naming Settings field contains invalid API name 
+        Tests that isValidSettings() validates user changed Household Naming Settings 
     verify:
-        The method returns false.    
-        The page contains an error message containing the user specified field name.    
+        The method returns false if a Household Naming Settings field is invalid 
     **********************************************************************************************************/ 
-    public static testMethod void STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNamingContactFieldIsNotCaseSensitiveApiName() {
-        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidNameFormatsShouldAddPageErrorMessageWhenHHNamingContactFieldIsNotCaseSensitiveApiName') return;
-
-        setupHHNamingSettings(            
-            '{!{!FirstName} {!lastname}} Household', //lastname is not a correct case sensitive API Name
-            '{!{!Title} {!FirstName}}{!LastName}',
-            '{!{!FirstName}}'
-        );
-
+    public static testMethod void STG_PanelHouseholds_isValidSettingsShouldValidateUserChangesOfHHNamingSettings() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_isValidSettingsShouldValidateUserChangesOfHHNamingSettings') return;
+        
+        setupHHNamingSettings();
+        
         Test.setCurrentPage(Page.STG_PanelHouseholds);
 
         STG_PanelHouseholds_CTRL ctrl = new STG_PanelHouseholds_CTRL();
-        System.assertEquals(false, ctrl.isValidNameFormats());     
+        System.assertEquals(true, ctrl.isValidSettings());      
+        
+        STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName}} {!LastName}} Household'; //invalid format        
+        System.assertEquals(false, ctrl.isValidSettings());    
+        UTIL_UnitTestData_TEST.assertPageHasError('Invalid field'); 
 
-        String expectedMessage = String.format(Label.stgErrorInvalidFieldApiName, new String[]{ 'lastname' }); 
-        UTIL_UnitTestData_TEST.assertPageHasError(expectedMessage); 
+        STG_Panel.stgService.stgHN.Household_Name_Format__c = '{!{!FirstName} {!LastName}} Household'; 
+        System.assertEquals(true, ctrl.isValidSettings());      
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests strNameSpecExample when a Household Naming Settings format field is invalid
+    verify:
+        The method throws an exception
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_strNameSpecExampleShouldThrowExceptionWhenHHNamingSettingsFieldIsInvalid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_strNameSpecExampleShouldThrowExceptionWhenHHNamingSettingsFieldIsInvalid') return;
+        
+        setupInvalidHHNamingSettings();
+
+        try {
+            String exampleName = STG_PanelHouseholds_CTRL.strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2);
+
+            System.assert(false, 'Expected exception for invalid format field');
+        } catch(Exception e) {
+            System.assert(e.getMessage().contains('Invalid field'));
+        }    
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests strNameSpecExample when a Household Name Format field is valid
+    verify:
+        The method returns a Household Name example 
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_strNameSpecExampleShouldReturnHouseholdNameExampleWhenHHNameFormatFieldIsValid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_strNameSpecExampleShouldReturnHouseholdNameExampleWhenHHNameFormatFieldIsValid') return;
+        
+        setupHHNamingSettings();
+
+        String exampleName = STG_PanelHouseholds_CTRL.strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2);
+
+        System.assert(!String.isBlank(exampleName));
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Tests strNameSpecExample when Implementing Class is invalid
+    verify:
+        The method returns an error message
+    **********************************************************************************************************/ 
+    public static testMethod void STG_PanelHouseholds_strNameSpecExampleShouldReturnErrorMessageWhenImplementingClassIsInvalid() {
+        if (strTestOnly != '*' && strTestOnly != 'STG_PanelHouseholds_strNameSpecExampleShouldReturnErrorMessageWhenImplementingClassIsInvalid') return;
+        
+        Household_Naming_Settings__c settings = setupHHNamingSettings();
+        settings.Implementing_Class__c = 'foo';
+
+        String exampleName = STG_PanelHouseholds_CTRL.strNameSpecExample(STG_Panel.stgService.stgHN, 'Household_Name_Format__c', 2);
+
+        System.assertEquals(Label.stgErrorInvalidClass, exampleName);
     }
 
     /*********************************************************************************************************
@@ -1182,10 +1207,10 @@ public with sharing class STG_SettingsManager_TEST {
 
     /*********************************************************************************************************
     * @description Configures Household Naming Settings with invalid Name and Greetings formats
-    * @return void
+    * @return Household_Naming_Settings__c
     **********************************************************************************************************/
-    private static void setupInvalidHHNamingSettings() {
-        setupHHNamingSettings(
+    private static Household_Naming_Settings__c setupInvalidHHNamingSettings() {
+        return setupHHNamingSettings(
             '{!{!FirstName}} {!LastName}} Household',
             '{!{!Title} {!FirstName}}}{!LastName}',
             '{!{!FirstName}}}'
@@ -1194,10 +1219,10 @@ public with sharing class STG_SettingsManager_TEST {
 
     /*********************************************************************************************************
     * @description Configures Household Naming Settings with valid Name and Greetings formats
-    * @return void
+    * @return Household_Naming_Settings__c
     **********************************************************************************************************/
-    private static void setupHHNamingSettings() {
-        setupHHNamingSettings(            
+    private static Household_Naming_Settings__c setupHHNamingSettings() {
+        return setupHHNamingSettings(            
             '{!{!FirstName} {!LastName}} Household',
             '{!{!Title} {!FirstName}}{!LastName}',
             '{!{!FirstName}}'
@@ -1209,10 +1234,10 @@ public with sharing class STG_SettingsManager_TEST {
     * @param hhNameFormat Household Naming Format
     * @param formalGreetingFormat Formal Greeting Format
     * @param informalGreetingFormat Informal Greeting Format
-    * @return void
+    * @return Household_Naming_Settings__c
     **********************************************************************************************************/
-    private static void setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
-        UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
+    private static Household_Naming_Settings__c setupHHNamingSettings(String hhNameFormat, String formalGreetingFormat, String informalGreetingFormat) {
+        return UTIL_CustomSettingsFacade.getHouseholdNamingSettingsForTests(
             new Household_Naming_Settings__c(
                 Household_Name_Format__c = hhNameFormat,
                 Formal_Greeting_Format__c = formalGreetingFormat,

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -303,6 +303,79 @@ public class UTIL_Describe {
         }
     }
 
+    /*********************************************************************************************************
+    * @description Validates if field name is a valid API Name for an Sobject 
+    * @param fieldName Field name
+    * @param fieldResultsByFieldName The Sobject's field results mapped by a field name or a relationship name
+    * @return Boolean
+    */
+    public static Boolean isValidApiName(String fieldName, Map<String, Schema.DescribeFieldResult> fieldResultsByFieldName) {
+        if (String.isBlank(fieldName)) {
+            return false;
+        }
+
+        if (fieldResultsByFieldName.keySet().contains(fieldName)) {
+            return true;
+        }
+
+        String[] nameParts = fieldName.split('\\.');
+        Boolean isReferenceField = nameParts.size() > 1;
+
+        if (!isReferenceField) { 
+            return false;
+        }
+        
+        String relationshipName = nameParts[0];
+        String referenceFieldName = fieldName.substringAfter('.');
+
+        return isValidApiNameOnReferenceSobject(referenceFieldName, fieldResultsByFieldName.get(relationshipName));
+    }
+
+    /*********************************************************************************************************
+    * @description Validates if field name is a valid API Name for the referenced Sobject 
+    * @param fieldName Field name
+    * @param referenceFieldResult The reference (Lookup, M-D) field result
+    * @return Boolean
+    */
+    private static Boolean isValidApiNameOnReferenceSobject(String fieldName, Schema.DescribeFieldResult referenceFieldResult) {
+        Schema.SObjectType[] references = referenceFieldResult == null 
+            ? null 
+            : referenceFieldResult.getReferenceTo();
+
+        if (String.isBlank(fieldName) || references == null) { 
+            return false; 
+        }
+
+        for (Schema.SObjectType referenceTo : references) {
+            if (isValidApiName(fieldName, getFieldResultsByName(referenceTo))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /*********************************************************************************************************
+    * @description Returns Sobject field results mapped by a field name or a relationship name
+    * @param sobjectType Schema.SobjectType
+    * @return Map<String, Schema.DescribeFieldResult>
+    */
+    public static Map<String, Schema.DescribeFieldResult> getFieldResultsByName(Schema.SobjectType sobjectType) {
+        Map<String, Schema.DescribeFieldResult> fieldResults = new Map<String, Schema.DescribeFieldResult>();
+
+        for (Schema.SObjectField field : sobjectType.getDescribe().fields.getMap().values()) {
+            Schema.DescribeFieldResult fieldResult = field.getDescribe();
+
+            fieldResults.put(fieldResult.getName(), fieldResult);
+
+            if (String.isNotBlank(fieldResult.getRelationshipName())) {
+                fieldResults.put(fieldResult.getRelationshipName(), fieldResult);
+            }
+        }
+
+        return fieldResults;
+    }
+
     /*******************************************************************************************************
     * @description utility to check for compatible datatypes for data copying
     * @param dtSrc the DisplayType of the source object

--- a/src/classes/UTIL_Describe_TEST.cls
+++ b/src/classes/UTIL_Describe_TEST.cls
@@ -84,6 +84,72 @@ public with sharing class UTIL_Describe_TEST {
         } catch (exception e) {
             system.assertEquals('Invalid field name \'sdlkfjsdlkfjsldkfjlsdkfj\'', e.getMessage());
         } 
-    }       
+    }  
+
+    /*********************************************************************************************************
+    @description
+        Test getFieldResultsByName() for an Sobject
+    verify:
+        The method returns field results by the field name or relationship name for the specified Sobject
+    **********************************************************************************************************/ 
+    private static testMethod void getFieldResultsByNameShouldReturnFieldResultsForAnSobject() {
+        Map<String, Schema.DescribeFieldResult> fieldResultsByName = UTIL_Describe.getFieldResultsByName(Contact.SObjectType);
+
+        for (String fieldName : new String[] {
+            'FirstName', 'AccountId', 'Account', 'OwnerId', 'Owner'
+        }) {
+            System.assert(fieldResultsByName.containsKey(fieldName), fieldName + ' should be in Contact fields: ' + fieldResultsByName.keySet());
+        }
+        
+        fieldResultsByName = UTIL_Describe.getFieldResultsByName(Opportunity.SObjectType);
+
+        for (String fieldName : new String[] {
+            'Name', 'StageName', 'AccountId', 'Account'
+        }) {
+            System.assert(fieldResultsByName.containsKey(fieldName), fieldName + ' should be in Opportunity fields: ' + fieldResultsByName.keySet());
+        }
+    }
+
+    /*********************************************************************************************************
+    @description
+        Test isValidApiName() when a field is valid case sensitive API Name for the Sobject
+    verify:
+        The method returns true
+    **********************************************************************************************************/ 
+    private static testMethod void isValidApiNameShouldReturnTrueWhenFieldNameIsValid() {
+        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = UTIL_Describe.getFieldResultsByName(Contact.SObjectType);
+
+        for (String fieldName : new String[] {
+            'Name', 'FirstName', 'LastName',
+            'AccountId', 'Account.Id', 'Account.Name', 
+            'Account.BillingCity', 'Account.npe01__One2OneContact__c',
+            'Account.npe01__One2OneContact__r.LastName',
+            'OwnerId', 'Owner.Name'
+        }) {
+            System.assert(UTIL_Describe.isValidApiName(fieldName, contactFieldResultsByName), fieldName + ' should be valid');
+        }
+    }
+
+    /*********************************************************************************************************
+    @description
+        Test isValidApiName() when a field name is invalid case sensitive API Name for the Sobject
+    verify:
+        The method returns false
+    **********************************************************************************************************/ 
+    private static testMethod void isValidApiNameShouldReturnFalseWhenFieldNameIsInvalid() {
+        Map<String, Schema.DescribeFieldResult> contactFieldResultsByName = UTIL_Describe.getFieldResultsByName(Contact.SObjectType);
+
+        for (String fieldName : new String[] {
+            null, '', ' ',
+            'firstname', 'Firstname', 'FirstName__c',
+            'foo', 'Account.foo', 
+            'Account.npe01__One2OneContact__r.foo',
+            'Account.npe01__One2OneContact__r.',
+            'Account.npe01__One2OneContact__c.foo',
+            'Owner.foo'
+        }) {
+            System.assert(!UTIL_Describe.isValidApiName(fieldName, contactFieldResultsByName), fieldName + ' should be invalid');
+        }
+    }     
 
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4098,7 +4098,7 @@ To view these jobs, search for Scheduled Jobs in Salesforce Setup.</value>
         <fullName>stgErrorInvalidApiName</fullName>
         <categories>Settings</categories>
         <language>en_US</language>
-        <protected>false</protected>
+        <protected>true</protected>
         <shortDescription>stgErrorInvalidApiName</shortDescription>
         <value>The field name {0} is not the correct case sensitive API Name</value>
     </labels>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4095,6 +4095,14 @@ To view these jobs, search for Scheduled Jobs in Salesforce Setup.</value>
         <value>Error in {0}: {1}</value>
     </labels>
     <labels>
+        <fullName>stgErrorInvalidApiName</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>stgErrorInvalidApiName</shortDescription>
+        <value>The field name {0} is not the correct case sensitive API Name</value>
+    </labels>
+    <labels>
         <fullName>stgHHNameRefreshTitle</fullName>
         <categories>Settings</categories>
         <language>en_US</language>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4100,7 +4100,7 @@ To view these jobs, search for Scheduled Jobs in Salesforce Setup.</value>
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>stgErrorInvalidApiName</shortDescription>
-        <value>The field name {0} is not the correct case sensitive API Name</value>
+        <value>The naming format fields are case sensitive. The field, {0}, does not match the correct case of the API field name.</value>
     </labels>
     <labels>
         <fullName>stgHHNameRefreshTitle</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1339,8 +1339,8 @@
         <members>stgDocumentation</members>
         <members>stgDontAutoScheduleHelpText</members>
         <members>stgErrorINaming</members>
+        <members>stgErrorInvalidApiName</members>
         <members>stgErrorInvalidClass</members>
-        <members>stgErrorInvalidFieldApiName</members>
         <members>stgErrorInvalidNameFormat</members>
         <members>stgHHNameRefreshTitle</members>
         <members>stgHelpAccountModel</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -124,6 +124,8 @@
         <members>HH_HouseholdNaming</members>
         <members>HH_HouseholdNaming_BATCH</members>
         <members>HH_HouseholdNaming_TEST</members>
+		<members>HH_HouseholdNamingSettingValidator</members>
+		<members>HH_HouseholdNamingSettingValidator_TEST</members>
         <members>HH_Households</members>
         <members>HH_Households_TDTM</members>
         <members>HH_Households_TEST</members>
@@ -1338,6 +1340,7 @@
         <members>stgDontAutoScheduleHelpText</members>
         <members>stgErrorINaming</members>
         <members>stgErrorInvalidClass</members>
+        <members>stgErrorInvalidFieldApiName</members>
         <members>stgErrorInvalidNameFormat</members>
         <members>stgHHNameRefreshTitle</members>
         <members>stgHelpAccountModel</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -124,8 +124,8 @@
         <members>HH_HouseholdNaming</members>
         <members>HH_HouseholdNaming_BATCH</members>
         <members>HH_HouseholdNaming_TEST</members>
-		<members>HH_HouseholdNamingSettingValidator</members>
-		<members>HH_HouseholdNamingSettingValidator_TEST</members>
+        <members>HH_HouseholdNamingSettingValidator</members>
+        <members>HH_HouseholdNamingSettingValidator_TEST</members>
         <members>HH_Households</members>
         <members>HH_Households_TDTM</members>
         <members>HH_Households_TEST</members>

--- a/src/pages/STG_PanelHouseholds.page
+++ b/src/pages/STG_PanelHouseholds.page
@@ -63,7 +63,7 @@
 
     // initialize the format selectlists in case they need to display other,
     // and set our examples, when the user goes into edit mode.
-    function initEditMode() {
+    function initOtherFields() {
         initSelectListsForOther('slstrFormatHH', 'txtFormatHH');
         initSelectListsForOther('slstrFormatFG', 'txtFormatFG');
         initSelectListsForOther('slstrFormatIG', 'txtFormatIG');
@@ -116,7 +116,7 @@
         <c:STG_PageHeader sectionLabel="{!$Label.stgNavPeople}" pageLabel="{!$Label.stgLabelHHSettings}" />
         <c:UTIL_PageMessages />
         <div class="slds-grid slds-grid--align-center slds-grid--vertical-align-center slds-m-around--large">
-            <apex:commandButton id="editHouseholds" value="{!$Label.stgBtnEdit}" status="statusLoad" action="{!editSettings}" oncomplete="initEditMode();" rendered="{!isReadOnlyMode}" immediate="true" rerender="form" styleClass="slds-button slds-button--neutral" />
+            <apex:commandButton id="editHouseholds" value="{!$Label.stgBtnEdit}" status="statusLoad" action="{!editSettings}" oncomplete="initOtherFields();" rendered="{!isReadOnlyMode}" immediate="true" rerender="form" styleClass="slds-button slds-button--neutral" />
         </div>
 
         <div class="slds-section-title--divider">{!$Label.stgLabelHHNaming}</div>
@@ -308,7 +308,7 @@
             </div>
         </div>
         <div class="slds-grid slds-grid--align-center slds-grid--vertical-align-center slds-m-around--large">
-            <apex:commandButton id="saveHouseholds" value="{!$Label.stgBtnSave}" status="statusLoad" action="{!saveSettings}" rendered="{!isEditMode}" immediate="false" rerender="form" styleClass="slds-button slds-button--small slds-button--brand" />
+            <apex:commandButton id="saveHouseholds" value="{!$Label.stgBtnSave}" status="statusLoad" action="{!saveSettings}" oncomplete="initOtherFields();" rendered="{!isEditMode}" immediate="false" rerender="form" styleClass="slds-button slds-button--small slds-button--brand" />
             <apex:commandButton id="cancelHouseholds" value="{!$Label.stgBtnCancel}" status="statusLoad" action="{!cancelEdit}" rendered="{!isEditMode}" immediate="true" rerender="form" styleClass="slds-button slds-button--small slds-button--neutral" />
         </div>
     </apex:form>


### PR DESCRIPTION
# Critical Changes

# Changes
When NPSP Settings > Household Naming Settings are saved, they are validated whether Automatic Household Naming is checked or not. Moreover, the settings validation will be done when NPSP Settings > Refresh Household Names button is clicked on and if the Automatic Household Naming is not checked. The Automatic Household Naming will be checked and the batch process will execute only if the Household Naming Settings are valid.

# Issues Closed
Fixes #2476