### PR TITLE
Removing setting of scheduled jobs from the post install script.

### DIFF
--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -52,7 +52,6 @@ global without sharing class STG_InstallScript implements InstallHandler {
                 insertTdtmDefaults(null);
             }
             UTIL_MasterSchedulableHelper.abortOldScheduledJobs();
-            UTIL_MasterSchedulableHelper.scheduleJobsFromOldObject();
         } catch(Exception e) {
             sendEmailOnInstallError(e, context);
             ERR_Handler.processError(e, ERR_Handler_API.Context.STTG);

--- a/src/classes/STG_InstallScript_TEST2.cls
+++ b/src/classes/STG_InstallScript_TEST2.cls
@@ -130,48 +130,4 @@ public with sharing class STG_InstallScript_TEST2 {
         System.assertEquals(2, newHandlers[2].Load_Order__c);     
         System.assertEquals('AfterInsert;AfterDelete', newHandlers[2].Trigger_Action__c);     
     }
-
-    public static testmethod void schedulersChanged() {
-        List<Schedulable__c> schedForInsert = new List<Schedulable__c>();
-        schedForInsert.add(new Schedulable__c(Name = 'Recurring Donation Updates', Class_Name__c = 'RD_RecurringDonations_BATCH', 
-                    Active__c = true, Frequency__c = 'Daily'));
-        schedForInsert.add(new Schedulable__c(Name = 'Opportunity Account Rollups', Class_Name__c = 'RLLP_OppAccRollup_BATCH', 
-                Active__c = true, Frequency__c = 'Daily'));
-        schedForInsert.add(new Schedulable__c(Name = 'Opportunity Contact Rollups', Class_Name__c = 'RLLP_OppContactRollup_BATCH', 
-                Active__c = true, Frequency__c = 'Daily'));
-        schedForInsert.add(new Schedulable__c(Name = 'Opportunity Household Rollups', Class_Name__c = 'RLLP_OppHouseholdRollup_BATCH', 
-                Active__c = false, Frequency__c = 'Daily'));
-        schedForInsert.add(new Schedulable__c(Name = 'Opportunity Soft Credit Rollups', Class_Name__c = 'RLLP_OppSoftCreditRollup_BATCH', 
-                Active__c = false, Frequency__c = 'Daily'));
-        schedForInsert.add(new Schedulable__c(Name = 'Seasonal Address Updates', Class_Name__c = 'ADDR_SEASONAL_SCHED',
-                Active__c = false, Frequency__c = 'Daily'));
-        schedForInsert.add(new Schedulable__c(Name = 'GAU Allocations Rollups', Class_Name__c = 'ALLO_Rollup_SCHED',
-                Active__c = false, Frequency__c = 'Daily'));
-
-        insert schedForInsert;
-
-        //abort already scheduled jobs so test can re-sechedule them
-        for(CronTrigger ct : [SELECT Id FROM CronTrigger WHERE CronJobDetail.JobType = '7']) {
-            System.abortJob(ct.Id);
-        }
-
-        Test.startTest();
-        UTIL_MasterSchedulableHelper.scheduleJobsFromOldObject();
-        Test.stopTest();
-
-        Set<String> chronJobNames = new Set<String>();
-        for(CronTrigger ct : [SELECT CronJobDetail.Name FROM CronTrigger WHERE CronJobDetail.JobType = '7']) {
-            chronJobNames.add(ct.CronJobDetail.Name);
-        }
-
-        System.assert(chronJobNames.contains('NPSP 00 - Error Processing'));
-        System.assert(chronJobNames.contains('NPSP 01 - Opportunity Account Rollups'));
-        System.assert(chronJobNames.contains('NPSP 02 - Opportunity Contact Rollups'));
-        System.assert(chronJobNames.contains('NPSP 06 - Recurring Donation Updates'));
-
-        System.assert(!chronJobNames.contains('NPSP 03 - Opportunity Household Rollups'));
-        System.assert(!chronJobNames.contains('NPSP 04 - Opportunity Soft Credit Rollups'));
-        System.assert(!chronJobNames.contains('NPSP 05 - GAU Allocation Rollups'));
-
-    }
 }

--- a/src/classes/UTIL_MasterSchedulableHelper.cls
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls
@@ -76,49 +76,6 @@ public without sharing class UTIL_MasterSchedulableHelper {
     };
 
     /*******************************************************************************************************
-    * @description Schedules all NPSP jobs based on whether they are marked Active in the old Schedulable__c
-    * table, then clears the Schedulable__c table. If some jobs were disabled, sets the setting to prevent
-    * NPSP from auto scheduling them in the future. This method is only called from the post install script. 
-    * @return void
-    */
-    public static void scheduleJobsFromOldObject() {
-        List<Schedulable__c> scheduleObjects = [SELECT Id, Class_Name__c, Active__c FROM Schedulable__c];
-
-        Boolean allJobsActive = true;
-        for (Schedulable__c sched : scheduleObjects) { 
-            if (!sched.Active__c) {
-                allJobsActive = false;
-            }
-        }
-
-        //if all jobs are still active or no records are in the schedulable table, schedule them all. 
-        //This will be the default once this method has run once, since we are
-        //deleting all Schedulable__c records at the end of this method.
-        if (scheduleObjects.isEmpty() || allJobsActive) {
-            setScheduledJobs();
-        } else {
-            //there was no Schedulable__c object for error processing, so create it anyway
-            createJob('NPSP 00 - Error Processing');
-            for (Schedulable__c sched : scheduleObjects) {
-                if (sched.Active__c) {
-                    for (String jobName : defaultScheduledJobs.keySet()) {
-                        if (sched.Class_Name__c.equalsIgnoreCase(defaultScheduledJobs.get(jobname)[1])) {
-                            createJob(jobName);
-                        }
-                    }
-                }
-            }
-            Error_Settings__c orgErrorSettings = UTIL_CustomSettingsFacade.getOrgErrorSettings();
-            orgErrorSettings.Don_t_Auto_Schedule_Default_NPSP_Jobs__c = true;
-            if (!Test.isRunningTest()) {
-                update orgErrorSettings;
-            }
-        }
-
-        delete scheduleObjects;
-    }
-
-    /*******************************************************************************************************
     * @description Schedules all NPSP jobs that are not already scheduled.
     * @return void
     */


### PR DESCRIPTION
This removes all attempted creation of scheduled jobs during the post install script, in order to avoid sending error messages for new jobs that the post-install [special user](https://salesforce.stackexchange.com/questions/32607/installhandler-runs-under-a-special-ghost-user-what-rights-does-it-have) doesn't have permissions for.

This is a stop-gap measure to avoid sending unnecessary and confusing error messages to our users. Users will have to access NPSP settings for jobs to be scheduled. An investigation into a better way users to manage NPSP scheduled jobs will be necessary to improve on this user experience.

As a side-effect of this change, we no longer attempt to process the old Schedulable__c objects to determine if any scheduled jobs had previously been disabled when attempting to re-schedule them. This will only impact an extremely limited subset of users: users are on NPSP 3, but have been excluded from push upgrades since before NPSP [3.83](https://github.com/SalesforceFoundation/Cumulus/releases/tag/rel%2F3.83), and that had disabled some scheduled jobs via the Schedulable__c.Active__c checkbox.


# Critical Changes

# Changes

# Issues Closed