### PR TITLE
Fix Health Check warning when trigger handler actions do not exactly match in alphabetical order

### DIFF
--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -587,8 +587,8 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
                         alreadyExists = true;
     
                         // Determine if order, action, active, async has changed
-                        if (defaultHandler.Load_Order__c != existingHandler.Load_Order__c || 
-                            defaultHandler.Trigger_Action__c != existingHandler.Trigger_Action__c ||
+                        if (defaultHandler.Load_Order__c != existingHandler.Load_Order__c ||
+                            !compareTriggerHandlerActions(defaultHandler, existingHandler) ||
                             defaultHandler.Active__c != existingHandler.Active__c ||
                             defaultHandler.Asynchronous__c != existingHandler.Asynchronous__c) {
                             
@@ -619,6 +619,25 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
         } catch (exception ex) {
             createDR(Label.healthLabelTriggerHandlerCheck, statusError, ex.getMessage(), null);                   
         }    
+    }
+
+    /**
+     * @description Compare the Trigger_Action list between two trigger handlers usnig logic that can ignore
+     * both case and the sequence of the actions in the list.
+     */
+    private static Boolean compareTriggerHandlerActions(Trigger_Handler__c handlerA, Trigger_Handler__c handlerB) {
+        List<String> listA = handlerA.Trigger_Action__c.toLowerCase().split(';');
+        List<String> listB = handlerB.Trigger_Action__c.toLowerCase().split(';');
+
+        Set<String> unionBintoA = new Set<String>();
+        unionBintoA.addAll(listA);
+        unionBintoA.addAll(listB);
+
+        // The number of elements in in unionBintoA should match the number of elements in listA and listB
+        if (listA.size() != listB.size() || unionBintoA.size() != listA.size() || unionBintoA.size() != listB.size()) {
+            return false;
+        }
+        return true;
     }
     
     /*********************************************************************************************************

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -572,6 +572,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
     * @description Verifies that the default trigger handlers exist in the Trigger_Handler object, and warns
     * about any NPSP triggers marked as Async.
     */
+    @TestVisible
     private void verifyTriggerHandlers() {
         try {
             List<Trigger_Handler__c> listHandlersDefault = TDTM_DefaultConfig.getDefaultRecords();

--- a/src/classes/STG_PanelHealthCheck_TEST.cls
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls
@@ -170,4 +170,47 @@ public with sharing class STG_PanelHealthCheck_TEST {
         system.assertEquals(1,  hc.listDR[0].strDetails.countMatches('<br/>'));
         system.assertEquals(STG_PanelHealthCheck_CTRL.statusError, hc.listDR[0].strStatus);
     }
+
+    /*******************************************************************************************************
+    * @description verify trigger handler action comparisons work as expected if case & sequence are not an exact match
+    */
+    static testMethod void verifyTriggerHandlers_succeed() {
+        List<Trigger_Handler__c> listHandlersDefault = TDTM_DefaultConfig.getDefaultRecords();
+        for (Trigger_Handler__c th : listHandlersDefault) {
+            if (th.Trigger_Action__c == 'BeforeUpdate;AfterUpdate') {
+                // Change the order of these in the list to verify that the logic ignores sequence & caes
+                th.Trigger_Action__c = 'AfterUpdate;Beforeupdate';
+                break;
+            }
+        }
+        insert listHandlersDefault;
+
+        Test.startTest();
+
+        STG_PanelHealthCheck_CTRL hc = new STG_PanelHealthCheck_CTRL();
+        hc.verifyTriggerHandlers();
+
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusSuccess, hc.listDR[0].strStatus,
+                'The result status should be Success\n' + hc.listDR[0]);
+    }
+
+    /*******************************************************************************************************
+    * @description verify that the trigger handler check picks up a missing trigger and a load order change
+    */
+    static testMethod void verifyTriggerHandlers_fail() {
+        List<Trigger_Handler__c> listHandlersDefault = TDTM_DefaultConfig.getDefaultRecords();
+        listHandlersDefault[1].Load_Order__c = 10;
+        insert listHandlersDefault;
+        delete listHandlersDefault[0];  // delete one record
+
+        Test.startTest();
+
+        STG_PanelHealthCheck_CTRL hc = new STG_PanelHealthCheck_CTRL();
+        hc.verifyTriggerHandlers();
+
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusWarning, hc.listDR[0].strStatus,
+                'The result status should be Warning\n' + hc.listDR[0]);
+        System.assertEquals(2, hc.listDR[0].strDetails.countMatches('<li>'),
+                'There should be two warning messages generated for this\n' + hc.listDR[0]);
+    }
 }


### PR DESCRIPTION
Update the Health Check trigger verification logic to compare the trigger actions without regards to the order or case of the actions in the lists.

# Critical Changes

# Changes

# Issues Closed

Fixes #2732 