### PR TITLE
Feature/kofi healthcheck account rt

### DIFF
--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -321,7 +321,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
                         Label.healthLabelAccountDefaultRT, 
                         statusError, 
                         String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountRecordTypeInfo.getName()}),
-                        String.format(Label.healthSolutionAccountDefaultRTIssue, new List<String>{accountRecordTypeInfo.getName()})
+                        Label.healthSolutionAccountDefaultRTIssue
                     );
                     return;
                 }

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -163,7 +163,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
         verifyAccountModel(); 
         verifyAccountData();
         verifyAccountData2();
-        verifyAccountDefaultRecordType();
+        verifyAccountModelRecordType();
         verifyContactData();
         verifyNoOrphanedHouseholds();
         verifyNoOrphanedOne2OneAccounts();
@@ -291,19 +291,19 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
     }
 
     /*********************************************************************************************************
-    * @description Verifies HouseHold RecordType is not the default RecordType for the current User.
+    * @description Verifies HouseHold and One To One RecordTypes are not the default RecordType for the current User.
     */
     @TestVisible
-    private void verifyAccountDefaultRecordType() {
+    private void verifyAccountModelRecordType() {
         try {
            
-            Id npspHouseholdRecordType = UTIL_CustomSettingsFacade.getOrgContactsSettings().npe01__HH_Account_RecordTypeID__c;
-            Id npspOneToOneRecordType = UTIL_CustomSettingsFacade.getOrgContactsSettings().npe01__One_to_One_RecordTypeID__c;
-            Map<Id,Schema.RecordTypeInfo> accountRecordTypeInfosById = Account.SObjectType.getDescribe().getRecordTypeInfosById();
+            Id npspHouseholdRecordType = STG_Panel.stgService.stgCon.npe01__HH_Account_RecordTypeID__c;
+            Id npspOneToOneRecordType = STG_Panel.stgService.stgCon.npe01__One_to_One_RecordTypeID__c;
+            Map<Id,Schema.RecordTypeInfo> accountRecordTypeInfosById = UTIL_Describe.getObjectDescribe('Account').getRecordTypeInfosById();
 
-            //Check if the Household and the One To One RecordRecord Type in the Settings is valid. 
-            //This should never happen, unless the User manually updated the Account Model Record Type in the Custom Settings.
-            if(
+            //Check if the Household and the One To One Record Type in the Settings are valid. 
+            //This should never happen, unless the User manually updates the Account Model Record Type in the Custom Settings.
+            if (
                 (npspHouseholdRecordType != null && accountRecordTypeInfosById.keySet().contains(npspHouseholdRecordType) == false) ||
                 (npspOneToOneRecordType != null && accountRecordTypeInfosById.keySet().contains(npspOneToOneRecordType) == false)
             ) {
@@ -311,25 +311,23 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
                 return;
             }
 
-            //Check the Household and One To One Record Type in the Settings and create a Failed Test if it is the Default one on the Account.
-            for(Schema.RecordTypeInfo accountRecordTypeInfo : accountRecordTypeInfosById.values()) {
-                if(
+            //Check the Household and One To One Record Type in the Settings and create a failed test if it is the Default one on the Account.
+            for (Schema.RecordTypeInfo accountRecordTypeInfo : accountRecordTypeInfosById.values()) {
+                if (
                     accountRecordTypeInfo.isDefaultRecordTypeMapping() &&
-                    (
-                        accountRecordTypeInfo.getRecordTypeId() == npspHouseholdRecordType ||
-                        accountRecordTypeInfo.getRecordTypeId() == npspOneToOneRecordType
-                    )
+                    (accountRecordTypeInfo.getRecordTypeId() == npspHouseholdRecordType || accountRecordTypeInfo.getRecordTypeId() == npspOneToOneRecordType)
                 ) {
                     createDR(
                         Label.healthLabelAccountDefaultRT, 
                         statusError, 
-                        Label.healthDetailsAccountDefaultRTIssue, 
-                        String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountRecordTypeInfo.getName()})
+                        String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountRecordTypeInfo.getName()}),
+                        String.format(Label.healthSolutionAccountDefaultRTIssue, new List<String>{accountRecordTypeInfo.getName()})
                     );
                     return;
                 }
             }
 
+            //Create a success test
             createDR(Label.healthLabelAccountDefaultRT, statusSuccess, null, null);
         }
         catch(Exception ex) {

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -163,6 +163,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
         verifyAccountModel(); 
         verifyAccountData();
         verifyAccountData2();
+        verifyAccountDefaultRecordType();
         verifyContactData();
         verifyNoOrphanedHouseholds();
         verifyNoOrphanedOne2OneAccounts();
@@ -287,6 +288,53 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
         } catch (exception ex) {
             createDR(Label.healthLabelAccountModelData, statusError,  ex.getMessage(), null);                   
         }    
+    }
+
+    /*********************************************************************************************************
+    * @description Verifies HouseHold RecordType is not the default RecordType for the current User.
+    */
+    @TestVisible
+    private void verifyAccountDefaultRecordType() {
+        try {
+           
+            Id npspHouseholdRecordType = UTIL_CustomSettingsFacade.getOrgContactsSettings().npe01__HH_Account_RecordTypeID__c;
+            Id npspOneToOneRecordType = UTIL_CustomSettingsFacade.getOrgContactsSettings().npe01__One_to_One_RecordTypeID__c;
+            Map<Id,Schema.RecordTypeInfo> accountRecordTypeInfosById = Account.SObjectType.getDescribe().getRecordTypeInfosById();
+
+            //Check if the Household and the One To One RecordRecord Type in the Settings is valid. 
+            //This should never happen, unless the User manually updated the Account Model Record Type in the Custom Settings.
+            if(
+                (npspHouseholdRecordType != null && accountRecordTypeInfosById.keySet().contains(npspHouseholdRecordType) == false) ||
+                (npspOneToOneRecordType != null && accountRecordTypeInfosById.keySet().contains(npspOneToOneRecordType) == false)
+            ) {
+                createDR(Label.healthLabelAccountDefaultRT, statusError, Label.healthDetailsAccountDefaultRTInvalid, Label.healthSolutionAccountDefaultRTInvalid);
+                return;
+            }
+
+            //Check the Household and One To One Record Type in the Settings and create a Failed Test if it is the Default one on the Account.
+            for(Schema.RecordTypeInfo accountRecordTypeInfo : accountRecordTypeInfosById.values()) {
+                if(
+                    accountRecordTypeInfo.isDefaultRecordTypeMapping() &&
+                    (
+                        accountRecordTypeInfo.getRecordTypeId() == npspHouseholdRecordType ||
+                        accountRecordTypeInfo.getRecordTypeId() == npspOneToOneRecordType
+                    )
+                ) {
+                    createDR(
+                        Label.healthLabelAccountDefaultRT, 
+                        statusError, 
+                        Label.healthDetailsAccountDefaultRTIssue, 
+                        String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountRecordTypeInfo.getName()})
+                    );
+                    return;
+                }
+            }
+
+            createDR(Label.healthLabelAccountDefaultRT, statusSuccess, null, null);
+        }
+        catch(Exception ex) {
+            createDR(Label.healthLabelAccountDefaultRT, statusError,  ex.getMessage(), null); 
+        } 
     }
 
     /*********************************************************************************************************

--- a/src/classes/STG_PanelHealthCheck_TEST.cls
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls
@@ -215,16 +215,17 @@ public with sharing class STG_PanelHealthCheck_TEST {
     }
 
     /*******************************************************************************************************
-    * @description In this test scenario, we set the a non default Household Record Type in the Contact And Orgs Settings.
-    * This should create a Failed Detect Result the Test.
+    * @description In this test scenario, we set a non default Household Record Type in the Contact And Orgs Settings.
+    * This should create a Success Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsHHRT() {
         //Check if the Org has more than 1 Record Type for Account.
+        //In case there is only one RecordType, it will be the default, therefore we should run this test.
         Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
         if(Account.SObjectType.getDescribe().getRecordTypeInfos().size() < 2) {
             return;
         }
-        //Get the Default Account RecordType for the current user.
+        //Get a non default Account RecordType for the current user.
         for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
             if(accountRecordTypeInfo.isDefaultRecordTypeMapping() == false) {
                 accountDefaultRecordTypeInfo = accountRecordTypeInfo;
@@ -237,9 +238,11 @@ public with sharing class STG_PanelHealthCheck_TEST {
             new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
         );
 
+        Test.startTest();
         //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
         //Confirm there is a Success Detect Result
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
@@ -250,16 +253,17 @@ public with sharing class STG_PanelHealthCheck_TEST {
     }
 
     /*******************************************************************************************************
-    * @description In this test scenario, we set the a non default One To One Record Type in the Contact And Orgs Settings.
-    * This should create a Failed Detect Result the Test.
+    * @description In this test scenario, we set a non default One To One Record Type in the Contact And Orgs Settings.
+    * This should create a Success Detect Result the Test.
     */
     static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsOneToOneRT() {
         //Check if the Org has more than 1 Record Type for Account.
+        //In case there is only one RecordType, it will be the default, therefore we should run this test.
         Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
         if(Account.SObjectType.getDescribe().getRecordTypeInfos().size() < 2) {
             return;
         }
-        //Get the Default Account RecordType for the current user.
+        //Get the non default Account RecordType for the current user.
         for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
             if(accountRecordTypeInfo.isDefaultRecordTypeMapping() == false) {
                 accountDefaultRecordTypeInfo = accountRecordTypeInfo;
@@ -272,9 +276,11 @@ public with sharing class STG_PanelHealthCheck_TEST {
             new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
         );
 
+        Test.startTest();
         //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
         //Confirm there is a Success Detect Result
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
@@ -303,9 +309,11 @@ public with sharing class STG_PanelHealthCheck_TEST {
             new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
         );
 
+        Test.startTest();
         //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
         //Confirm there is a Failed Detect Result
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
@@ -337,9 +345,11 @@ public with sharing class STG_PanelHealthCheck_TEST {
             new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
         );
 
+        Test.startTest();
         //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
         //Confirm there is a Failed Detect Result
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
@@ -358,19 +368,22 @@ public with sharing class STG_PanelHealthCheck_TEST {
     * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_InvalidRT_In_SettingsHHRT() {
-         //Get a random opportunity RecordType for the current user.
+        //Get a random opportunity RecordType for the current user.
         Schema.RecordTypeInfo opportunityRecordTypeInfo = Opportunity.SObjectType.getDescribe().getRecordTypeInfos()[0];
 
-        //Set the opportunity Record in the One To One Model Custom Settings
+        //Set the opportunity Record in the Household Model Custom Settings. 
+        //The goal is test an invalid Account Record Type in the Custom Settings.
         npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
             new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
         );
 
-       //Run the Health Check to verify the Account default Record Type.
+        Test.startTest();
+        //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
-        //Confirm there is a Failed Detect Result
+        //Confirm there is a Failed Detect Result, because the logic is expecting an Account Record Type.
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
         System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
         System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
@@ -387,14 +400,17 @@ public with sharing class STG_PanelHealthCheck_TEST {
         //Get a random Contact RecordType for the current user.
         Schema.RecordTypeInfo opportunityRecordTypeInfo = Opportunity.SObjectType.getDescribe().getRecordTypeInfos()[0];
 
-        //Set the Contact Record in the One To One Model Custom Settings
+        //Set the Contact Record in the One To One Model Custom Settings.
+        //The goal is test an invalid Account Record Type in the Custom Settings.
         npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
             new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
         );
 
+        Test.startTest();
         //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
         //Confirm there is a Failed Detect Result
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
@@ -409,16 +425,18 @@ public with sharing class STG_PanelHealthCheck_TEST {
     * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsHHRT() {
-        //Set the default Account Record in the One To One Model Custom Settings
+        //Set an invalid Account Record ID in the Household Model Custom Settings
         npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
             new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = 'NOT_AN_ID')
         );
 
+        Test.startTest();
         //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
-        //Confirm there is a Failed Detect Result
+        //Confirm there is a Failed Detect Result, because of the invalid ID
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
         System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
         System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
@@ -431,16 +449,18 @@ public with sharing class STG_PanelHealthCheck_TEST {
     * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsOneToOneRT() {
-        //Set the Contact Record in the One To One Model Custom Settings
+        //Set an invalid Account Record ID in the One To One Model Custom Settings
         npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
             new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = 'NOT_AN_ID')
         );
 
+        Test.startTest();
         //Run the Health Check to verify the Account default Record Type.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
         panelHealthCheckController.verifyAccountDefaultRecordType();
+        Test.stopTest();
 
-        //Confirm there is a Failed Detect Result
+        //Confirm there is a Failed Detect Result, because of the invalid ID
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
         System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
         System.assertEquals(true, String.isNotBlank(panelHealthCheckController.listDR[0].strDetails), 'A System.Exception should be thrown');

--- a/src/classes/STG_PanelHealthCheck_TEST.cls
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls
@@ -341,7 +341,7 @@ public with sharing class STG_PanelHealthCheck_TEST {
             panelHealthCheckController.listDR[0].strDetails
         );
         System.assertEquals(
-            String.format(Label.healthSolutionAccountDefaultRTIssue, new List<String>{accountDefaultRecordTypeInfo.getName()}),
+            Label.healthSolutionAccountDefaultRTIssue,
             panelHealthCheckController.listDR[0].strSolution
         );
     }

--- a/src/classes/STG_PanelHealthCheck_TEST.cls
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls
@@ -213,4 +213,264 @@ public with sharing class STG_PanelHealthCheck_TEST {
         System.assertEquals(2, hc.listDR[0].strDetails.countMatches('<li>'),
                 'There should be two warning messages generated for this\n' + hc.listDR[0]);
     }
+
+    /*******************************************************************************************************
+    * @description verify that the health check test for verifying no missing payments succeeds when we
+    * have an opp with payments.
+    */ 
+    static testmethod void check() {
+
+        npe01__Contacts_And_Orgs_Settings__c PaymentsSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__Payments_Enabled__c= true));
+        
+        Account acc = new Account(name='my account');
+        insert acc;
+        Opportunity opp = new Opportunity(Name='my opp', StageName=UTIL_UnitTestData_TEST.getClosedWonStage(), 
+            CloseDate=system.Today(), Amount=100, AccountId=acc.Id);
+        insert opp;
+        system.assertEquals(1, [select count() from npe01__OppPayment__c]);
+        
+        STG_PanelHealthCheck_CTRL hc = new STG_PanelHealthCheck_CTRL();
+        system.assertEquals(0, hc.listDR.size());
+        
+        Test.startTest();
+        hc.verifyNoMissingOppPayments();
+        Test.stopTest();
+        
+        system.assertEquals(1, hc.listDR.size());
+        system.assertEquals(STG_PanelHealthCheck_CTRL.statusSuccess, hc.listDR[0].strStatus);
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set the a non default Household Record Type in the Contact And Orgs Settings.
+    *              This should create a Failed Detect Result the Test.
+    */ 
+    static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsHHRT() {
+        //Check if the Org has more than 1 Record Type for Account.
+        Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
+        if(Account.SObjectType.getDescribe().getRecordTypeInfos().size() < 2) {
+            return;
+        }
+        //Get the Default Account RecordType for the current user.
+        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
+            if(accountRecordTypeInfo.isDefaultRecordTypeMapping() == false) {
+                accountDefaultRecordTypeInfo = accountRecordTypeInfo;
+                break;
+            }
+        }
+
+        //Set the non default Account Record in the HouseHold Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
+        );
+
+        //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Success Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusSuccess, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(null, panelHealthCheckController.listDR[0].strDetails);
+        System.assertEquals(null, panelHealthCheckController.listDR[0].strSolution);
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set the a non default One To One Record Type in the Contact And Orgs Settings.
+    *              This should create a Failed Detect Result the Test.
+    */
+    static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsOneToOneRT() {
+        //Check if the Org has more than 1 Record Type for Account.
+        Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
+        if(Account.SObjectType.getDescribe().getRecordTypeInfos().size() < 2) {
+            return;
+        }
+        //Get the Default Account RecordType for the current user.
+        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
+            if(accountRecordTypeInfo.isDefaultRecordTypeMapping() == false) {
+                accountDefaultRecordTypeInfo = accountRecordTypeInfo;
+                break;
+            }
+        }
+
+        //Set the non default Account Record in the One To One Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
+        );
+
+        //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Success Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusSuccess, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(null, panelHealthCheckController.listDR[0].strDetails);
+        System.assertEquals(null, panelHealthCheckController.listDR[0].strSolution);
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set the Default Househod Record Type in the Contact And Orgs Settings.
+    *              This should create a Failed Detect Result the Test.
+    */ 
+    static testmethod void test_VerifyAccountDefaultRecordType_DefaultRT_In_SettingsHHRT() {
+        //Get the Default Account RecordType for the current user.
+        Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
+        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
+            if(accountRecordTypeInfo.isDefaultRecordTypeMapping()) {
+                accountDefaultRecordTypeInfo = accountRecordTypeInfo;
+                break;
+            }
+        }
+
+        //Set the default Account Record in the HouseHold Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
+        );
+
+        //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Failed Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName, 'The Dectect Result should be the one the');
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(Label.healthDetailsAccountDefaultRTIssue, panelHealthCheckController.listDR[0].strDetails);
+        System.assertEquals(
+            String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountDefaultRecordTypeInfo.getName()}),
+            panelHealthCheckController.listDR[0].strSolution
+        );
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set the Default One To One Record Type in the Contact And Orgs Settings.
+    *              This should create a Failed Detect Result the Test.
+    */ 
+    static testmethod void test_VerifyAccountDefaultRecordType_DefaultRT_In_SettingsOneToOneRT() {
+        //Get the Default Account RecordType for the current user.
+        Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
+        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
+            if(accountRecordTypeInfo.isDefaultRecordTypeMapping()) {
+                accountDefaultRecordTypeInfo = accountRecordTypeInfo;
+                break;
+            }
+        }
+
+        //Set the default Account Record in the One To One Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
+        );
+
+        //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Failed Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(Label.healthDetailsAccountDefaultRTIssue, panelHealthCheckController.listDR[0].strDetails);
+        System.assertEquals(
+            String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountDefaultRecordTypeInfo.getName()}),
+            panelHealthCheckController.listDR[0].strSolution
+        );
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set an Invalid value of Household Record Type in the opportunity And Orgs Settings.
+                   In this case, we use a opportunity Record Type as an invalid value for the One to One Record Type.
+    *              This should create a Failed Detect Result the Test.
+    */ 
+    static testmethod void test_VerifyAccountDefaultRecordType_InvalidRT_In_SettingsHHRT() {
+         //Get a random opportunity RecordType for the current user.
+        Schema.RecordTypeInfo opportunityRecordTypeInfo = Opportunity.SObjectType.getDescribe().getRecordTypeInfos()[0];
+
+        //Set the opportunity Record in the One To One Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
+        );
+
+       //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Failed Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(Label.healthDetailsAccountDefaultRTInvalid, panelHealthCheckController.listDR[0].strDetails);
+        System.assertEquals(Label.healthSolutionAccountDefaultRTInvalid, panelHealthCheckController.listDR[0].strSolution);
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set an Invalid value of One To One Record Type in the Contact And Orgs Settings.
+                   In this case, we use a Contact Record Type as an invalid value for the One to One Record Type.
+    *              This should create a Failed Detect Result the Test.
+    */ 
+    static testmethod void test_VerifyAccountDefaultRecordType_InvalidRT_In_SettingsOneToOneRT() {
+        //Get a random Contact RecordType for the current user.
+        Schema.RecordTypeInfo opportunityRecordTypeInfo = Opportunity.SObjectType.getDescribe().getRecordTypeInfos()[0];
+
+        //Set the Contact Record in the One To One Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
+        );
+
+        //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Failed Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(Label.healthDetailsAccountDefaultRTInvalid, panelHealthCheckController.listDR[0].strDetails);
+        System.assertEquals(Label.healthSolutionAccountDefaultRTInvalid, panelHealthCheckController.listDR[0].strSolution);
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set an Invalid ID of Household Record Type in the Contact And Orgs Settings.
+    *              This should create a Failed Detect Result the Test.
+    */ 
+    static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsHHRT() {
+        //Set the default Account Record in the One To One Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = 'NOT_AN_ID')
+        );
+
+        //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Failed Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(true, String.isNotBlank(panelHealthCheckController.listDR[0].strDetails), 'A System.Exception should be thrown');
+        System.assertEquals(null, panelHealthCheckController.listDR[0].strSolution);
+    }
+
+    /*******************************************************************************************************
+    * @description In this test scenario, we set an Invalid ID of One To One Record Type in the Contact And Orgs Settings.
+    *              This should create a Failed Detect Result the Test.
+    */ 
+    static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsOneToOneRT() {
+        //Set the Contact Record in the One To One Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = 'NOT_AN_ID')
+        );
+
+        //Run the Health Check to verify the Account default Record Type.
+        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
+        panelHealthCheckController.verifyAccountDefaultRecordType();
+
+        //Confirm there is a Failed Detect Result
+        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
+        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
+        System.assertEquals(true, String.isNotBlank(panelHealthCheckController.listDR[0].strDetails), 'A System.Exception should be thrown');
+        System.assertEquals(null, panelHealthCheckController.listDR[0].strSolution);
+    }
 }

