### PR TITLE
Multi-Currency Support for UDRs

### DIFF
--- a/src/classes/RLLP_OppRollup.cls
+++ b/src/classes/RLLP_OppRollup.cls
@@ -885,12 +885,23 @@ public without sharing class RLLP_OppRollup {
         
         //deal with user rollups
         if (RLLP_OppRollup_UTIL.urfsMap.size() > 0){
+
             for (string s : RLLP_OppRollup_UTIL.urfsMap.keyset()){
-                if (obj.getSObjectType().getDescribe().getName() == RLLP_OppRollup_UTIL.urfsMap.get(s).npo02__Object_Name__c){
+
+                if (obj.getSObjectType().getDescribe().getName() == RLLP_OppRollup_UTIL.urfsMap.get(s).npo02__Object_Name__c) {
+
                     npo02__User_Rollup_Field_Settings__c urfs = RLLP_OppRollup_UTIL.urfsMap.get(s);
-                    string x = urfs.Name;                   
-                    if (r.get(x) != null)
-                       obj.put(urfs.npo02__Target_Field__c, r.get(x));
+                    string x = urfs.Name;
+                    Schema.DescribeFieldResult f = UTIL_Describe.getFieldDescribe('Opportunity', RLLP_OppRollup_UTIL.urfsMap.get(s).npo02__Source_Field__c);
+
+                    if (r.get(x) != null) {
+                        // calculate amounts into correct currency if needed, and only if source is a Currency field. Assumes that the UDR config is valid.
+                        if (f.getType() == Schema.Displaytype.Currency && RLLP_OppRollup_UTIL.isMultiCurrency()) {
+                            obj.put(urfs.npo02__Target_Field__c, RLLP_OppRollup_UTIL.ConvertFromCorporate((string) obj.get('CurrencyIsoCode'), (decimal) r.get(x)));
+                        } else {
+                            obj.put(urfs.npo02__Target_Field__c, r.get(x));
+                        }
+                    }
                 }
             }
         } 

--- a/src/classes/RLLP_OppRollup_TEST2.cls
+++ b/src/classes/RLLP_OppRollup_TEST2.cls
@@ -339,13 +339,13 @@ public with sharing class RLLP_OppRollup_TEST2 {
         testUserRollup1.Name = 'TestRollup8675309';
         testURFS.add(TestUserRollup1);
 
-        npo02__User_Rollup_Field_Settings__c TestUserRollup2 = new npo02__User_Rollup_Field_Settings__c();
+        npo02__User_Rollup_Field_Settings__c testUserRollup2 = new npo02__User_Rollup_Field_Settings__c();
         testUserRollup2.npo02__Target_Field__c = 'NumberOfEmployees'; 
         testUserRollup2.npo02__Source_Field__c = 'FiscalYear';
         testUserRollup2.npo02__Object_Name__c = 'Account'; 
         testUserRollup2.npo02__Field_Action__c = 'MAX';
         testUserRollup2.Name = 'TestRollup2';
-        testURFS.add(TestUserRollup2);
+        testURFS.add(testUserRollup2);
 
         npo02__User_Rollup_Field_Settings__c testUserRollup3 = new npo02__User_Rollup_Field_Settings__c();
         testUserRollup3.npo02__Target_Field__c = 'npo02__LastCloseDate__c'; 
@@ -353,8 +353,15 @@ public with sharing class RLLP_OppRollup_TEST2 {
         testUserRollup3.npo02__Object_Name__c = 'npo02__Household__c'; 
         testUserRollup3.npo02__Field_Action__c = 'MAX';
         testUserRollup3.Name = 'TestRollup3';
-        testURFS.add(TestUserRollup3);
+        testURFS.add(testUserRollup3);
 
+        npo02__User_Rollup_Field_Settings__c testUserRollup4 = new npo02__User_Rollup_Field_Settings__c();
+        testUserRollup4.npo02__Target_Field__c = 'AnnualRevenue';
+        testUserRollup4.npo02__Source_Field__c = 'Amount';
+        testUserRollup4.npo02__Object_Name__c = 'Account';
+        testUserRollup4.npo02__Field_Action__c = 'SUM';
+        testUserRollup4.Name = 'TestRollup4';
+        testURFS.add(testUserRollup4);
         insert testURFS; 
 
         Contact c = new Contact(LastName = 'Lastname', BirthDate = system.today().addDays(-4));
@@ -373,7 +380,7 @@ public with sharing class RLLP_OppRollup_TEST2 {
             }
 
         map<string, npo02__User_Rollup_Field_Settings__c> urfsMap = UTIL_ListCustomSettingsFacade.getMapUserRollupFieldSettings();
-        system.assertEquals(3, urfsMap.keySet().size());                    
+        system.assertEquals(4, urfsMap.keySet().size());
 
         Test.StartTest();
         insert newOpp;


### PR DESCRIPTION
Allow UDRs to detect if they are aggregating a currency and if so
convert that value correctly. Added test which exercises the routine if
tested in a multicurrency environment