### PR TITLE
Fix apex cpu timeout in TDTM_DMLgt200_TEST class

### DIFF
--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -51,9 +51,9 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_contacts_with_affiliations() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableRelationshipTriggers();
-        disableUnusedContactTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableRelationshipTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
 
         npe5__Affiliations_Settings__c affiliationsSettingsForTests = UTIL_CustomSettingsFacade.getAffiliationsSettingsForTests(
                 new npe5__Affiliations_Settings__c(npe5__Automatic_Affiliation_Creation_Turned_On__c = true));
@@ -102,9 +102,9 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_contacts_with_primary_affiliations() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableRelationshipTriggers();
-        disableUnusedContactTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableRelationshipTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
 
         npe5__Affiliations_Settings__c affiliationsSettingsForTests = UTIL_CustomSettingsFacade.getAffiliationsSettingsForTests(
                 new npe5__Affiliations_Settings__c(npe5__Automatic_Affiliation_Creation_Turned_On__c = true));
@@ -140,8 +140,9 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_contacts_with_relationships() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableAffiliationsTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableAffiliationsTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
 
         Test.startTest();
 
@@ -184,9 +185,10 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_opportunities_with_default_alloc() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableRollupTriggers();
-        disableUnusedContactTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableRollupTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
+        UTIL_UnitTestData_TEST.disableOppNonOCRTriggers();
 
         Contact c = UTIL_UnitTestData_TEST.getContact();
         insert c;
@@ -255,10 +257,11 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_recurring_donations() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableRollupTriggers();
-        disableUnusedContactTriggers();
-        disableOCRTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableRollupTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
+        UTIL_UnitTestData_TEST.disableOCRTriggers();
+        UTIL_UnitTestData_TEST.disableOppNonOCRTriggers();
 
         Contact c = UTIL_UnitTestData_TEST.getContact();
         insert c;
@@ -301,11 +304,11 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_addresses() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableAffiliationsTriggers();
-        disableRelationshipTriggers();
-        disableUnusedContactTriggers();
-        disableHHNamingTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableAffiliationsTriggers();
+        UTIL_UnitTestData_TEST.disableRelationshipTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
+        UTIL_UnitTestData_TEST.disableHHNamingTriggers();
 
         Test.startTest();
 
@@ -338,10 +341,10 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_household_account_naming() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableAffiliationsTriggers();
-        disableRelationshipTriggers();
-        disableUnusedContactTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableAffiliationsTriggers();
+        UTIL_UnitTestData_TEST.disableRelationshipTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
 
         Test.startTest();
 