--- a/src/classes/STG_PanelHealthCheck_TEST.cls
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls
@@ -216,70 +216,60 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set a non default Household Record Type in the Contact And Orgs Settings.
-    * This should create a Success Detect Result the Test.
+    * This should create a Success Detect Result.
     */ 
-    static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsHHRT() {
-        //Check if the Org has more than 1 Record Type for Account.
-        //In case there is only one RecordType, it will be the default, therefore we should run this test.
-        Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
-        if(Account.SObjectType.getDescribe().getRecordTypeInfos().size() < 2) {
-            return;
-        }
-        //Get a non default Account RecordType for the current user.
-        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
-            if(accountRecordTypeInfo.isDefaultRecordTypeMapping() == false) {
-                accountDefaultRecordTypeInfo = accountRecordTypeInfo;
-                break;
-            }
-        }
-
-        //Set the non default Account Record in the HouseHold Model Custom Settings
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
-        );
-
-        Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
-        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
-        Test.stopTest();
-
-        //Confirm there is a Success Detect Result
-        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
-        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
-        System.assertEquals(STG_PanelHealthCheck_CTRL.statusSuccess, panelHealthCheckController.listDR[0].strStatus);
-        System.assertEquals(null, panelHealthCheckController.listDR[0].strDetails);
-        System.assertEquals(null, panelHealthCheckController.listDR[0].strSolution);
+    static testmethod void test_VerifyAccountModelRecordType_NonDefaultRT_In_SettingsHHRT() {
+        //Run the test for the Household Record Type
+        verifyAccountModelRecordType_NonDefaultRT_In_Settings(true);
     }
 
     /*******************************************************************************************************
     * @description In this test scenario, we set a non default One To One Record Type in the Contact And Orgs Settings.
-    * This should create a Success Detect Result the Test.
+    * This should create a Success Detect Result.
     */
