### PR TITLE
Rollups + Multi-Currency: Workaround roll-up summary fields when ACM is enabled

### DIFF
--- a/src/classes/BDI_Donations_TEST.cls
+++ b/src/classes/BDI_Donations_TEST.cls
@@ -1170,13 +1170,13 @@ public with sharing class BDI_Donations_TEST {
         system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);       
         system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
         
-        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        Opportunity opp = getOpportunityWithPayments(di.DonationImported__c);
         npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
         
         system.assertEquals(false, opp.IsWon);
         system.assertEquals(false, opp.IsClosed);
         system.assertEquals(600, opp.Amount);
-        system.assertEquals(250, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(250, PMT_PaymentCreator.getAmountOutstanding(opp));
         system.assertEquals(350, pmt.npe01__Payment_Amount__c);
         system.assertEquals(true, pmt.npe01__Paid__c);
     }
@@ -1282,13 +1282,13 @@ public with sharing class BDI_Donations_TEST {
         system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
         system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
 
-        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        Opportunity opp = getOpportunityWithPayments(di.DonationImported__c);
         npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
 
         system.assertEquals(false, opp.IsWon);
         system.assertEquals(false, opp.IsClosed);
         system.assertEquals(48, opp.Amount);
-        system.assertEquals(36, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(36, PMT_PaymentCreator.getAmountOutstanding(opp));
         system.assertEquals(12, pmt.npe01__Payment_Amount__c);
         system.assertEquals(true, pmt.npe01__Paid__c);
     }
@@ -1322,13 +1322,13 @@ public with sharing class BDI_Donations_TEST {
         system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
         system.assertEquals(label.bdiMatchedBest, di.PaymentImportStatus__c);
 
-        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        Opportunity opp = getOpportunityWithPayments(di.DonationImported__c);
         npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c, npe01__Scheduled_Date__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
 
         system.assertEquals(false, opp.IsWon);
         system.assertEquals(false, opp.IsClosed);
         system.assertEquals(48, opp.Amount);
-        system.assertEquals(36, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(36, PMT_PaymentCreator.getAmountOutstanding(opp));
         system.assertEquals(12, pmt.npe01__Payment_Amount__c);
         system.assertEquals(true, pmt.npe01__Paid__c);
         system.assertEquals(system.Today(), pmt.npe01__Scheduled_Date__c);
@@ -1363,13 +1363,13 @@ public with sharing class BDI_Donations_TEST {
         system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
         system.assertEquals(label.bdiMatchedBest, di.PaymentImportStatus__c);
 
-        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        Opportunity opp = getOpportunityWithPayments(di.DonationImported__c);
         npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c, npe01__Scheduled_Date__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
 
         system.assertEquals(false, opp.IsWon);
         system.assertEquals(false, opp.IsClosed);
         system.assertEquals(48, opp.Amount);
-        system.assertEquals(36, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(36, PMT_PaymentCreator.getAmountOutstanding(opp));
         system.assertEquals(12, pmt.npe01__Payment_Amount__c);
         system.assertEquals(true, pmt.npe01__Paid__c);
         system.assertEquals(system.Today()+1, pmt.npe01__Scheduled_Date__c);
@@ -1425,13 +1425,13 @@ public with sharing class BDI_Donations_TEST {
         system.assertEquals(label.bdiMatched, di.DonationImportStatus__c);
         system.assertEquals(label.bdiMatched, di.PaymentImportStatus__c);
 
-        Opportunity opp = [select Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c from Opportunity where id = :di.DonationImported__c];
+        Opportunity opp = getOpportunityWithPayments(di.DonationImported__c);
         npe01__OppPayment__c pmt = [select Id, npe01__Payment_Amount__c, npe01__Paid__c, npe01__Scheduled_Date__c, npe01__Payment_Date__c from npe01__OppPayment__c where id = :di.PaymentImported__c];
 
         system.assertEquals(true, opp.IsWon);
         system.assertEquals(true, opp.IsClosed);
         system.assertEquals(15, opp.Amount);
-        system.assertEquals(0, opp.npe01__Amount_Outstanding__c);
+        system.assertEquals(0, PMT_PaymentCreator.getAmountOutstanding(opp));
         system.assertEquals(15, pmt.npe01__Payment_Amount__c);
         system.assertEquals(true, pmt.npe01__Paid__c);
         system.assertEquals(system.Today(), pmt.npe01__Payment_Date__c);
@@ -1577,5 +1577,12 @@ public with sharing class BDI_Donations_TEST {
 	        list<Opportunity> listOppX = [select Id, Name, Amount, Primary_Contact__c from Opportunity];
 	        system.assertEquals(listOpp.size(), listOppX.size());
         }
+    }
+
+    private static Opportunity getOpportunityWithPayments(Id oppId) {
+        // requery the Opportunity for all fields that we need.
+        return [SELECT Id, IsWon, IsClosed, Amount, npe01__Amount_Outstanding__c,
+            (SELECT Id, npe01__Payment_Amount__c, npe01__Written_Off__c, npe01__Paid__c FROM  npe01__OppPayment__r)
+            FROM Opportunity WHERE Id = :oppId LIMIT 1];
     }
 }

--- a/src/classes/PMT_PaymentCreator.cls
+++ b/src/classes/PMT_PaymentCreator.cls
@@ -145,7 +145,8 @@ public class PMT_PaymentCreator {
         
         npe01__Contacts_And_Orgs_Settings__c ContactSettings = UTIL_CustomSettingsFacade.getContactsSettings();
 
-        Boolean isACMEnabled = true; /* TODO: UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled(); */
+        // TODO: Update when merge with full Multi-Currency support branch
+        Boolean isACMEnabled = true; /* UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled(); */
 
         // If ACM is enabled in an organization, changes to the Payment object will not roll-up to (and cause triggers
         // to execute) on the Opportunity. The trigger on the Payment Object is used to detect a new/updated payment
@@ -396,7 +397,7 @@ public class PMT_PaymentCreator {
     * @return Decimal amount outstanding
     */
     public static Decimal getAmountOutstanding(Opportunity currentOpp) {
-        // TODO
+        // TODO: Update when merge with full Multi-Currency support branch
         if (false /* !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled() */ ) {
             return currentOpp.npe01__Amount_Outstanding__c;
         } else {
@@ -424,7 +425,7 @@ public class PMT_PaymentCreator {
     * @return Decimal total of payment records where Paid = True
     */
     public static Decimal getPaymentsMade(Opportunity currentOpp) {
-        // TODO
+        // TODO: Update when merge with full Multi-Currency support branch
         if (false /* !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled() */ ) {
             return currentOpp.npe01__Payments_Made__c;
         } else {

--- a/src/classes/PMT_PaymentCreator.cls
+++ b/src/classes/PMT_PaymentCreator.cls
@@ -370,6 +370,7 @@ public class PMT_PaymentCreator {
     * from the Payment object will not work. This method will detect that scenario and return either the
     * value from the formula or calculate the Amount Outstanding from the payment records
     * track this.
+    * @param currentOpp = Opportunity object with a subquery on all Payment records
     * @return Decimal amount outstanding
     */
     public static Decimal getAmountOutstanding(Opportunity currentOpp) {
@@ -395,9 +396,10 @@ public class PMT_PaymentCreator {
     /*******************************************************************************************************
     * @description When Advanced Currency Management is enabled in an org, the packaged rollups and formula
     * from the Payment object will not work. This method will detect that scenario and return either the
-    * value from the formula or calculate the Amount Outstanding from the payment records
+    * value from the formula or calculate the Total Payments (Paid) from the payment records
     * track this.
-    * @return Decimal amount outstanding
+    * @param currentOpp = Opportunity object with a subquery on all Payment records
+    * @return Decimal total of payment records where Paid = True
     */
     public static Decimal getPaymentsMade(Opportunity currentOpp) {
         // !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()
@@ -416,10 +418,11 @@ public class PMT_PaymentCreator {
     }
 
     /**
-     * @description Build a query string to retrieve a list of Opportunities with a subquery on the Payments object
+     * @description Build a query string to retrieve a list of Opportunities with a subquery on the Payments object.
+     * Does not include a Where clause.
      * @return SOQL string
      */
-    public static String buildOppsQuery() {
+    private static String buildOppsQuery() {
         String soqlStatement = '';
         soqlStatement += 'SELECT Id, CloseDate, Amount, isClosed, isWon, npe01__Do_Not_Automatically_Create_Payment__c, Type, ';
         if (OppRecordTypeId != null) {

--- a/src/classes/PMT_PaymentCreator.cls
+++ b/src/classes/PMT_PaymentCreator.cls
@@ -144,34 +144,53 @@ public class PMT_PaymentCreator {
         TDTM_Runnable.DMLWrapper dmlWrapper) {
         
         npe01__Contacts_And_Orgs_Settings__c ContactSettings = UTIL_CustomSettingsFacade.getContactsSettings();
-                    
+
+        Boolean isACMEnabled = true; /* TODO: UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled(); */
+
+        // If ACM is enabled in an organization, changes to the Payment object will not roll-up to (and cause triggers
+        // to execute) on the Opportunity. The trigger on the Payment Object is used to detect a new/updated payment
+        // and to handle auto-closing the Opportunity if necessary. However, if the Opportunity.Amount is updated to
+        // match the total of the payments, the Opportunity must still be closed. The issue is that when ACM is enabled
+        // the npe01__Payments_Made__c rollup field on the Opportunity does not work. In this case, we have to force
+        // a requery of the Opportunities (with a sub-query on Payments) to allow the actual Payment Amount to be
+        // queried.
+
         if (ContactSettings != null && ContactSettings.npe01__Payments_Enabled__c == true){
             list<Opportunity> newOpps = newOppsMap.values();
+            list<Opportunity> updatedOpps = new list<Opportunity>();
+            Map<Id, Opportunity> newOppsMapRequeried = new Map<Id, Opportunity>();
             list<npe01__OppPayment__c> paymentsToInsert = new list<npe01__OppPayment__c>();
             list<npe01__OppPayment__c> paymentsToUpdate = new list<npe01__OppPayment__c>();
             list<npe01__OppPayment__c> paymentsToDelete = new list<npe01__OppPayment__c>();
-            list<Opportunity> updatedOpps = new list<Opportunity>();
-            
+
+            // SOQL for Updated Opps and Related Payments.
+            // AfterUpdate => Queries for known fields and field in custom Payment Field Mappings.
+            // BeforeUpdate AND IsACMEnabled => Used to handle summing total payments when ACM is enabled in the org.
+            if (ta == TDTM_Runnable.Action.AfterUpdate || (isACMEnabled && ta == TDTM_Runnable.Action.BeforeUpdate)) {
+                String query = buildOppsQuery() + 'WHERE Id IN :newOpps';
+                updatedOpps = database.query(query);
+                if (isACMEnabled && ta == TDTM_Runnable.Action.BeforeUpdate) {
+                    newOppsMapRequeried = new Map<Id, Opportunity>((List<Opportunity>)(updatedOpps));
+                }
+            }
+
             if (TDTM_Runnable.Action.BeforeUpdate == ta) {
                 if (!String.isEmpty(ContactSettings.Payments_Auto_Close_Stage_Name__c)) {
                     String closedStageName = ContactSettings.Payments_Auto_Close_Stage_Name__c;
-                    for (Opportunity opp : newOppsMap.values()) {
+                    for (Opportunity opp : newOpps) {
+
+                        Decimal totalPaymentAmount = (isACMEnabled
+                                ? PMT_PaymentCreator.getPaymentsMade(newOppsMapRequeried.get(opp.Id)) : opp.npe01__Payments_Made__c);
                         closeOpportunityIfAllPaymentsReceived(
                             oldOppsMap.get(opp.Id),
                             opp,
-                            closedStageName
+                            closedStageName,
+                            totalPaymentAmount
                         );
                     }
                 }
             }
 
-            //SOQL for Updated Opps and Related Payments.  Queries for known fields and field in custom Payment Field Mappings.
-            if (ta == TDTM_Runnable.Action.AfterUpdate){
-                String query = buildOppsQuery();
-                query += 'WHERE Id IN :newOpps';
-                updatedOpps = Database.query(query);
-            }
-    
             //IF Trigger is Insert, Create a new Payment
             if( ta == TDTM_Runnable.Action.AfterInsert){
                 for (Opportunity thisOpp : newOpps){
@@ -340,18 +359,21 @@ public class PMT_PaymentCreator {
      * @description Close an opportunity if all payments have been received.
      * This will update the StageName of newOpp, in place, if "all payments
      * received" conditions are satisfied.
+     * This method will not execute if Advanced Currency Mgt is enabled. In that
+     * case, a trigger on the Payment object is used to auto-close the Opportunity.
      * @param oldOpp The opportunity before being updated
      * @param newOpp The opportunity after being updated
      * @param closedStageName The name of an opportunity stage that corresponds to Closed/Won to transition to if all payments are determined to be received
+     * @param totalPaymentAmount The total amount of all Paid Payment records for the Opportunity
      * @return void
      */
-// TODO: Need to figure out how to deal with npe01__Payments_Made__c for both the OLD and NEW Opportunity
-    private void closeOpportunityIfAllPaymentsReceived(Opportunity oldOpp, Opportunity newOpp, String closedStageName) {
+    private void closeOpportunityIfAllPaymentsReceived(Opportunity oldOpp, Opportunity newOpp, String closedStageName,
+            Decimal totalPaymentAmount) {
         Boolean amountUpdated = (oldOpp.Amount != newOpp.Amount);
-        Boolean paymentAmountReceivedUpdated = (oldOpp.npe01__Payments_Made__c != newOpp.npe01__Payments_Made__c);
+        Boolean paymentAmountReceivedUpdated = (oldOpp.npe01__Payments_Made__c != totalPaymentAmount);
         Boolean amountPositive = (newOpp.Amount > 0);
         Boolean isNotAndWasNotClosed = (!oldOpp.IsClosed && !newOpp.IsClosed);
-        Boolean amountEqualPaymentReceived = (newOpp.Amount == newOpp.npe01__Payments_Made__c);
+        Boolean amountEqualPaymentReceived = (newOpp.Amount == totalPaymentAmount);
         Boolean stageNameSpecified = !String.isEmpty(closedStageName);
 
         if (
@@ -374,8 +396,8 @@ public class PMT_PaymentCreator {
     * @return Decimal amount outstanding
     */
     public static Decimal getAmountOutstanding(Opportunity currentOpp) {
-        // !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()
-        if (false) {
+        // TODO
+        if (false /* !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled() */ ) {
             return currentOpp.npe01__Amount_Outstanding__c;
         } else {
             // calculate the value since the roll-ups and formula are not functional with ACM
@@ -402,8 +424,8 @@ public class PMT_PaymentCreator {
     * @return Decimal total of payment records where Paid = True
     */
     public static Decimal getPaymentsMade(Opportunity currentOpp) {
-        // !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()
-        if (false) {
+        // TODO
+        if (false /* !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled() */ ) {
             return currentOpp.npe01__Payments_Made__c;
         } else {
             // calculate the value since the roll-ups and formula are not functional with ACM

--- a/src/classes/PMT_PaymentCreator.cls
+++ b/src/classes/PMT_PaymentCreator.cls
@@ -373,7 +373,8 @@ public class PMT_PaymentCreator {
     * @return Decimal amount outstanding
     */
     public static Decimal getAmountOutstanding(Opportunity currentOpp) {
-        if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
+        // !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()
+        if (false) {
             return currentOpp.npe01__Amount_Outstanding__c;
         } else {
             // calculate the value since the roll-ups and formula are not functional with ACM
@@ -387,7 +388,7 @@ public class PMT_PaymentCreator {
                     amtWrittenOff += pmt.npe01__Payment_Amount__c;
                 }
             }
-            return (currentOpp.Amount = totalPayments - amtWrittenOff);
+            return (currentOpp.Amount - totalPayments - amtWrittenOff);
         }
     }
 
@@ -399,7 +400,8 @@ public class PMT_PaymentCreator {
     * @return Decimal amount outstanding
     */
     public static Decimal getPaymentsMade(Opportunity currentOpp) {
-        if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
+        // !UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()
+        if (false) {
             return currentOpp.npe01__Payments_Made__c;
         } else {
             // calculate the value since the roll-ups and formula are not functional with ACM

--- a/src/classes/PMT_PaymentCreator.cls
+++ b/src/classes/PMT_PaymentCreator.cls
@@ -35,6 +35,12 @@
 */
 public class PMT_PaymentCreator {
 
+    /* @description Retrieve info about specific fields that may or may not exist on the objects */
+    private static final SObjectField OppCurrencyField = Schema.sObjectType.Opportunity.fields.getMap().get('CurrencyIsoCode');
+    private static final SObjectField PaymentCurrencyField = Schema.sObjectType.npe01__OppPayment__c.fields.getMap().get('CurrencyIsoCode');
+    private static final SObjectField OppRecordTypeId = Schema.sObjectType.Opportunity.fields.getMap().get('RecordTypeId');
+
+
     /*******************************************************************************************************
     * @description map of Opportunity to Payment field mappings, validated to only contain mappings that
     * are of compatible types.
@@ -146,12 +152,6 @@ public class PMT_PaymentCreator {
             list<npe01__OppPayment__c> paymentsToDelete = new list<npe01__OppPayment__c>();
             list<Opportunity> updatedOpps = new list<Opportunity>();
             
-            // James Melville Added to support multi-currency sfdc.  */
-            // CurrencyIsoCode doesn't exist in non-multi-currency orgs
-            SObjectField OppCurrencyField = Schema.sObjectType.Opportunity.fields.getMap().get('CurrencyIsoCode');
-            SObjectField PaymentCurrencyField = Schema.sObjectType.npe01__OppPayment__c.fields.getMap().get('CurrencyIsoCode');    
-            SObjectField OppRecordTypeId = Schema.sObjectType.Opportunity.fields.getMap().get('RecordTypeId');
-
             if (TDTM_Runnable.Action.BeforeUpdate == ta) {
                 if (!String.isEmpty(ContactSettings.Payments_Auto_Close_Stage_Name__c)) {
                     String closedStageName = ContactSettings.Payments_Auto_Close_Stage_Name__c;
@@ -167,84 +167,66 @@ public class PMT_PaymentCreator {
 
             //SOQL for Updated Opps and Related Payments.  Queries for known fields and field in custom Payment Field Mappings.
             if (ta == TDTM_Runnable.Action.AfterUpdate){
-                String soqlStatement = '';
-                soqlStatement += 'select id, CloseDate, Amount, isClosed, isWon, npe01__Do_Not_Automatically_Create_Payment__c, Type, ';
-                if (OppRecordTypeId != null)
-                    soqlStatement += 'RecordTypeId, ';
-                for (string s : paymentMappings.keyset()) {
-                    npe01__Payment_Field_Mapping_Settings__c pfms = paymentMappings.get(s);
-                    if (!soqlStatement.contains(pfms.npe01__Opportunity_Field__c)) {               
-                        soqlStatement += pfms.npe01__Opportunity_Field__c + ', ';
-                    }   
-                }
-                if (OppCurrencyField!=null)
-                    soqlStatement += 'CurrencyIsoCode, ';
-                soqlStatement += 'npe01__payments_made__c, ';
-                string soqlSub = '(SELECT id, npe01__Paid__c, npe01__Payment_Amount__c, npe01__Payment_Date__c, npe01__Written_Off__c, ';
-                for (string s : paymentMappings.keyset()) {
-                    npe01__Payment_Field_Mapping_Settings__c pfms = paymentMappings.get(s);
-                    if (!soqlSub.contains(pfms.npe01__Payment_Field__c)) {               
-                        soqlSub += pfms.npe01__Payment_Field__c + ', ';   
-                    }
-                }
-                soqlStatement += soqlSub;
-                soqlStatement += 'npe01__scheduled_date__c ';
-                soqlStatement += 'from Opportunity.npe01__OppPayment__r WHERE npe01__Opportunity__c IN :newOpps) from Opportunity WHERE id in :newOpps';
-                updatedOpps = Database.query(soqlStatement);
+                String query = buildOppsQuery();
+                query += 'WHERE Id IN :newOpps';
+                updatedOpps = Database.query(query);
             }
     
             //IF Trigger is Insert, Create a new Payment
             if( ta == TDTM_Runnable.Action.AfterInsert){
                 for (Opportunity thisOpp : newOpps){
                     
-                    if (isNoPaymentForOpp(thisOpp))
+                    if (isNoPaymentForOpp(thisOpp)) {
                         continue;
+                    }
                         
-                    // if opp is closed won with no payments scheduled or made, add an automatic payment
-                        if ( /*(thisOpp.IsClosed && thisOpp.IsWon) && */
-                                        thisOpp.amount > 0 && thisOpp.npe01__payments_made__c == 0 && thisOpp.npe01__Number_of_Payments__c == 0) {
-                                npe01__oppPayment__c op = new npe01__oppPayment__c(
-                                    npe01__opportunity__c = thisOpp.id
-                                );
-                                
-                                //in multicurrency SFDC set the payment currency field to equal to the opp currency
-                                if(PaymentCurrencyField != null && OppCurrencyField != null)
-                                    op.put(PaymentCurrencyField, thisOpp.get(OppCurrencyField));
-                                
-                                op.npe01__payment_amount__c = thisOpp.amount;
-                            
-                            if (paymentMappings.size() > 0){
-                                for (string s : paymentMappings.keyset()){
-                                        npe01__Payment_Field_Mapping_Settings__c pfms = paymentMappings.get(s);
-                                        string x = pfms.npe01__Opportunity_Field__c;
-                                        if (thisOpp.get(x) != null)
-                                           op.put(pfms.npe01__Payment_Field__c, thisOpp.get(x));
+                    // if has no payments scheduled or made, add an automatic payment
+                    // Can there ever be a scenario where these fields are anything other than zero during an AfterInsert?
+                    if (thisOpp.amount > 0 && thisOpp.npe01__payments_made__c == 0 && thisOpp.npe01__Number_of_Payments__c == 0) {
+
+                        npe01__oppPayment__c op = new npe01__oppPayment__c(
+                            npe01__opportunity__c = thisOpp.id
+                        );
+
+                        //in multicurrency SFDC set the payment currency field to equal to the opp currency
+                        if(PaymentCurrencyField != null && OppCurrencyField != null) {
+                            op.put(PaymentCurrencyField, thisOpp.get(OppCurrencyField));
+                        }
+                        op.npe01__payment_amount__c = thisOpp.amount;
+
+                        if (paymentMappings.size() > 0){
+                            for (string s : paymentMappings.keyset()){
+                                npe01__Payment_Field_Mapping_Settings__c pfms = paymentMappings.get(s);
+                                string x = pfms.npe01__Opportunity_Field__c;
+                                if (thisOpp.get(x) != null) {
+                                    op.put(pfms.npe01__Payment_Field__c, thisOpp.get(x));
                                 }
                             }
-                            
-                            if (thisOpp.IsClosed && thisOpp.IsWon){
-                                op.npe01__paid__c = true;
-                                op.npe01__payment_date__c = thisOpp.closeDate;
-                            }
-                            
-                            if (!thisOpp.IsClosed){
-                                op.npe01__paid__c = false;
-                                op.npe01__scheduled_date__c = thisOpp.closeDate;
-                            }
-                            
-                            paymentsToInsert.add(op);
                         }
-                        /*
-                        else if (!thisOpp.IsClosed && 
-                                        thisOpp.amount > 0 && thisOpp.npe01__payments_made__c == 0 && thisOpp.npe01__Number_of_Payments__c == 0 && !thisOpp.npe01__Do_Not_Automatically_Create_Payment__c) {
-                            paymentsToInsert.add(new npe01__oppPayment__c(
-                                npe01__opportunity__c = thisOpp.id,
-                                npe01__scheduled_date__c = thisOpp.closeDate,
-                                npe01__payment_amount__c = thisOpp.amount,
-                                npe01__paid__c = false
-                            ));
+
+                        if (thisOpp.IsClosed && thisOpp.IsWon){
+                            op.npe01__paid__c = true;
+                            op.npe01__payment_date__c = thisOpp.closeDate;
                         }
-                        */
+
+                        if (!thisOpp.IsClosed){
+                            op.npe01__paid__c = false;
+                            op.npe01__scheduled_date__c = thisOpp.closeDate;
+                        }
+
+                        paymentsToInsert.add(op);
+                    }
+                    /*
+                    else if (!thisOpp.IsClosed &&
+                                    thisOpp.amount > 0 && thisOpp.npe01__payments_made__c == 0 && thisOpp.npe01__Number_of_Payments__c == 0 && !thisOpp.npe01__Do_Not_Automatically_Create_Payment__c) {
+                        paymentsToInsert.add(new npe01__oppPayment__c(
+                            npe01__opportunity__c = thisOpp.id,
+                            npe01__scheduled_date__c = thisOpp.closeDate,
+                            npe01__payment_amount__c = thisOpp.amount,
+                            npe01__paid__c = false
+                        ));
+                    }
+                    */
                 }
                 // put in the payment for closed opps       
                 if (!paymentsToInsert.isEmpty()) 
@@ -266,8 +248,11 @@ public class PMT_PaymentCreator {
                             mappingsUpdated = true;
                         }
                     }
-                
-                     
+
+                    // Use a method to determine the value for total payments that takes Advanced Currency Management
+                    // into consideration.
+                    Decimal totalPaymentsMade = getPaymentsMade(thisOpp);
+
                     if (thisOpp.npe01__OppPayment__r.size() > 0){
                          // if opp is updated, update the automatic payment
                         if ( ((thisOpp.Amount != oldOpp.Amount) || (thisOpp.CloseDate != oldOpp.CloseDate) || mappingsUpdated == true) &&
@@ -276,7 +261,7 @@ public class PMT_PaymentCreator {
                                 thisOpp.npe01__OppPayment__r.size() == 1 &&
                                 thisOpp.npe01__OppPayment__r[0].npe01__paid__c == False &&
                                 !thisOpp.isClosed && thisOpp.amount > 0 &&
-                                thisOpp.npe01__payments_made__c == 0) {
+                                totalPaymentsMade == 0) {
                             thisOpp.npe01__OppPayment__r[0].npe01__scheduled_date__c = thisOpp.closeDate;
                             thisOpp.npe01__OppPayment__r[0].npe01__payment_amount__c = thisOpp.amount;
                             
@@ -298,7 +283,7 @@ public class PMT_PaymentCreator {
                                 thisOpp.npe01__OppPayment__r.size() == 1 &&
                                 thisOpp.npe01__OppPayment__r[0].npe01__paid__c == False &&
                                 thisOpp.isClosed && thisOpp.isWon && thisOpp.amount > 0 &&
-                                thisOpp.npe01__payments_made__c == 0) {
+                                totalPaymentsMade == 0) {
                             thisOpp.npe01__OppPayment__r[0].npe01__payment_date__c = thisOpp.closeDate;
                             thisOpp.npe01__OppPayment__r[0].npe01__payment_amount__c = thisOpp.amount;
                             thisOpp.npe01__OppPayment__r[0].npe01__paid__c = true;
@@ -360,6 +345,7 @@ public class PMT_PaymentCreator {
      * @param closedStageName The name of an opportunity stage that corresponds to Closed/Won to transition to if all payments are determined to be received
      * @return void
      */
+// TODO: Need to figure out how to deal with npe01__Payments_Made__c for both the OLD and NEW Opportunity
     private void closeOpportunityIfAllPaymentsReceived(Opportunity oldOpp, Opportunity newOpp, String closedStageName) {
         Boolean amountUpdated = (oldOpp.Amount != newOpp.Amount);
         Boolean paymentAmountReceivedUpdated = (oldOpp.npe01__Payments_Made__c != newOpp.npe01__Payments_Made__c);
@@ -377,5 +363,87 @@ public class PMT_PaymentCreator {
         ) {
             newOpp.StageName = closedStageName;
         }
+    }
+
+    /*******************************************************************************************************
+    * @description When Advanced Currency Management is enabled in an org, the packaged rollups and formula
+    * from the Payment object will not work. This method will detect that scenario and return either the
+    * value from the formula or calculate the Amount Outstanding from the payment records
+    * track this.
+    * @return Decimal amount outstanding
+    */
+    public static Decimal getAmountOutstanding(Opportunity currentOpp) {
+        if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
+            return currentOpp.npe01__Amount_Outstanding__c;
+        } else {
+            // calculate the value since the roll-ups and formula are not functional with ACM
+            Decimal totalPayments = 0;
+            Decimal amtWrittenOff = 0;
+            for (npe01__OppPayment__c pmt : currentOpp.npe01__OppPayment__r) {
+                if (pmt.npe01__Paid__c == true) {
+                    totalPayments += pmt.npe01__Payment_Amount__c;
+                }
+                if (pmt.npe01__Written_Off__c == true) {
+                    amtWrittenOff += pmt.npe01__Payment_Amount__c;
+                }
+            }
+            return (currentOpp.Amount = totalPayments - amtWrittenOff);
+        }
+    }
+
+    /*******************************************************************************************************
+    * @description When Advanced Currency Management is enabled in an org, the packaged rollups and formula
+    * from the Payment object will not work. This method will detect that scenario and return either the
+    * value from the formula or calculate the Amount Outstanding from the payment records
+    * track this.
+    * @return Decimal amount outstanding
+    */
+    public static Decimal getPaymentsMade(Opportunity currentOpp) {
+        if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
+            return currentOpp.npe01__Payments_Made__c;
+        } else {
+            // calculate the value since the roll-ups and formula are not functional with ACM
+            Decimal totalPayments = 0;
+            for (npe01__OppPayment__c pmt : currentOpp.npe01__OppPayment__r) {
+                if (pmt.npe01__Paid__c == true) {
+                    totalPayments += pmt.npe01__Payment_Amount__c;
+                }
+            }
+            return totalPayments;
+        }
+    }
+
+    /**
+     * @description Build a query string to retrieve a list of Opportunities with a subquery on the Payments object
+     * @return SOQL string
+     */
+    public static String buildOppsQuery() {
+        String soqlStatement = '';
+        soqlStatement += 'SELECT Id, CloseDate, Amount, isClosed, isWon, npe01__Do_Not_Automatically_Create_Payment__c, Type, ';
+        if (OppRecordTypeId != null) {
+            soqlStatement += 'RecordTypeId, ';
+        }
+        for (string s : paymentMappings.keyset()) {
+            npe01__Payment_Field_Mapping_Settings__c pfms = paymentMappings.get(s);
+            if (!soqlStatement.contains(pfms.npe01__Opportunity_Field__c)) {
+                soqlStatement += pfms.npe01__Opportunity_Field__c + ', ';
+            }
+        }
+        if (OppCurrencyField!=null) {
+            soqlStatement += 'CurrencyIsoCode, ';
+        }
+        soqlStatement += 'npe01__payments_made__c, ';
+        string soqlSub = '(SELECT id, npe01__Paid__c, npe01__Payment_Amount__c, npe01__Payment_Date__c, npe01__Written_Off__c, ';
+        for (string s : paymentMappings.keyset()) {
+            npe01__Payment_Field_Mapping_Settings__c pfms = paymentMappings.get(s);
+            if (!soqlSub.contains(pfms.npe01__Payment_Field__c)) {
+                soqlSub += pfms.npe01__Payment_Field__c + ', ';
+            }
+        }
+        soqlStatement += soqlSub;
+        soqlStatement += 'npe01__scheduled_date__c ';
+        soqlStatement += 'FROM Opportunity.npe01__OppPayment__r) FROM Opportunity ';
+
+        return soqlStatement;
     }
 }

--- a/src/classes/PMT_PaymentCreator_TEST.cls
+++ b/src/classes/PMT_PaymentCreator_TEST.cls
@@ -325,7 +325,7 @@ private with sharing class PMT_PaymentCreator_TEST {
 
         oh.refresh();
 
-        System.assertEquals(oh.opp.Amount, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(oh.opp.Amount, oh.getTotalPaymentsMade());
         System.assertEquals(closedWonStage, oh.opp.StageName);
     }
 
@@ -360,7 +360,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         oh.refresh();
 
         System.assertEquals(500, oh.opp.Amount);
-        System.assertEquals(250, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(250, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
 
         Test.startTest();
@@ -373,7 +373,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         oh.refresh();
 
         System.assertEquals(250, oh.opp.Amount);
-        System.assertEquals(oh.opp.Amount, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(oh.opp.Amount, oh.getTotalPaymentsMade());
         System.assertEquals(closedWonStage, oh.opp.StageName);
     }
 
@@ -408,7 +408,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         oh.refresh();
 
         System.assertEquals(500, oh.opp.Amount);
-        System.assertEquals(0, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(0, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
 
         Test.startTest();
@@ -421,7 +421,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         oh.refresh();
 
         System.assertEquals(500, oh.opp.Amount);
-        System.assertEquals(250, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(250, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
     }
 
@@ -457,7 +457,7 @@ private with sharing class PMT_PaymentCreator_TEST {
 
         oh.refresh();
 
-        System.assertEquals(oh.opp.Amount, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(oh.opp.Amount, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
     }
 
@@ -493,7 +493,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         oh.refresh();
 
         System.assertEquals(500, oh.opp.Amount);
-        System.assertEquals(250, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(250, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
 
         Test.startTest();
@@ -507,7 +507,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         oh.refresh();
 
         System.assertEquals(250, oh.opp.Amount);
-        System.assertEquals(oh.opp.Amount, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(oh.opp.Amount, oh.getTotalPaymentsMade());
         System.assertEquals(closedLostStage, oh.opp.StageName);
     }
 
@@ -532,7 +532,7 @@ private with sharing class PMT_PaymentCreator_TEST {
 
         System.assertEquals(1, payments.size());
         System.assertEquals(oh.opp.Amount, payments.get(0).npe01__Payment_Amount__c);
-        System.assertEquals(0, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(0, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
 
         payments.get(0).npe01__Written_Off__c = true;
@@ -545,7 +545,7 @@ private with sharing class PMT_PaymentCreator_TEST {
 
         oh.refresh();
 
-        System.assertEquals(0, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(0, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
     }
 
@@ -582,7 +582,7 @@ private with sharing class PMT_PaymentCreator_TEST {
         oh.refresh();
 
         System.assertEquals(0, oh.opp.Amount);
-        System.assertEquals(oh.opp.Amount, oh.opp.npe01__Payments_Made__c);
+        System.assertEquals(oh.opp.Amount, oh.getTotalPaymentsMade());
         System.assertEquals(openStage, oh.opp.StageName);
     }
 
@@ -606,11 +606,13 @@ private with sharing class PMT_PaymentCreator_TEST {
                     IsClosed,
                     IsWon,
                     npe01__Number_Of_Payments__c,
+                    npe01__Amount_Outstanding__c,
                     npe01__Payments_Made__c,
                     (
                         SELECT
                             npe01__Paid__c,
-                            npe01__Payment_Amount__c
+                            npe01__Payment_Amount__c,
+                            npe01__Written_Off__c
                         FROM npe01__OppPayment__r
                     )
                 FROM Opportunity
@@ -619,6 +621,38 @@ private with sharing class PMT_PaymentCreator_TEST {
         }
         public List<npe01__OppPayment__c> getPayments() {
             return opp.npe01__OppPayment__r;
+        }
+        public Decimal getTotalPaymentsMade() {
+            if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
+                return opp.npe01__Payments_Made__c;
+            } else {
+                // calculate the value since the roll-ups and formula are not functional with ACM
+                Decimal totalPayments = 0;
+                for (npe01__OppPayment__c pmt : opp.npe01__OppPayment__r) {
+                    if (pmt.npe01__Paid__c == true) {
+                        totalPayments += pmt.npe01__Payment_Amount__c;
+                    }
+                }
+                return totalPayments;
+            }
+        }
+        public Decimal getAmountOutstanding() {
+            if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
+                return opp.npe01__Amount_Outstanding__c;
+            } else {
+                // calculate the value since the roll-ups and formula are not functional with ACM
+                Decimal totalPayments = 0;
+                Decimal amtWrittenOff = 0;
+                for (npe01__OppPayment__c pmt : opp.npe01__OppPayment__r) {
+                    if (pmt.npe01__Paid__c == true) {
+                        totalPayments += pmt.npe01__Payment_Amount__c;
+                    }
+                    if (pmt.npe01__Written_Off__c == true) {
+                        amtWrittenOff += pmt.npe01__Payment_Amount__c;
+                    }
+                }
+                return (opp.Amount = totalPayments - amtWrittenOff);
+            }
         }
         public void deletePayments() {
             delete getPayments();

--- a/src/classes/PMT_PaymentCreator_TEST.cls
+++ b/src/classes/PMT_PaymentCreator_TEST.cls
@@ -623,36 +623,10 @@ private with sharing class PMT_PaymentCreator_TEST {
             return opp.npe01__OppPayment__r;
         }
         public Decimal getTotalPaymentsMade() {
-            if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
-                return opp.npe01__Payments_Made__c;
-            } else {
-                // calculate the value since the roll-ups and formula are not functional with ACM
-                Decimal totalPayments = 0;
-                for (npe01__OppPayment__c pmt : opp.npe01__OppPayment__r) {
-                    if (pmt.npe01__Paid__c == true) {
-                        totalPayments += pmt.npe01__Payment_Amount__c;
-                    }
-                }
-                return totalPayments;
-            }
+            return PMT_PaymentCreator.getPaymentsMade(this.opp);
         }
         public Decimal getAmountOutstanding() {
-            if (!UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled()) {
-                return opp.npe01__Amount_Outstanding__c;
-            } else {
-                // calculate the value since the roll-ups and formula are not functional with ACM
-                Decimal totalPayments = 0;
-                Decimal amtWrittenOff = 0;
-                for (npe01__OppPayment__c pmt : opp.npe01__OppPayment__r) {
-                    if (pmt.npe01__Paid__c == true) {
-                        totalPayments += pmt.npe01__Payment_Amount__c;
-                    }
-                    if (pmt.npe01__Written_Off__c == true) {
-                        amtWrittenOff += pmt.npe01__Payment_Amount__c;
-                    }
-                }
-                return (opp.Amount = totalPayments - amtWrittenOff);
-            }
+            return PMT_PaymentCreator.getAmountOutstanding(this.opp);
         }
         public void deletePayments() {
             delete getPayments();

--- a/src/classes/PMT_PaymentWizard_CTRL.cls
+++ b/src/classes/PMT_PaymentWizard_CTRL.cls
@@ -50,6 +50,13 @@ public with sharing class PMT_PaymentWizard_CTRL {
     */ 
     public Boolean redirect {get; set;}
 
+    /**
+     * @description The currency symbol or ISO code of the related record or
+     * org default
+     */
+    @TestVisible
+    private String currencySymbol;
+
     /*******************************************************************************************************
     * @description Class that stored numbered payment
     */ 
@@ -176,7 +183,7 @@ public with sharing class PMT_PaymentWizard_CTRL {
             haveAmount = false;
         } else {
             currentOpp = o[0];
-            haveAmount = (currentOpp.npe01__amount_outstanding__c > 0);
+            haveAmount = (getAmountOutstanding() > 0);
             isClosedLost = currentOpp.isClosed && !currentOpp.isWon;
             samplePayment = new npe01__OppPayment__c();
             samplePayment.npe01__Scheduled_Date__c = system.today();
@@ -203,9 +210,9 @@ public with sharing class PMT_PaymentWizard_CTRL {
             paymentcount = [select count() from npe01__OppPayment__c where npe01__Opportunity__c = :o[0].id and npe01__Paid__c != true];
             
             outstanding_payments = paymentcount;
-            haveAmount = (currentOpp.npe01__amount_outstanding__c > 0);
+            haveAmount = (getAmountOutstanding() > 0);
             writeoffPayment = new npe01__OppPayment__c();
-            writeoffPayment.npe01__Payment_Amount__c = currentOpp.npe01__amount_outstanding__c;
+            writeoffPayment.npe01__Payment_Amount__c = getAmountOutstanding();
             writeoffPayment.npe01__Written_Off__c = true;
             writeoffPayment.npe01__Opportunity__c = currentOpp.Id;
             writeoffPayment.npe01__Payment_Date__c = system.today();
@@ -225,7 +232,8 @@ public with sharing class PMT_PaymentWizard_CTRL {
             if (!query.contains(pfms.npe01__Opportunity_Field__c.toLowerCase())) {               
                 query += ', ' + pfms.npe01__Opportunity_Field__c;
             }   
-        }       
+        }
+        query += ', (SELECT Id, npe01__Payment_Amount__c, npe01__Written_Off__c, npe01__Paid__c FROM  npe01__OppPayment__r)';
         //if currencyiso field exists add it to query for use later
         if(Schema.sObjectType.Opportunity.fields.getMap().get('CurrencyIsoCode') != null)
             query = query + ',CurrencyIsoCode';
@@ -244,10 +252,11 @@ public with sharing class PMT_PaymentWizard_CTRL {
             // clear the list
             newPayments.clear();
                         
-            Decimal OppAmountFloat = currentOpp.npe01__Amount_Outstanding__c;
-            if (removePaidPayments == true)
+            Decimal OppAmountFloat = getAmountOutstanding();
+            if (removePaidPayments == true) {
                 OppAmountFloat = currentOpp.Amount;
-    
+            }
+
             //divide the amount by the number of installments, and deal with the remainder
             Decimal paymentAmount = OppAmountFloat.divide(numberOfPayments, 2, system.roundingmode.FLOOR);
             decimal remainder = OppAmountFloat - (paymentAmount * numberOfPayments);
@@ -279,9 +288,10 @@ public with sharing class PMT_PaymentWizard_CTRL {
                 }
                 
                 //in multicurrency SFDC set the payment currency field to equal the opp currency
-                if(PaymentCurrencyField != null && OppCurrencyField != null)
-                    thisPayment.oppPayment.put(PaymentCurrencyField,CurrentOpp.get(OppCurrencyField));
-                    
+                if(PaymentCurrencyField != null && OppCurrencyField != null) {
+                    thisPayment.oppPayment.put(PaymentCurrencyField, CurrentOpp.get(OppCurrencyField));
+                }
+
                 // modify new payment records with any Opp-Payment Mappings.
                 if (PMT_PaymentCreator.paymentMappings.size() > 0) {
                     for (string s : PMT_PaymentCreator.paymentMappings.keyset()) {
@@ -415,7 +425,7 @@ public with sharing class PMT_PaymentWizard_CTRL {
         }
         return null;
     }
-    
+
     /*******************************************************************************************************
     * @description ActionMethod for the Remove Paid Payments button, which sets the internal flag to
     * track this.
@@ -425,5 +435,42 @@ public with sharing class PMT_PaymentWizard_CTRL {
         removePaidPayments = true;
         return null;
     }
-   
+
+    /**
+     * @description Return the currency symbol appropriate for the current
+     * user/org/record.  If the org is multi currency enabled, it will use the
+     * currency iso code from the related record.  If the org is not multi
+     * currency enabled, it will return the symbol for the currency of the org,
+     * or the currency iso code if no symbol is known.
+     *
+     * @return String A currency symbol or currency ISO code
+     */
+    public String getCurrencySymbol() {
+        if (currencySymbol == null) {
+            currencySymbol = UTIL_Currency.getInstance().getCurrencySymbol(currentOpp.Id);
+        }
+        return currencySymbol;
+    }
+
+    /*******************************************************************************************************
+    * @description When Advanced Currency Management is enabled in an org, the packaged rollups and formula
+    * from the Payment object will not work. This method will detect that scenario and return either the
+    * value from the formula or calculate the Amount Outstanding from the payment records
+    * track this.
+    * @return Decimal amount outstanding
+    */
+    public Decimal getAmountOutstanding() {
+        return PMT_PaymentCreator.getAmountOutstanding(this.currentOpp);
+    }
+
+    /*******************************************************************************************************
+    * @description When Advanced Currency Management is enabled in an org, the packaged rollups and formula
+    * from the Payment object will not work. This method will detect that scenario and return either the
+    * value from the formula or calculate the Amount Outstanding from the payment records
+    * track this.
+    * @return Decimal total paid payments
+    */
+    public Decimal getTotalPaymentsMade() {
+        return PMT_PaymentCreator.getPaymentsMade(this.currentOpp);
+    }
 }

--- a/src/classes/PMT_Payment_TDTM.cls
+++ b/src/classes/PMT_Payment_TDTM.cls
@@ -58,7 +58,7 @@ public class PMT_Payment_TDTM extends TDTM_Runnable {
     }
 
     /*******************************************************************************************************
-    * @description Trigger Handler on Payment for managing Payments
+    * @description Trigger Handler on Payment for managing Payments.
     * @param newlist the list of Payments from trigger new.
     * @param oldlist the list of Payments from trigger old.
     * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).
@@ -70,41 +70,73 @@ public class PMT_Payment_TDTM extends TDTM_Runnable {
         if (!UTIL_Currency.getInstance().isMultiCurrencyOrganization()) {
             return null;
         }
-        if (triggerAction != TDTM_Runnable.Action.BeforeInsert && triggerAction != TDTM_Runnable.Action.BeforeUpdate) {
-            return null;
-        }
+
+        DmlWrapper dmlWrapper = new DmlWrapper();
 
         Set<Id> oppIds = new Set<Id>();
         for (npe01__OppPayment__c pmt : newlist) {
             oppIds.add(pmt.npe01__Opportunity__c);
         }
 
-        String soql = 'SELECT Id, CurrencyIsoCode, CloseDate FROM Opportunity WHERE Id IN :oppIds';
+        // Query the Opportunity with a sub-query on Payments
+        String soql = 'SELECT Id, Amount, IsClosed, IsWon, StageName, ';
+        if (UserInfo.isMultiCurrencyOrganization()) {
+            soql += 'CurrencyIsoCode, ';
+        }
+        soql += ' (SELECT id, npe01__Paid__c, npe01__Payment_Amount__c, npe01__Payment_Date__c, npe01__Written_Off__c ' +
+                ' FROM Opportunity.npe01__OppPayment__r)' +
+                ' FROM Opportunity WHERE Id IN :oppIds';
         Map<Id, Opportunity> mapOfOpps = new Map<Id, Opportunity>((List<Opportunity>)database.query(soql));
 
-        // Validation and default the CurrencyIsoCode for new records
-        for (integer i=0; i<newlist.size(); i++) {
-            npe01__OppPayment__c pmt = newlist[i];
+        // Validation and default the CurrencyIsoCode for new records for Before Insert/update
+        if (UserInfo.isMultiCurrencyOrganization() && (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate)) {
+            for (integer i = 0; i < newlist.size(); i++) {
+                npe01__OppPayment__c pmt = newlist[i];
 
-            String oppCurrency = (String)mapOfOpps.get(pmt.npe01__Opportunity__c).get('CurrencyIsoCode');
-            String pmtCurrency = (String)pmt.get('CurrencyIsoCode');
-            String oldPmtCurrency = (oldList != null ? (String)oldlist[i].get('CurrencyIsoCode') : null);
+                String oppCurrency = (String) mapOfOpps.get(pmt.npe01__Opportunity__c).get('CurrencyIsoCode');
+                String pmtCurrency = (String) pmt.get('CurrencyIsoCode');
+                String oldPmtCurrency = (oldList != null ? (String) oldlist[i].get('CurrencyIsoCode') : null);
 
-            // Prevent the Payment CurrencyCode from being modified directly
-            if (triggerAction == TDTM_Runnable.Action.BeforeUpdate && pmtCurrency != oldPmtCurrency && pmtCurrency != oppCurrency) {
-                pmt.addError(Label.pmtModifyCurrency);
+                // Prevent the Payment CurrencyCode from being modified directly
+                if (triggerAction == TDTM_Runnable.Action.BeforeUpdate && pmtCurrency != oldPmtCurrency && pmtCurrency != oppCurrency) {
+                    pmt.addError(Label.pmtModifyCurrency);
 
-            } else if (triggerAction == TDTM_Runnable.Action.BeforeInsert && pmtCurrency != oppCurrency && pmtCurrency != null) {
-                // If the User is attempting to set the Payment Currency to something different than the Opp currency
-                pmt.addError(Label.pmtModifyCurrency);
+                } else if (triggerAction == TDTM_Runnable.Action.BeforeInsert && pmtCurrency != oppCurrency && pmtCurrency != null) {
+                    // If the User is attempting to set the Payment Currency to something different than the Opp currency
+                    pmt.addError(Label.pmtModifyCurrency);
 
-            } else if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
-                // Otherwise default the Payment CurrencyIsoCode to the value from the parent Opportunity
-                pmt.put('CurrencyIsoCode', oppCurrency);
+                } else if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
+                    // Otherwise default the Payment CurrencyIsoCode to the value from the parent Opportunity
+                    pmt.put('CurrencyIsoCode', oppCurrency);
+                }
             }
         }
 
-        return null;
+        // For an After Insert/Update Payment action, when Advanced Curr Mgt is enabled and there is a defined
+        // Closed stage name in settings, roll up the total paynents and compare to the Opp.Amount. If the
+        // two values are equal then close the Opportunity by setting the stage name.
+        if (triggerAction == TDTM_Runnable.Action.AfterInsert || triggerAction == TDTM_Runnable.Action.AfterUpdate) {
+
+            npe01__Contacts_And_Orgs_Settings__c ContactSettings = UTIL_CustomSettingsFacade.getContactsSettings();
+            String closedStageName = ContactSettings.Payments_Auto_Close_Stage_Name__c;
+
+            // TODO
+            Boolean isACMEnabled = true; // UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled();
+            if (isACMEnabled && !String.isEmpty(closedStageName)) {
+                // Loop through all the queried Opps with the subquery on payments
+                for (Opportunity opp : mapOfOpps.values()) {
+                    // If the Opp Amount is greater than zero and the Opp is not currently closed
+                    // and the amount paid is equal to the total opportunity amount
+                    Decimal paidAmount = PMT_PaymentCreator.getPaymentsMade(opp);
+                    if (opp.Amount > 0 && paidAmount == opp.Amount && !opp.isClosed && !opp.IsWon) {
+                        opp.StageName = closedStageName;
+                        dmlWrapper.objectsToUpdate.add(opp);
+                    }
+                }
+            }
+        }
+
+        return dmlWrapper;
     }
 
     /*******************************************************************************************************
@@ -122,11 +154,16 @@ public class PMT_Payment_TDTM extends TDTM_Runnable {
 
         DmlWrapper dmlWrapper = new DmlWrapper();
 
-        // Create new Payments as necessary
+        // Create new Payments as necessary. Also (when Advanced Curr Mgt is not enabled), auto close the
+        // Opportunity if that is enabled in settings and the total Payments == Opp.Amount.
+        // If ACM is enabled, changes to payment records will not cause the Opportunity trigger to execute, so
+        // the decision to close the Opportunity is handled in the runForPayments() method.
+        // However, even if ACM is enabled, if the Opportunity.Amount is updated to match the total Payments
+        // the Opportunity should still be marked as closed.
         PMT_PaymentCreator pc = new PMT_PaymentCreator(mapIdOppNew, mapIdOppOld, triggerAction, dmlWrapper);
 
         //if currency has changed, reset payment currencies
-        if (triggerAction == TDTM_Runnable.Action.AfterUpdate && UTIL_Currency.getInstance().isMultiCurrencyOrganization()) {
+        if (triggerAction == TDTM_Runnable.Action.AfterUpdate && UserInfo.isMultiCurrencyOrganization()) {
             List<Opportunity> listOppsForProcessing = new List<Opportunity>();
             for (integer i = 0; i < newlist.size(); i++) {
                 Opportunity opp = newlist[i];

--- a/src/classes/PMT_Payment_TDTM.cls
+++ b/src/classes/PMT_Payment_TDTM.cls
@@ -120,7 +120,7 @@ public class PMT_Payment_TDTM extends TDTM_Runnable {
             npe01__Contacts_And_Orgs_Settings__c ContactSettings = UTIL_CustomSettingsFacade.getContactsSettings();
             String closedStageName = ContactSettings.Payments_Auto_Close_Stage_Name__c;
 
-            // TODO
+            // TODO: Update when merge with full Multi-Currency support branch
             Boolean isACMEnabled = true; // UTIL_Currency.getInstance().isAdvancedCurrencyManagementEnabled();
             if (isACMEnabled && !String.isEmpty(closedStageName)) {
                 // Loop through all the queried Opps with the subquery on payments

--- a/src/classes/PMT_Payment_TEST.cls
+++ b/src/classes/PMT_Payment_TEST.cls
@@ -215,7 +215,8 @@ private class PMT_Payment_TEST {
         UTIL_Currency_TEST.UtilCurrencyMock mock = new UTIL_Currency_TEST.UtilCurrencyMock();
         mock.getCurrencySymbolReturn = 'USD';
         mock.isMultiCurrencyOrganizationReturn = true;
-//        mock.isAdvancedMultiCurrencyOrgReturn = true; // TODO
+        // TODO: Update when merge with full Multi-Currency support branch
+        // mock.isAdvancedMultiCurrencyOrgReturn = true;
         UTIL_Currency.instance = mock;
 
         String closedWonStage = UTIL_UnitTestData_TEST.getClosedWonStage();

--- a/src/classes/PMT_Payment_TEST.cls
+++ b/src/classes/PMT_Payment_TEST.cls
@@ -200,6 +200,88 @@ private class PMT_Payment_TEST {
         }
     }
 
+    /**
+     * @description Test that when Advanced Currency Management (ACM) is enabled, the logic that determines
+     * when an Opportunity should be auto-closed still executes properly. In this scenario, the roll-ups from
+     * Payment to the Opportunity object do not work, so a trigger on the Payment object is used instead.
+     * This test validates that logic by setting mock to pretend that ACM is enabled.
+     */
+    private static testMethod void testOpportunityWillAutoCloseWithACMEnabled() {
+
+        // Pretend the advanced multi-currency is enabled
+        // Note: Trigger methods need to use UserInfo.isMultiCurrencyOrganization() to determine if the
+        // CurrencyIsoCode should be queried to avoid an error when multi-currency is actually enabled
+        // in an organization.
+        UTIL_Currency_TEST.UtilCurrencyMock mock = new UTIL_Currency_TEST.UtilCurrencyMock();
+        mock.getCurrencySymbolReturn = 'USD';
+        mock.isMultiCurrencyOrganizationReturn = true;
+//        mock.isAdvancedMultiCurrencyOrgReturn = true; // TODO
+        UTIL_Currency.instance = mock;
+
+        String closedWonStage = UTIL_UnitTestData_TEST.getClosedWonStage();
+        String openStage = UTIL_UnitTestData_TEST.getOpenStage();
+
+        if (String.isEmpty(closedWonStage) || String.isEmpty(openStage)) {
+            System.debug(
+                    System.LoggingLevel.ERROR,
+                    'Organization settings do not contain the necessary opportunity stages to run this test. Not running test.'
+            );
+            return;
+        }
+
+        // Disable auto payment creation fro this test
+        UTIL_CustomSettingsFacade.getContactsSettings().npe01__Payments_Enabled__c = false;
+        UTIL_CustomSettingsFacade.getContactsSettings().Payments_Auto_Close_Stage_Name__c = closedWonStage;
+
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+
+        Opportunity opp = new Opportunity(
+                Name='success',
+                Amount = 500,
+                AccountID=acc.id,
+                CloseDate=system.today(),
+                StageName=openStage);
+        insert opp;
+
+        List<npe01__OppPayment__c> pmts = new List<npe01__OppPayment__c>{
+                new npe01__OppPayment__c(
+                        npe01__Paid__c = true,
+                        npe01__Payment_Amount__c = 250,
+                        npe01__Opportunity__c = opp.Id
+                ),
+                new npe01__OppPayment__c(
+                        npe01__Paid__c = false,
+                        npe01__Payment_Amount__c = 250,
+                        npe01__Opportunity__c = opp.Id
+                )
+        };
+
+        Test.startTest();
+
+        insert pmts;
+
+        opp = [SELECT Name, Amount, StageName, IsClosed, IsWon FROM Opportunity WHERE Id = :opp.Id LIMIT 1];
+        System.assertEquals(openStage, opp.StageName, 'The Opportunity should still be in an open state');
+
+        // Mark the payment as Paid
+        pmts[1].npe01__Paid__c = true;
+        update pmts;
+
+        Test.stopTest();
+
+        // Verify that the Opportunity is now closed
+        /*opp = [SELECT Name, Amount, StageName, IsClosed, IsWon, npe01__Number_Of_Payments__c,
+                npe01__Amount_Outstanding__c, npe01__Payments_Made__c,
+                (SELECT npe01__Paid__c, npe01__Payment_Amount__c, npe01__Written_Off__c FROM npe01__OppPayment__r)
+                FROM Opportunity
+                WHERE Id = :opp.Id LIMIT 1];*/
+        opp = [SELECT Name, Amount, StageName, IsClosed, IsWon FROM Opportunity WHERE Id = :opp.Id LIMIT 1];
+        System.assertEquals(closedWonStage, opp.StageName);
+    }
+
+    /**
+     * @description Reusable utility method to retrieve a specific payment record for an Opportunity
+     */
     private static npe01__OppPayment__c getPaymentRecord(Id oppId) {
         String soql = 'SELECT Id, CurrencyIsoCode FROM npe01__OppPayment__c WHERE npe01__Opportunity__c = \'' + oppId + '\' LIMIT 1';
         return (npe01__OppPayment__c)database.query(soql);

--- a/src/classes/PMT_Payment_TEST.cls
+++ b/src/classes/PMT_Payment_TEST.cls
@@ -216,7 +216,7 @@ private class PMT_Payment_TEST {
         mock.getCurrencySymbolReturn = 'USD';
         mock.isMultiCurrencyOrganizationReturn = true;
         // TODO: Update when merge with full Multi-Currency support branch
-        // mock.isAdvancedMultiCurrencyOrgReturn = true;
+        // mock.isAdvancedCurrencyManagementEnabledReturn = true;
         UTIL_Currency.instance = mock;
 
         String closedWonStage = UTIL_UnitTestData_TEST.getClosedWonStage();

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -197,7 +197,7 @@ public without sharing class TDTM_DefaultConfig {
         // Payment records - currency code validation
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'PMT_Payment_TDTM', Load_Order__c = 0, Object__c = 'npe01__OppPayment__c',
-                Trigger_Action__c = 'BeforeUpdate;BeforeInsert'));
+                Trigger_Action__c = 'BeforeUpdate;BeforeInsert;AfterInsert;AfterUpdate'));
 
         // OpportunityContactRoles on Opportunity
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,

--- a/src/pages/PMT_PaymentWizard.page
+++ b/src/pages/PMT_PaymentWizard.page
@@ -139,7 +139,10 @@ Copyright (c) 2008 Evan Callahan, evanc@npowerseattle.org, NPower Seattle, 403 2
                                 <label class="slds-form-element__label" for="oppAmount">{!$ObjectType.Opportunity.Fields.Amount.Label}</label>
                                 <div class="slds-form-element__control">
                                     <span class="slds-form-element__static">
-                                        <apex:outputField value="{!currentOpp.Amount}" id="oppAmount"/>
+                                        <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                        <apex:outputText value="{0, number, ###,##0.00}" id="oppAmount">
+                                            <apex:param value="{!currentOpp.Amount}"/>
+                                        </apex:outputText>
                                     </span>
                                 </div>
                             </div>
@@ -313,7 +316,10 @@ Copyright (c) 2008 Evan Callahan, evanc@npowerseattle.org, NPower Seattle, 403 2
                             <div class="slds-form-element">
                                 <label class="slds-form-element__label" for="oppAmount4">{!$ObjectType.Opportunity.Fields.Amount.Label}</label>
                                 <div class="slds-form-element__control">
-                                    <apex:outputField value="{!currentOpp.Amount}" id="oppAmount4" styleClass="slds-form-element__static"/>
+                                    <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                    <apex:outputText value="{0, number, ###,##0.00}" id="oppAmount4" styleClass="slds-form-element__static">
+                                        <apex:param value="{!currentOpp.Amount}"/>
+                                    </apex:outputText>
                                 </div>
                             </div>
                             <div class="slds-form-element">

--- a/src/pages/PMT_PaymentWizard.page
+++ b/src/pages/PMT_PaymentWizard.page
@@ -147,7 +147,10 @@ Copyright (c) 2008 Evan Callahan, evanc@npowerseattle.org, NPower Seattle, 403 2
                                 <label class="slds-form-element__label" for="oppPmtMade">{!$ObjectType.Opportunity.Fields.npe01__Payments_Made__c.Label}</label>
                                 <div class="slds-form-element__control">
                                     <span class="slds-form-element__static">
-                                        <apex:outputField value="{!currentOpp.npe01__Payments_Made__c}" id="oppPmtMade"/>
+                                        <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                        <apex:outputText value="{0, number, ###,##0.00}"  id="oppPmtMade">
+                                            <apex:param value="{!totalPaymentsMade}"/>
+                                        </apex:outputText>
                                     </span>
                                 </div>
                             </div>
@@ -155,7 +158,10 @@ Copyright (c) 2008 Evan Callahan, evanc@npowerseattle.org, NPower Seattle, 403 2
                                 <label class="slds-form-element__label" for="oppAmtOutstanding">{!$ObjectType.Opportunity.Fields.npe01__Amount_Outstanding__c.Label}</label>
                                 <div class="slds-form-element__control">
                                     <span class="slds-form-element__static">
-                                        <apex:outputField value="{!currentOpp.npe01__Amount_Outstanding__c}" id="oppAmtOutstanding"/>
+                                        <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                        <apex:outputText value="{0, number, ###,##0.00}"  id="oppAmtOutstanding">
+                                            <apex:param value="{!amountOutstanding}"/>
+                                        </apex:outputText>
                                     </span>
                                 </div>
                             </div>
@@ -313,13 +319,19 @@ Copyright (c) 2008 Evan Callahan, evanc@npowerseattle.org, NPower Seattle, 403 2
                             <div class="slds-form-element">
                                 <label class="slds-form-element__label" for="oppPmtMade2">{!$ObjectType.Opportunity.Fields.npe01__Payments_Made__c.Label}</label>
                                 <div class="slds-form-element__control">
-                                    <apex:outputField value="{!currentOpp.npe01__Payments_Made__c}" id="oppPmtMade2" styleClass="slds-form-element__static"/>
+                                    <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                    <apex:outputText value="{0, number, ###,##0.00}"  id="oppPmtMade2" styleClass="slds-form-element__static">
+                                        <apex:param value="{!totalPaymentsMade}"/>
+                                    </apex:outputText>
                                 </div>
                             </div>
                             <div class="slds-form-element">
                                 <label class="slds-form-element__label" for="oppAmtOutstanding2">{!$ObjectType.Opportunity.Fields.npe01__Amount_Outstanding__c.Label}</label>
                                 <div class="slds-form-element__control">
-                                    <apex:outputField value="{!currentOpp.npe01__Amount_Outstanding__c}" id="oppAmtOutstanding2" styleClass="slds-form-element__static"/>
+                                    <span class="slds-form-element__addon">{!currencySymbol}</span>
+                                    <apex:outputText value="{0, number, ###,##0.00}"  id="oppAmtOutstanding2" styleClass="slds-form-element__static">
+                                        <apex:param value="{!amountOutstanding}"/>
+                                    </apex:outputText>
                                 </div>
                             </div>
                         </div>
@@ -339,7 +351,7 @@ Copyright (c) 2008 Evan Callahan, evanc@npowerseattle.org, NPower Seattle, 403 2
                     <div class="slds-notify slds-notify--alert slds-theme--inverse-text slds-theme--alert-texture slds-m-around--medium" role="alert">
                         <apex:outputText value="{!$Label.pmtWizardWriteoffMessage}">
                            <apex:param value="{!outstanding_payments}"/>
-                           <apex:param value="{!currentOpp.npe01__Amount_Outstanding__c}"/>
+                           <apex:param value="{!currencySymbol}{!amountOutstanding}"/>
                         </apex:outputText>
                     </div>
                     <div class="slds-grid slds-wrap slds-grid--align-center">


### PR DESCRIPTION
When Advanced Currency Management is enabled in an Organization, there are 3 fields on the Opportunity that will stop functioning. Two of them are Roll-Up Summary fields from the Payment object and the third is a formula that references those two fields. In addition, the Opportunity.Amount field cannot be used with <Apex:OutputField> on the PaymentWizard VF page. This PR adds logic to manually calculate the total payments and amount outstanding to use with triggers (specifically to auto-close an Opportunity when TotalPayments==Opp.Amount), the payment wizard page controller, and unit tests. 

This merges into the feature/rollups branch only.

# Critical Changes

# Changes

# Issues Closed