@@ -378,11 +381,11 @@ private class TDTM_DMLgt200_TEST {
         ADDR_Validator_TEST.createDefaultSettings();
         Test.setMock(HttpCalloutMock.class, new ADDR_MockHttpRespGenerator_TEST());
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
-        disableAffiliationsTriggers();
-        disableRelationshipTriggers();
-        disableUnusedContactTriggers();
-        disableHHNamingTriggers();
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
+        UTIL_UnitTestData_TEST.disableAffiliationsTriggers();
+        UTIL_UnitTestData_TEST.disableRelationshipTriggers();
+        UTIL_UnitTestData_TEST.disableMergeTriggers();
+        UTIL_UnitTestData_TEST.disableHHNamingTriggers();
 
         // Create more than 200 Contact records and then validate that all of the Addresses were verified
         List<Contact> contacts = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(insertCnt);
@@ -421,7 +424,7 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void testAllocationsCreatedForManyOpenEndedRecurringDonations() {
 
-        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        UTIL_Debug.disableDebugLogging();     // Override debug logging for this test because it's an expensive operation
 
         Contact c = UTIL_UnitTestData_TEST.getContact();
         insert c;
@@ -471,56 +474,6 @@ private class TDTM_DMLgt200_TEST {
 
         System.assertEquals(240, [SELECT Count() FROM Allocation__c WHERE Opportunity__c IN :createdOpportunities],
                 'There should be 240 generated default allocations records');
-    }
-
-    /* @description Disable all Affiliations related trigger handlers when not needed to improve performance */
-    private static void disableAffiliationsTriggers() {
-        createDefaultTDTMHandlers();
-        TDTM_ProcessControl.toggleTriggerState('Contact', 'AFFL_Affiliations_TDTM', false);
-        TDTM_ProcessControl.toggleTriggerState('Account', 'AFFL_Affiliations_TDTM', false);
-        TDTM_ProcessControl.toggleTriggerState('npe5__Affiliation__c', 'AFFL_Affiliations_TDTM', false);
-    }
-    /* @description Disable all Relationship related trigger handlers when not needed to improve performance */
-    private static void disableRelationshipTriggers() {
-        createDefaultTDTMHandlers();
-        TDTM_ProcessControl.toggleTriggerState('CampaignMember', 'REL_Relationships_Cm_TDTM', false);
-        TDTM_ProcessControl.toggleTriggerState('Contact', 'REL_Relationships_Con_TDTM', false);
-        TDTM_ProcessControl.toggleTriggerState('npe4__Relationship__c', 'REL_Relationships_TDTM', false);
-    }
-    /* @description Disable all OppContactRole related trigger handlers when not needed to improve performance */
-    private static void disableOCRTriggers() {
-        createDefaultTDTMHandlers();
-        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'OPP_OpportunityContactRoles_TDTM', false);
-        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'HH_OppContactRoles_TDTM', false);
-    }
-    /* @description Disable all OppRollup related trigger handlers when not needed to improve performance */
-    private static void disableRollupTriggers() {
-        createDefaultTDTMHandlers();
-        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'RLLP_OppRollup_TDTM', false);
-    }
-    /* @description Disable all Account/Contact Merge related trigger handlers when not needed to improve performance */
-    private static void disableUnusedContactTriggers() {
-        createDefaultTDTMHandlers();
-        TDTM_ProcessControl.toggleTriggerState('Contact', 'CON_ContactMerge_TDTM', false);
-        TDTM_ProcessControl.toggleTriggerState('Account', 'ACCT_AccountMerge_TDTM', false);
-    }
-    /* @description Disable all HH Naming related trigger handlers and setting when not needed to improve performance */
-    private static void disableHHNamingTriggers() {
-        createDefaultTDTMHandlers();
-        TDTM_ProcessControl.toggleTriggerState('Contact', 'HH_Households_TDTM', false);
-        UTIL_UnitTestData_TEST.turnOffAutomaticHHNaming();
-    }
-
-    /**
-     * @description Create the default trigger handler records if they haven't already been created
-     */
-    private static Boolean haveTriggerRecordsBeenCreated = false;
-    private static void createDefaultTDTMHandlers() {
-        if (!haveTriggerRecordsBeenCreated && TDTM_Config_API.getCachedRecords().size() == 0) {
-            insert TDTM_DefaultConfig.getDefaultRecords();
-            TDTM_ObjectDataGateway.ClearCachedTriggerHandlersForTest();
-            haveTriggerRecordsBeenCreated = true;
-        }
     }
 
 }

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -33,7 +33,11 @@
  * @group TDTM
  * @group-content ../../ApexDocContent/TDTM.htm
  * @description Test class to validate behavior changes related to TDTM Static Flag handling, primarily focused on