-    static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsOneToOneRT() {
+    static testmethod void test_VerifyAccountModelRecordType_NonDefaultRT_In_SettingsOneToOneRT() {
+        //Run the test for the One To One Record Type
+        verifyAccountModelRecordType_NonDefaultRT_In_Settings(false);
+    }
+
+    /*******************************************************************************************************
+    * @description method that checks the Non Default Record Type
+    * @param parameter to check if we are testing a Household Record type or One To One. 
+    * True if it is a household and false if it is One To One
+    */
+    private static void verifyAccountModelRecordType_NonDefaultRT_In_Settings(Boolean isHouseHold) {
         //Check if the Org has more than 1 Record Type for Account.
-        //In case there is only one RecordType, it will be the default, therefore we should run this test.
-        Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
-        if(Account.SObjectType.getDescribe().getRecordTypeInfos().size() < 2) {
+        //In case there is only one RecordType, it will be the default, therefore we should not run this test.
+        if(UTIL_Describe.getObjectDescribe('Account').getRecordTypeInfos().size() < 2) {
             return;
         }
+
+        Schema.RecordTypeInfo accountNonDefaultRecordTypeInfo;
         //Get the non default Account RecordType for the current user.
-        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
+        for(Schema.RecordTypeInfo accountRecordTypeInfo : UTIL_Describe.getObjectDescribe('Account').getRecordTypeInfos()) {
             if(accountRecordTypeInfo.isDefaultRecordTypeMapping() == false) {
-                accountDefaultRecordTypeInfo = accountRecordTypeInfo;
+                accountNonDefaultRecordTypeInfo = accountRecordTypeInfo;
                 break;
             }
         }
 
-        //Set the non default Account Record in the One To One Model Custom Settings
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
-        );
+        //Set the non default Account Record in the Household or One To One Model Custom Settings
+        npe01__Contacts_And_Orgs_Settings__c settings;
+        if(isHouseHold) {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountNonDefaultRecordTypeInfo.getRecordTypeId())
+            );
+        }
+        else {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountNonDefaultRecordTypeInfo.getRecordTypeId())
+            );
+        }
 
         Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
+        //Run the Health Check.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
+        panelHealthCheckController.verifyAccountModelRecordType();
         Test.stopTest();
 
         //Confirm there is a Success Detect Result
@@ -291,125 +281,118 @@ public with sharing class STG_PanelHealthCheck_TEST {
     }
 
     /*******************************************************************************************************
-    * @description In this test scenario, we set the Default Househod Record Type in the Contact And Orgs Settings.
-    * This should create a Failed Detect Result the Test.
+    * @description In this test scenario, we set the Default Household Record Type in the Contact And Orgs Settings.
+    * This should create a Failed Detect Result.
     */ 
-    static testmethod void test_VerifyAccountDefaultRecordType_DefaultRT_In_SettingsHHRT() {
-        //Get the Default Account RecordType for the current user.
-        Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
-        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
-            if(accountRecordTypeInfo.isDefaultRecordTypeMapping()) {
-                accountDefaultRecordTypeInfo = accountRecordTypeInfo;
-                break;
-            }
-        }
-
-        //Set the default Account Record in the HouseHold Model Custom Settings
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
-        );
-
-        Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
-        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
-        Test.stopTest();
-
-        //Confirm there is a Failed Detect Result
-        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
-        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName, 'The Dectect Result should be the one the');
-        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
-        System.assertEquals(Label.healthDetailsAccountDefaultRTIssue, panelHealthCheckController.listDR[0].strDetails);
-        System.assertEquals(
-            String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountDefaultRecordTypeInfo.getName()}),
-            panelHealthCheckController.listDR[0].strSolution
-        );
+    static testmethod void test_VerifyAccountModelRecordType_DefaultRT_In_SettingsHHRT() {
+        //Run the test for the Household Record Type
+        verifyAccountModelRecordType_DefaultRT_In_Settings(true);
     }
 
     /*******************************************************************************************************
     * @description In this test scenario, we set the Default One To One Record Type in the Contact And Orgs Settings.
-    * This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result.
     */ 