- * dml operations with more than 200 records.
+ * dml operations with more than 200 records. Unit tests in this class are generally meant to push limits beyond
+ * what most of our unit tests will normally do by inserting more than 200 records at a time. This causes Salesforce
+ * to execute each set of triggers twice (once for a block of 200 records and then again for a block of 10 records).
+ * These tests validate that all expected functionality completes properly even when the triggers are executed twice
+ * as described (i.e., we're testing that our static flag recursion control logic works properly in this scenario).
  *
 ***/
 @isTest

--- a/src/classes/TDTM_DMLgt200_TEST.cls
+++ b/src/classes/TDTM_DMLgt200_TEST.cls
@@ -51,6 +51,10 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_contacts_with_affiliations() {
 
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableRelationshipTriggers();
+        disableUnusedContactTriggers();
+
         npe5__Affiliations_Settings__c affiliationsSettingsForTests = UTIL_CustomSettingsFacade.getAffiliationsSettingsForTests(
                 new npe5__Affiliations_Settings__c(npe5__Automatic_Affiliation_Creation_Turned_On__c = true));
 
@@ -98,6 +102,10 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_contacts_with_primary_affiliations() {
 
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableRelationshipTriggers();
+        disableUnusedContactTriggers();
+
         npe5__Affiliations_Settings__c affiliationsSettingsForTests = UTIL_CustomSettingsFacade.getAffiliationsSettingsForTests(
                 new npe5__Affiliations_Settings__c(npe5__Automatic_Affiliation_Creation_Turned_On__c = true));
 
@@ -131,6 +139,9 @@ private class TDTM_DMLgt200_TEST {
     */
     @isTest
     static void test_contacts_with_relationships() {
+
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableAffiliationsTriggers();
 
         Test.startTest();
 
@@ -172,6 +183,10 @@ private class TDTM_DMLgt200_TEST {
     */
     @isTest
     static void test_opportunities_with_default_alloc() {
+
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableRollupTriggers();
+        disableUnusedContactTriggers();
 
         Contact c = UTIL_UnitTestData_TEST.getContact();
         insert c;
@@ -240,6 +255,11 @@ private class TDTM_DMLgt200_TEST {
     @isTest
     static void test_recurring_donations() {
 
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableRollupTriggers();
+        disableUnusedContactTriggers();
+        disableOCRTriggers();
+
         Contact c = UTIL_UnitTestData_TEST.getContact();
         insert c;
 
@@ -280,6 +300,13 @@ private class TDTM_DMLgt200_TEST {
     */
     @isTest
     static void test_addresses() {
+
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableAffiliationsTriggers();
+        disableRelationshipTriggers();
+        disableUnusedContactTriggers();
+        disableHHNamingTriggers();
+
         Test.startTest();
 
         // Create more than 200 Contact records and then validate that all of the Household Accounts were created
@@ -310,18 +337,16 @@ private class TDTM_DMLgt200_TEST {
     */
     @isTest
     static void test_household_account_naming() {
+
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableAffiliationsTriggers();
+        disableRelationshipTriggers();
+        disableUnusedContactTriggers();
+
         Test.startTest();
 
         // Create more than 200 Contact records and then validate that all of the Household Accounts were created
         List<Contact> contacts = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(insertCnt);
-        for (Contact c : contacts) {
-            c.OtherCity = null;
-            c.MailingStreet = '1313 Mockingbird Lane';
-            c.MailingCity = 'Munsterville';
-            c.MailingState = 'Illinois';
-            c.MailingPostalCode = '06123';
-            c.MailingCountry = 'United States';
-        }
         Database.DMLOptions dml = new Database.DMLOptions();
         dml.DuplicateRuleHeader.AllowSave = true;
         Database.insert(contacts, dml);
@@ -352,6 +377,12 @@ private class TDTM_DMLgt200_TEST {
 
         ADDR_Validator_TEST.createDefaultSettings();
         Test.setMock(HttpCalloutMock.class, new ADDR_MockHttpRespGenerator_TEST());
+
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
+        disableAffiliationsTriggers();
+        disableRelationshipTriggers();
+        disableUnusedContactTriggers();
+        disableHHNamingTriggers();
 
         // Create more than 200 Contact records and then validate that all of the Addresses were verified
         List<Contact> contacts = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(insertCnt);
@@ -389,6 +420,8 @@ private class TDTM_DMLgt200_TEST {
      */
     @isTest
     static void testAllocationsCreatedForManyOpenEndedRecurringDonations() {
+
+        UTIL_Debug.enabled = false;     // Override debug logging for this test because it's an expensive operation
 
         Contact c = UTIL_UnitTestData_TEST.getContact();
         insert c;
@@ -439,4 +472,55 @@ private class TDTM_DMLgt200_TEST {
         System.assertEquals(240, [SELECT Count() FROM Allocation__c WHERE Opportunity__c IN :createdOpportunities],
                 'There should be 240 generated default allocations records');
     }
+
+    /* @description Disable all Affiliations related trigger handlers when not needed to improve performance */
+    private static void disableAffiliationsTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'AFFL_Affiliations_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Account', 'AFFL_Affiliations_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('npe5__Affiliation__c', 'AFFL_Affiliations_TDTM', false);
+    }
+    /* @description Disable all Relationship related trigger handlers when not needed to improve performance */
+    private static void disableRelationshipTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('CampaignMember', 'REL_Relationships_Cm_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'REL_Relationships_Con_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('npe4__Relationship__c', 'REL_Relationships_TDTM', false);
+    }
+    /* @description Disable all OppContactRole related trigger handlers when not needed to improve performance */
+    private static void disableOCRTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'OPP_OpportunityContactRoles_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'HH_OppContactRoles_TDTM', false);
+    }
+    /* @description Disable all OppRollup related trigger handlers when not needed to improve performance */
+    private static void disableRollupTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'RLLP_OppRollup_TDTM', false);
+    }
+    /* @description Disable all Account/Contact Merge related trigger handlers when not needed to improve performance */
+    private static void disableUnusedContactTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'CON_ContactMerge_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Account', 'ACCT_AccountMerge_TDTM', false);
+    }
+    /* @description Disable all HH Naming related trigger handlers and setting when not needed to improve performance */
+    private static void disableHHNamingTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'HH_Households_TDTM', false);
+        UTIL_UnitTestData_TEST.turnOffAutomaticHHNaming();
+    }
+
+    /**
+     * @description Create the default trigger handler records if they haven't already been created
+     */
+    private static Boolean haveTriggerRecordsBeenCreated = false;
+    private static void createDefaultTDTMHandlers() {
+        if (!haveTriggerRecordsBeenCreated && TDTM_Config_API.getCachedRecords().size() == 0) {
+            insert TDTM_DefaultConfig.getDefaultRecords();
+            TDTM_ObjectDataGateway.ClearCachedTriggerHandlersForTest();
+            haveTriggerRecordsBeenCreated = true;
+        }
+    }
+
 }

--- a/src/classes/UTIL_Debug.cls
+++ b/src/classes/UTIL_Debug.cls
@@ -102,7 +102,11 @@ public class UTIL_Debug {
     }
 
     /*******************************************************************************************************
-    * @description Force the enabled static var to false regardless of the Test.isRunningTest() or custom settings value.
+    * @description Force the enabled static var to false regardless of the Test.isRunningTest() or custom
+    * settings value to prevent all system.debug() logging through this class. Debug statements can be
+    * expensive in terms of cpu time especially if they're called repitively in loops, through recursive
+    * triggers, or repetitive operations. Disabling debug statements can help reduce the change of an apex
+    * cpu time out in a unit test.
     */
     public static void disableDebugLogging() {
         enabled = false;

--- a/src/classes/UTIL_Debug.cls
+++ b/src/classes/UTIL_Debug.cls
@@ -100,4 +100,12 @@ public class UTIL_Debug {
             );
         }
     }
+
+    /*******************************************************************************************************
+    * @description Force the enabled static var to false regardless of the Test.isRunningTest() or custom settings value.
+    */
+    public static void disableDebugLogging() {
+        enabled = false;
+    }
+
 }

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -645,4 +645,65 @@ public class UTIL_UnitTestData_TEST {
         );
     }
 
+    // =====================================================================================================
+    // Methods to disable blocks of TDTM trigger handlers to aid in staying within unit test governor limits
+    // =====================================================================================================
+
+    /* @description Disable all Affiliations related trigger handlers when not needed to improve performance */
+    public static void disableAffiliationsTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'AFFL_Affiliations_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Account', 'AFFL_Affiliations_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('npe5__Affiliation__c', 'AFFL_Affiliations_TDTM', false);
+    }
+    /* @description Disable all Relationship related trigger handlers when not needed to improve performance */
+    public static void disableRelationshipTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('CampaignMember', 'REL_Relationships_Cm_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'REL_Relationships_Con_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('npe4__Relationship__c', 'REL_Relationships_TDTM', false);
+    }
+    /* @description Disable all OppContactRole elated trigger handlers when not needed to improve performance */
+    public static void disableOCRTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'OPP_OpportunityContactRoles_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'HH_OppContactRoles_TDTM', false);
+    }
+    /* @description Disable all non-OCR related Opportunity trigger handlers when not needed to improve performance */
+    public static void disableOppNonOCRTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'MTCH_Opportunity_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'PSC_Opportunity_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'OPP_CampaignMember_TDTM', false);
+    }
+    /* @description Disable all OppRollup related trigger handlers when not needed to improve performance */
+    public static void disableRollupTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Opportunity', 'RLLP_OppRollup_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Task', 'EP_TaskRollup_TDTM', false);
+    }
+    /* @description Disable all Account/Contact Merge related trigger handlers when not needed to improve performance */
+    public static void disableMergeTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'CON_ContactMerge_TDTM', false);
+        TDTM_ProcessControl.toggleTriggerState('Account', 'ACCT_AccountMerge_TDTM', false);
+    }
+    /* @description Disable all HH Naming related trigger handlers and setting when not needed to improve performance */
+    public static void disableHHNamingTriggers() {
+        createDefaultTDTMHandlers();
+        TDTM_ProcessControl.toggleTriggerState('Contact', 'HH_Households_TDTM', false);
+        UTIL_UnitTestData_TEST.turnOffAutomaticHHNaming();
+    }
+
+    /**
+     * @description Create the default trigger handler records if they haven't already been created
+     */
+    private static Boolean haveTriggerRecordsBeenCreated = false;
+    private static void createDefaultTDTMHandlers() {
+        if (!haveTriggerRecordsBeenCreated && TDTM_Config_API.getCachedRecords().size() == 0) {
+            insert TDTM_DefaultConfig.getDefaultRecords();
+            TDTM_ObjectDataGateway.ClearCachedTriggerHandlersForTest();
+            haveTriggerRecordsBeenCreated = true;
+        }
+    }
 }


### PR DESCRIPTION
After a lot of unit test experiments with increasing the number of inserted records to force crashes (still sporadic though), I made 3 sets of changes to hopefully avoid future apex cpu time out errors in this test class:

1. Add logic to disable some of the triggers that were not used at all in the test method. Applied this to most of the test methods.
2. Force disable UTIL_Debug logging in all of the unit tests where triggers are disabled. From experience, System.Debug() statements are expensive in terms of CPU cycles especially if they're being called in a loop somewhere.
3. In test_household_account_naming(), removed the update of the Contact address fields to avoid any need for the address related triggers/logic.

Once the above changes were completed I've been unable to get tests to fail even after doubling the number of records inserted. Also all testing was done in a scratch org since that appears to be more fragile in terms of CPU Timeouts than my persistent Dev Org. This will be difficult to "test" other than to let it go through the build process as many times as possible.

# Critical Changes

# Changes

# Issues Closed