-    static testmethod void test_VerifyAccountDefaultRecordType_DefaultRT_In_SettingsOneToOneRT() {
+    static testmethod void test_VerifyAccountModelRecordType_DefaultRT_In_SettingsOneToOneRT() {
+        //Run the test for the One To One Record Type
+        verifyAccountModelRecordType_DefaultRT_In_Settings(false);
+    }
+
+    /*******************************************************************************************************
+    * @description method that checks Default Record Type in the Contact And Orgs Settings.
+    * @param parameter to check if we are testing a Household Record type or One To One. 
+    * True if it is a household and false if it is One To One
+    */ 
+    private static void verifyAccountModelRecordType_DefaultRT_In_Settings(Boolean isHouseHold) {
         //Get the Default Account RecordType for the current user.
         Schema.RecordTypeInfo accountDefaultRecordTypeInfo;
-        for(Schema.RecordTypeInfo accountRecordTypeInfo : Account.SObjectType.getDescribe().getRecordTypeInfos()) {
+        for(Schema.RecordTypeInfo accountRecordTypeInfo : UTIL_Describe.getObjectDescribe('Account').getRecordTypeInfos()) {
             if(accountRecordTypeInfo.isDefaultRecordTypeMapping()) {
                 accountDefaultRecordTypeInfo = accountRecordTypeInfo;
                 break;
             }
         }
 
-        //Set the default Account Record in the One To One Model Custom Settings
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
-        );
+        //Set the default Account Record in the Household or One To One Model Custom Settings
+         npe01__Contacts_And_Orgs_Settings__c settings;
+        if(isHouseHold) {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
+            );
+        }
+        else {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = accountDefaultRecordTypeInfo.getRecordTypeId())
+            );
+        }
 
         Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
+        //Run the Health Check.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
+        panelHealthCheckController.verifyAccountModelRecordType();
         Test.stopTest();
 
         //Confirm there is a Failed Detect Result
         System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
         System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
         System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
-        System.assertEquals(Label.healthDetailsAccountDefaultRTIssue, panelHealthCheckController.listDR[0].strDetails);
         System.assertEquals(
             String.format(Label.healthDetailsAccountDefaultRTIssue, new List<String>{accountDefaultRecordTypeInfo.getName()}),
+            panelHealthCheckController.listDR[0].strDetails
+        );
+        System.assertEquals(
+            String.format(Label.healthSolutionAccountDefaultRTIssue, new List<String>{accountDefaultRecordTypeInfo.getName()}),
             panelHealthCheckController.listDR[0].strSolution
         );
     }
 
     /*******************************************************************************************************
-    * @description In this test scenario, we set an Invalid value of Household Record Type in the opportunity And Orgs Settings.
-    * In this case, we use a opportunity Record Type as an invalid value for the One to One Record Type.
-    * This should create a Failed Detect Result the Test.
+    * @description In this test scenario, we set an Invalid value (Opportunity Record type) in the Household Contact And Orgs Settings.
+    * In this case, we use a Opportunity Record Type as an invalid value for the Household Record Type.
+    * This should create a Failed Detect Result.
     */ 
-    static testmethod void test_VerifyAccountDefaultRecordType_InvalidRT_In_SettingsHHRT() {
-        //Get a random opportunity RecordType for the current user.
-        Schema.RecordTypeInfo opportunityRecordTypeInfo = Opportunity.SObjectType.getDescribe().getRecordTypeInfos()[0];
-
-        //Set the opportunity Record in the Household Model Custom Settings. 
-        //The goal is test an invalid Account Record Type in the Custom Settings.
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
-        );
-
-        Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
-        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
-        Test.stopTest();
-
-        //Confirm there is a Failed Detect Result, because the logic is expecting an Account Record Type.
-        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
-        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
-        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
-        System.assertEquals(Label.healthDetailsAccountDefaultRTInvalid, panelHealthCheckController.listDR[0].strDetails);
-        System.assertEquals(Label.healthSolutionAccountDefaultRTInvalid, panelHealthCheckController.listDR[0].strSolution);
+    static testmethod void test_VerifyAccountModelRecordType_InvalidRT_In_SettingsHHRT() {
+        //Run the test for the Household Record Type
+        verifyAccountModelRecordType_InvalidRT_In_Settings(true);
     }
 
     /*******************************************************************************************************
-    * @description In this test scenario, we set an Invalid value of One To One Record Type in the Contact And Orgs Settings.
-    * In this case, we use a Contact Record Type as an invalid value for the One to One Record Type.
-    * This should create a Failed Detect Result the Test.
+    * @description In this test scenario, we set an Invalid value (Opportunity Record type) in the One To One Contact And Orgs Settings.
+    * In this case, we use a Opportunity Record Type as an invalid value for the One to One Record Type.
+    * This should create a Failed Detect Result.
     */ 
-    static testmethod void test_VerifyAccountDefaultRecordType_InvalidRT_In_SettingsOneToOneRT() {
-        //Get a random Contact RecordType for the current user.
-        Schema.RecordTypeInfo opportunityRecordTypeInfo = Opportunity.SObjectType.getDescribe().getRecordTypeInfos()[0];
+    static testmethod void test_VerifyAccountModelRecordType_InvalidRT_In_SettingsOneToOneRT() {
+        //Run the test for the One To One Record Type
+        verifyAccountModelRecordType_InvalidRT_In_Settings(false);
+    }
 
-        //Set the Contact Record in the One To One Model Custom Settings.
-        //The goal is test an invalid Account Record Type in the Custom Settings.
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
-        );
+    /*******************************************************************************************************
+    * @description method that sets an Invalid value Record Type (Opportunity Record type) in the Contact And Orgs Settings.
+    * @param parameter to check if we are testing a Household Record type or One To One. 
+    * True if it is a household and false if it is One To One
+    */ 
+    private static void verifyAccountModelRecordType_InvalidRT_In_Settings(Boolean isHouseHold) {
+        //Get a random Opportunity RecordType for the current user.
+        Schema.RecordTypeInfo opportunityRecordTypeInfo = UTIL_Describe.getObjectDescribe('Opportunity').getRecordTypeInfos()[0];
+
+        //Set the Opportunity Record Type in the Household or One To One Model Custom Settings.
+        //The goal is test an invalid Account Record Type.
+        npe01__Contacts_And_Orgs_Settings__c settings;
+        if(isHouseHold) {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
+            );
+        }
+        else {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = opportunityRecordTypeInfo.getRecordTypeId())
+            );
+        }
 
         Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
+        //Run the Health Check.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
+        panelHealthCheckController.verifyAccountModelRecordType();
         Test.stopTest();
 
         //Confirm there is a Failed Detect Result
@@ -422,42 +405,45 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set an Invalid ID of Household Record Type in the Contact And Orgs Settings.
-    * This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result.
     */ 
-    static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsHHRT() {
-        //Set an invalid Account Record ID in the Household Model Custom Settings
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = 'NOT_AN_ID')
-        );
-
-        Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
-        STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
-        Test.stopTest();
-
-        //Confirm there is a Failed Detect Result, because of the invalid ID
-        System.assertEquals(1, panelHealthCheckController.listDR.size(), 'We should have 1 Detect Result');
-        System.assertEquals(Label.healthLabelAccountDefaultRT, panelHealthCheckController.listDR[0].strName);
-        System.assertEquals(STG_PanelHealthCheck_CTRL.statusError, panelHealthCheckController.listDR[0].strStatus);
-        System.assertEquals(true, String.isNotBlank(panelHealthCheckController.listDR[0].strDetails), 'A System.Exception should be thrown');
-        System.assertEquals(null, panelHealthCheckController.listDR[0].strSolution);
+    static testmethod void test_VerifyAccountModelRecordType_InvalidIDRT_In_SettingsHHRT() {
+        //Run the test for the Household Record Type
+        verifyAccountModelRecordType_InvalidIDRT_In_Settings(true);
     }
 
     /*******************************************************************************************************
     * @description In this test scenario, we set an Invalid ID of One To One Record Type in the Contact And Orgs Settings.
-    * This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result.
     */ 
-    static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsOneToOneRT() {
-        //Set an invalid Account Record ID in the One To One Model Custom Settings
-        npe01__Contacts_And_Orgs_Settings__c settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = 'NOT_AN_ID')
-        );
+    static testmethod void test_VerifyAccountModelRecordType_InvalidIDRT_In_SettingsOneToOneRT() {
+        //Run the test for the One To One Record Type
+        verifyAccountModelRecordType_InvalidIDRT_In_Settings(false);
+    }
+
+    /*******************************************************************************************************
+    * @description method that sets an Invalid ID of Household Household or One To One Record Type in the Contact And Orgs Settings.
+    * @param parameter to check if we are testing a Household Record type or One To One. 
+    * True if it is a household and false if it is One To One
+    */ 
+    private static void verifyAccountModelRecordType_InvalidIDRT_In_Settings(Boolean isHouseHold) {
+        //Set an invalid Account Record ID in the Household or One To One Model Custom Settings
+         npe01__Contacts_And_Orgs_Settings__c settings;
+        if(isHouseHold) {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__HH_Account_RecordTypeID__c = 'NOT_AN_ID')
+            );
+        }
+        else {
+            settings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_And_Orgs_Settings__c (npe01__One_to_One_RecordTypeID__c = 'NOT_AN_ID')
+            );
+        }
 
         Test.startTest();
-        //Run the Health Check to verify the Account default Record Type.
+        //Run the Health Check.
         STG_PanelHealthCheck_CTRL panelHealthCheckController = new STG_PanelHealthCheck_CTRL();
-        panelHealthCheckController.verifyAccountDefaultRecordType();
+        panelHealthCheckController.verifyAccountModelRecordType();
         Test.stopTest();
 
         //Confirm there is a Failed Detect Result, because of the invalid ID

--- a/src/classes/STG_PanelHealthCheck_TEST.cls
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls
@@ -215,35 +215,8 @@ public with sharing class STG_PanelHealthCheck_TEST {
     }
 
     /*******************************************************************************************************
-    * @description verify that the health check test for verifying no missing payments succeeds when we
-    * have an opp with payments.
-    */ 
-    static testmethod void check() {
-
-        npe01__Contacts_And_Orgs_Settings__c PaymentsSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
-            new npe01__Contacts_And_Orgs_Settings__c (npe01__Payments_Enabled__c= true));
-        
-        Account acc = new Account(name='my account');
-        insert acc;
-        Opportunity opp = new Opportunity(Name='my opp', StageName=UTIL_UnitTestData_TEST.getClosedWonStage(), 
-            CloseDate=system.Today(), Amount=100, AccountId=acc.Id);
-        insert opp;
-        system.assertEquals(1, [select count() from npe01__OppPayment__c]);
-        
-        STG_PanelHealthCheck_CTRL hc = new STG_PanelHealthCheck_CTRL();
-        system.assertEquals(0, hc.listDR.size());
-        
-        Test.startTest();
-        hc.verifyNoMissingOppPayments();
-        Test.stopTest();
-        
-        system.assertEquals(1, hc.listDR.size());
-        system.assertEquals(STG_PanelHealthCheck_CTRL.statusSuccess, hc.listDR[0].strStatus);
-    }
-
-    /*******************************************************************************************************
     * @description In this test scenario, we set the a non default Household Record Type in the Contact And Orgs Settings.
-    *              This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsHHRT() {
         //Check if the Org has more than 1 Record Type for Account.
@@ -278,7 +251,7 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set the a non default One To One Record Type in the Contact And Orgs Settings.
-    *              This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result the Test.
     */
     static testmethod void test_VerifyAccountDefaultRecordType_NonDefaultRT_In_SettingsOneToOneRT() {
         //Check if the Org has more than 1 Record Type for Account.
@@ -313,7 +286,7 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set the Default Househod Record Type in the Contact And Orgs Settings.
-    *              This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_DefaultRT_In_SettingsHHRT() {
         //Get the Default Account RecordType for the current user.
@@ -347,7 +320,7 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set the Default One To One Record Type in the Contact And Orgs Settings.
-    *              This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_DefaultRT_In_SettingsOneToOneRT() {
         //Get the Default Account RecordType for the current user.
@@ -381,8 +354,8 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set an Invalid value of Household Record Type in the opportunity And Orgs Settings.
-                   In this case, we use a opportunity Record Type as an invalid value for the One to One Record Type.
-    *              This should create a Failed Detect Result the Test.
+    * In this case, we use a opportunity Record Type as an invalid value for the One to One Record Type.
+    * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_InvalidRT_In_SettingsHHRT() {
          //Get a random opportunity RecordType for the current user.
@@ -407,8 +380,8 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set an Invalid value of One To One Record Type in the Contact And Orgs Settings.
-                   In this case, we use a Contact Record Type as an invalid value for the One to One Record Type.
-    *              This should create a Failed Detect Result the Test.
+    * In this case, we use a Contact Record Type as an invalid value for the One to One Record Type.
+    * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_InvalidRT_In_SettingsOneToOneRT() {
         //Get a random Contact RecordType for the current user.
@@ -433,7 +406,7 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set an Invalid ID of Household Record Type in the Contact And Orgs Settings.
-    *              This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsHHRT() {
         //Set the default Account Record in the One To One Model Custom Settings
@@ -455,7 +428,7 @@ public with sharing class STG_PanelHealthCheck_TEST {
 
     /*******************************************************************************************************
     * @description In this test scenario, we set an Invalid ID of One To One Record Type in the Contact And Orgs Settings.
-    *              This should create a Failed Detect Result the Test.
+    * This should create a Failed Detect Result the Test.
     */ 
     static testmethod void test_VerifyAccountDefaultRecordType_InvalidIDRT_In_SettingsOneToOneRT() {
         //Set the Contact Record in the One To One Model Custom Settings

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1993,7 +1993,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthDetailsAccountDefaultRTInvalid</shortDescription>
-        <value>The Record Type selected for the Account Model isn&apos;t valid.</value>
+        <value>The Record Type selected for the current Account Model isn&apos;t valid.</value>
     </labels>
     <labels>
         <fullName>healthDetailsAccountDefaultRTIssue</fullName>
@@ -2001,7 +2001,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthDetailsAccountDefaultRTIssue</shortDescription>
-        <value>The Record Type, {0}, is selected for the Account Model (in NPSP Settings) and is used as your profile&apos;&apos;s default Account Record Type.</value>
+        <value>The Record Type, {0}, is selected for the current Account Model (in NPSP Settings) and is used as your profile&apos;&apos;s default Account Record Type.</value>
     </labels>
     <labels>
         <fullName>healthDetailsAccountModel</fullName>
@@ -2736,7 +2736,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthSolutionAccountDefaultRTIssue</shortDescription>
-        <value>The Record Type selected for the Account Model should not be used as the default Account Record Type for any Profile in your org. Using the same Record Type could cause various data issues.</value>
+        <value>The Record Type selected for the current Account Model should not be used as the default Account Record Type for any Profile in your org. Using the same Record Type could cause various data issues.</value>
     </labels>
     <labels>
         <fullName>healthSolutionAccountModel</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1988,6 +1988,22 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>There are {0} One-to-One Accounts who have no Contacts.</value>
     </labels>
     <labels>
+        <fullName>healthDetailsAccountDefaultRTInvalid</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>healthDetailsAccountDefaultRTInvalid</shortDescription>
+        <value>The Record selected for the Account Model is not valid.</value>
+    </labels>
+    <labels>
+        <fullName>healthDetailsAccountDefaultRTIssue</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>healthDetailsAccountDefaultRTIssue</shortDescription>
+        <value>The Record Type {0} is selected for the Account Model and is used as the default Account Record Type.</value>
+    </labels>
+    <labels>
         <fullName>healthDetailsAccountModel</fullName>
         <categories>Health Check</categories>
         <language>en_US</language>
@@ -2403,6 +2419,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Account Data</value>
     </labels>
     <labels>
+        <fullName>healthLabelAccountDefaultRT</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>healthLabelAccountDefaultRT</shortDescription>
+        <value>Account Default Record Type</value>
+    </labels>
+    <labels>
         <fullName>healthLabelAccountModelData</fullName>
         <categories>Health Check</categories>
         <language>en_US</language>
@@ -2697,6 +2721,22 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <protected>false</protected>
         <shortDescription>healthSolutionAccOne2OneNoContacts</shortDescription>
         <value>Consider deleting these unused One-to-One Accounts to save space.</value>
+    </labels>
+    <labels>
+        <fullName>healthSolutionAccountDefaultRTInvalid</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>healthSolutionAccountDefaultRTInvalid</shortDescription>
+        <value>Please select a valid Record Type for the Account Model.</value>
+    </labels>
+    <labels>
+        <fullName>healthSolutionAccountDefaultRTIssue</fullName>
+        <categories>Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>healthSolutionAccountDefaultRTIssue</shortDescription>
+        <value>The Record Type selected for the Account Model should not be used as the default Account Record Type for any Profile in your org. Using the same record type could cause various data issues.</value>
     </labels>
     <labels>
         <fullName>healthSolutionAccountModel</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2736,7 +2736,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthSolutionAccountDefaultRTIssue</shortDescription>
-        <value>The Record Type selected for the current Account Model should not be used as the default Account Record Type for any Profile in your org. Using the same Record Type could cause various data issues.</value>
+        <value>The Record Type selected for the current Account Model should not be used as the default Account Record Type for any Profile in this Salesforce organization. Using the same Record Type could cause various data issues.</value>
     </labels>
     <labels>
         <fullName>healthSolutionAccountModel</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1993,7 +1993,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthDetailsAccountDefaultRTInvalid</shortDescription>
-        <value>The Record selected for the Account Model is not valid.</value>
+        <value>The Record Type selected for the Account Model isn&apos;t valid.</value>
     </labels>
     <labels>
         <fullName>healthDetailsAccountDefaultRTIssue</fullName>
@@ -2001,7 +2001,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthDetailsAccountDefaultRTIssue</shortDescription>
-        <value>The Record Type {0} is selected for the Account Model and is used as the default Account Record Type.</value>
+        <value>The Record Type, {0}, is selected for the Account Model (in NPSP Settings) and is used as your profile&apos;&apos;s default Account Record Type.</value>
     </labels>
     <labels>
         <fullName>healthDetailsAccountModel</fullName>
@@ -2424,7 +2424,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthLabelAccountDefaultRT</shortDescription>
-        <value>Account Default Record Type</value>
+        <value>Account Model Record Type</value>
     </labels>
     <labels>
         <fullName>healthLabelAccountModelData</fullName>
@@ -2728,7 +2728,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthSolutionAccountDefaultRTInvalid</shortDescription>
-        <value>Please select a valid Record Type for the Account Model.</value>
+        <value>Go to &lt;strong&gt;People | Account Model&lt;/strong&gt; and select a valid Record Type.</value>
     </labels>
     <labels>
         <fullName>healthSolutionAccountDefaultRTIssue</fullName>
@@ -2736,7 +2736,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>healthSolutionAccountDefaultRTIssue</shortDescription>
-        <value>The Record Type selected for the Account Model should not be used as the default Account Record Type for any Profile in your org. Using the same record type could cause various data issues.</value>
+        <value>The Record Type selected for the Account Model should not be used as the default Account Record Type for any Profile in your org. Using the same Record Type could cause various data issues.</value>
     </labels>
     <labels>
         <fullName>healthSolutionAccountModel</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1195,6 +1195,7 @@
         <members>healthPaymentAutoCloseStageValid</members>
         <members>healthSolutionAccOne2OneNoContacts</members>
         <members>healthSolutionAccountDefaultRTInvalid</members>
+        <members>healthSolutionAccountDefaultRTIssue</members>
         <members>healthSolutionAccountModel</members>
         <members>healthSolutionAccountRTIssue</members>
         <members>healthSolutionAutoRelFieldsMissing</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1102,6 +1102,8 @@
         <members>flsError</members>
         <members>healthButtonRun</members>
         <members>healthDetailsAccOne2OneNoContacts</members>
+        <members>healthDetailsAccountDefaultRTInvalid</members>
+        <members>healthDetailsAccountDefaultRTIssue</members>
         <members>healthDetailsAccountModel</members>
         <members>healthDetailsAccountProcessor</members>
         <members>healthDetailsAccountRTIssue</members>
@@ -1154,6 +1156,7 @@
         <members>healthDetailsUDFBadDatatypes</members>
         <members>healthDetailsValidRDCustomPeriod</members>
         <members>healthLabelAccountData</members>
+        <members>healthLabelAccountDefaultRT</members>
         <members>healthLabelAccountModelData</members>
         <members>healthLabelAccountRTIssueValid</members>
         <members>healthLabelAllTestsPassed</members>
@@ -1191,6 +1194,7 @@
         <members>healthPaymentAutoCloseStageMustBeActiveClosedWonOrBlank</members>
         <members>healthPaymentAutoCloseStageValid</members>
         <members>healthSolutionAccOne2OneNoContacts</members>
+        <members>healthSolutionAccountDefaultRTInvalid</members>
         <members>healthSolutionAccountModel</members>
         <members>healthSolutionAccountRTIssue</members>
         <members>healthSolutionAutoRelFieldsMissing</members>


### PR DESCRIPTION
A new Health Check is added to check if the selected Record Type for the Account Model is the default Account Record Type. This check runs only for the logged in user. If the selected Record Type for the Account Model is the default Account Record Type for the logged in user, the Health Check shows a failed result.

# Critical Changes

# Changes

- There is a new Health Check that verifies the validity of the Record Type selected for your chosen Account Model (in NPSP Settings, under People | Account Model). The Health Check fails if the selected Record Type for the Account Model:
  - Is the same as the default Account Record Type for the logged in user
  - Is invalid

# Issues Closed

# New Metadata

# Deleted Metadata
