### PR TITLE
Update Contact Delete Override Page

### DIFF
--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -112,6 +112,24 @@ public with sharing class CON_DeleteContactOverride_CTRL {
     }
 
     /*******************************************************************************************************
+    * @description Deletes a contact, leaving empty Household Account, once the user has accepted to do so,
+    * after adding cascade deletion records for related opportunities and recurring donations. 
+    * Validates opportunities and adds error messages where appropriate.
+    * @return pageReference Redirects to the Contacts tab if the contact has been deleted, otherwise stays
+    * on the page and displays error messages.
+    */ 
+    public PageReference deleteContactOnly() {
+        shouldDeleteContactAlone = true;
+        try {
+            return deleteContact();
+        } catch (Exception ex){
+            if (!hasPageMessages)
+                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, ex.getMessage()));
+            return null;
+        }
+    }
+
+    /*******************************************************************************************************
     * @description Deletes a contact, after adding cascade deletion records for related opportunities and 
     * recurring donations. Validates opportunities and adds error messages where appropriate.
     * @return pageReference Redirects to the Contacts tab if the contact has been deleted, otherwise stays

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -90,6 +90,7 @@ public with sharing class CON_DeleteContactOverride_CTRL {
             //delete to remove the contact
             if (contactsInHousehold.size() == 1 && contactsInHousehold[0].get('ct') == 1) {
                 shouldDeleteContactAlone = false;
+            	ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, helpDeleteAccountInstead));
             }
         }
     }
@@ -207,7 +208,7 @@ public with sharing class CON_DeleteContactOverride_CTRL {
     * @description Returns a redirect enabled PageReference for the return URL
     * @return pageReference The PageReference with redirect enabled.
     */ 
-    private PageReference getRedirect() {
+    public PageReference getRedirect() {
         PageReference redirect = new PageReference(retURL);
         redirect.setRedirect(true);
         return redirect;

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -90,7 +90,7 @@ public with sharing class CON_DeleteContactOverride_CTRL {
             //delete to remove the contact
             if (contactsInHousehold.size() == 1 && contactsInHousehold[0].get('ct') == 1) {
                 shouldDeleteContactAlone = false;
-            	ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, helpDeleteAccountInstead));
+                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, helpDeleteAccountInstead));
             }
         }
     }

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls
@@ -106,8 +106,9 @@ public with sharing class CON_DeleteContactOverride_CTRL {
         try {
             return deleteContact();
         } catch (Exception ex){
-            if (!hasPageMessages)
+            if (!hasPageMessages) {
                 ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, ex.getMessage()));
+            }
             return null;
         }
     }
@@ -121,11 +122,15 @@ public with sharing class CON_DeleteContactOverride_CTRL {
     */ 
     public PageReference deleteContactOnly() {
         shouldDeleteContactAlone = true;
+
         try {
             return deleteContact();
-        } catch (Exception ex){
-            if (!hasPageMessages)
+        } catch (Exception ex) {
+            shouldDeleteContactAlone = false;
+
+            if (!hasPageMessages) {
                 ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, ex.getMessage()));
+            }
             return null;
         }
     }

--- a/src/components/UTIL_PageMessages.component
+++ b/src/components/UTIL_PageMessages.component
@@ -7,6 +7,13 @@
         required="false"
         />
 
+    <apex:attribute name="allowClose"
+        description="If true, Close icon will be displayed on the right. Otherwise, no Close icon will appear."
+        type="Boolean"
+        default="true"
+        required="false"
+        />
+
     <apex:outputText rendered="{!NOT(useToast)}">
         <style type="text/css">
             #page_messages .slds-notify_toast, #page_messages .slds-notify--toast {
@@ -19,12 +26,14 @@
         <div class="{!IF(useToast, 'slds-notify-container', '')}">
             <apex:repeat value="{!pageMessages}" var="m">
                 <div role="alert" class="slds-notify slds-notify_toast slds-notify--toast slds-theme_{!m.severityTheme} slds-theme--{!m.severityTheme}">
-                    <button class="slds-button slds-notify__close {!IF(m.severityTheme != 'warning', 'slds-button_icon-inverse slds-button--icon-inverse', '')}">
-                        <svg class="slds-button__icon slds-button__icon_large slds-button__icon--large" aria-hidden="true">
-                            <path d="M14.6 11.9l6-6c.3-.3.3-.7 0-1l-.9-1c-.3-.3-.7-.3-1 0L12.6 10c-.1.2-.4.2-.6 0L6 3.9c-.3-.3-.7-.3-1 0l-1 .9c-.3.3-.3.7 0 1l6.1 6.1c.1.1.1.4 0 .6L4 18.6c-.3.3-.3.7 0 1l.9.9c.3.3.7.3 1 0l6.1-6c.2-.2.5-.2.6 0l6.1 6c.3.3.7.3 1 0l.9-.9c.3-.3.3-.7 0-1l-6-6c-.2-.2-.2-.5 0-.7z"/>
-                        </svg>
-                        <span class="slds-assistive-text">Close</span>
-                    </button>
+                    <apex:outputPanel rendered="{!allowClose}">
+                        <button class="slds-button slds-notify__close {!IF(m.severityTheme != 'warning', 'slds-button_icon-inverse slds-button--icon-inverse', '')}">
+                            <svg class="slds-button__icon slds-button__icon_large slds-button__icon--large" aria-hidden="true">
+                                <path d="M14.6 11.9l6-6c.3-.3.3-.7 0-1l-.9-1c-.3-.3-.7-.3-1 0L12.6 10c-.1.2-.4.2-.6 0L6 3.9c-.3-.3-.7-.3-1 0l-1 .9c-.3.3-.3.7 0 1l6.1 6.1c.1.1.1.4 0 .6L4 18.6c-.3.3-.3.7 0 1l.9.9c.3.3.7.3 1 0l6.1-6c.2-.2.5-.2.6 0l6.1 6c.3.3.7.3 1 0l.9-.9c.3-.3.3-.7 0-1l-6-6c-.2-.2-.2-.5 0-.7z"/>
+                            </svg>
+                            <span class="slds-assistive-text">Close</span>
+                        </button> 
+                    </apex:outputPanel>
                     <div class="notify__content">
                         <div class="slds-media">
                             <div class="slds-media__figure">

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -609,7 +609,21 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>ConfirmDeleteAccount</shortDescription>
-        <value>{0} is the only contact in the {1} account. Deleting this contact would leave an empty account. Would you like to delete {1} instead?</value>
+        <value>{0} is the only Contact in the {1} Account. Deleting this Contact would leave an empty Account. Would you like to delete {1}, including {0}, instead?</value>
+    </labels>
+    <labels>
+        <fullName>Delete_Account</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Delete Account</shortDescription>
+        <value>Delete Account</value>
+    </labels>
+    <labels>
+        <fullName>Delete_Contact_Leave_Account</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Delete Contact Leave Account</shortDescription>
+        <value>Delete Contact and Leave Empty Account</value>
     </labels>
     <labels>
         <fullName>EPAddDependentTask</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -612,14 +612,14 @@
         <value>{0} is the only Contact in the {1} Account. Deleting this Contact would leave an empty Account. Would you like to delete {1}, including {0}, instead?</value>
     </labels>
     <labels>
-        <fullName>Delete_Account</fullName>
+        <fullName>DeleteAccount</fullName>
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Delete Account</shortDescription>
         <value>Delete Account</value>
     </labels>
     <labels>
-        <fullName>Delete_Contact_Leave_Account</fullName>
+        <fullName>DeleteContactLeaveAccount</fullName>
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Delete Contact Leave Account</shortDescription>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -615,14 +615,14 @@
         <fullName>DeleteAccount</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Delete Account</shortDescription>
+        <shortDescription>DeleteAccount</shortDescription>
         <value>Delete Account</value>
     </labels>
     <labels>
         <fullName>DeleteContactLeaveAccount</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Delete Contact Leave Account</shortDescription>
+        <shortDescription>DeleteContactLeaveAccount</shortDescription>
         <value>Delete Contact and Leave Empty Account</value>
     </labels>
     <labels>

--- a/src/package.xml
+++ b/src/package.xml
@@ -951,8 +951,8 @@
         <members>CascadeDeletionError</members>
         <members>ClosedWonOpportunities</members>
         <members>ConfirmDeleteAccount</members>
-        <members>Delete_Account</members>
-        <members>Delete_Contact_Leave_Account</members>
+        <members>DeleteAccount</members>
+        <members>DeleteContactLeaveAccount</members>
         <members>EPAddDependentTask</members>
         <members>EPAddTask</members>
         <members>EPDeleteTask</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -951,6 +951,8 @@
         <members>CascadeDeletionError</members>
         <members>ClosedWonOpportunities</members>
         <members>ConfirmDeleteAccount</members>
+        <members>Delete_Account</members>
+        <members>Delete_Contact_Leave_Account</members>
         <members>EPAddDependentTask</members>
         <members>EPAddTask</members>
         <members>EPDeleteTask</members>

--- a/src/pages/CON_DeleteContactOverride.page
+++ b/src/pages/CON_DeleteContactOverride.page
@@ -16,10 +16,10 @@
                 <apex:outputLink target="_self" title="{!$Label.REL_Return_to_Contact}" value="/{!$CurrentPage.parameters.id}" styleClass="slds-button slds-button_neutral">
                     {!$Label.REL_Return_to_Contact}
                 </apex:outputLink>
-                <apex:commandButton value="{!$Label.Delete_Account}" action="{!deleteAccount}" rendered="{!NOT(shouldDeleteContactAlone)}" styleClass="slds-button slds-button_brand"/>
+                <apex:commandButton value="{!$Label.DeleteAccount}" action="{!deleteAccount}" styleClass="slds-button slds-button_brand"/>
             </div>
                 <div class="slds-p-around_small slds-text-body_small">
-                    <apex:commandLink value="{!$Label.Delete_Contact_Leave_Account}" action="{!deleteContactOnly}" />
+                    <apex:commandLink value="{!$Label.DeleteContactLeaveAccount}" action="{!deleteContactOnly}" />
                 </div>
         </apex:outputPanel>
         <apex:outputPanel rendered="{!sforceNav != null}">

--- a/src/pages/CON_DeleteContactOverride.page
+++ b/src/pages/CON_DeleteContactOverride.page
@@ -8,19 +8,17 @@
                                icon="contact_120" iconCategory="standard"
                                showSaveBtn="false" cancelLabel="{!$Label.bdiBtnClose}"
                                cancelAction="{!getRedirect}" cancelReRender="vfForm"/>
-
+            
             <!-- PAGE MESSAGE -->
             <c:UTIL_PageMessages allowClose="false"/>
             
             <div class="slds-p-around_small">
+                <apex:commandButton value="{!$Label.Delete_Contact_Leave_Account}" action="{!deleteContactOnly}" styleClass="slds-button slds-button_neutral"/>
                 <apex:outputLink target="_self" title="{!$Label.REL_Return_to_Contact}" value="/{!$CurrentPage.parameters.id}" styleClass="slds-button slds-button_neutral">
                     {!$Label.REL_Return_to_Contact}
                 </apex:outputLink>
-                <apex:commandButton value="{!$Label.DeleteAccount}" action="{!deleteAccount}" styleClass="slds-button slds-button_brand"/>
+                <apex:commandButton value="{!$Label.Delete_Account}" action="{!deleteAccount}" styleClass="slds-button slds-button_brand"/>
             </div>
-                <div class="slds-p-around_small slds-text-body_small">
-                    <apex:commandLink value="{!$Label.DeleteContactLeaveAccount}" action="{!deleteContactOnly}" />
-                </div>
         </apex:outputPanel>
         <apex:outputPanel rendered="{!sforceNav != null}">
             <script type="text/javascript">

--- a/src/pages/CON_DeleteContactOverride.page
+++ b/src/pages/CON_DeleteContactOverride.page
@@ -13,11 +13,11 @@
             <c:UTIL_PageMessages allowClose="false"/>
             
             <div class="slds-p-around_small">
-                <apex:commandButton value="{!$Label.Delete_Contact_Leave_Account}" action="{!deleteContactOnly}" styleClass="slds-button slds-button_neutral"/>
+                <apex:commandButton value="{!$Label.DeleteContactLeaveAccount}" action="{!deleteContactOnly}" styleClass="slds-button slds-button_neutral"/>
                 <apex:outputLink target="_self" title="{!$Label.REL_Return_to_Contact}" value="/{!$CurrentPage.parameters.id}" styleClass="slds-button slds-button_neutral">
                     {!$Label.REL_Return_to_Contact}
                 </apex:outputLink>
-                <apex:commandButton value="{!$Label.Delete_Account}" action="{!deleteAccount}" styleClass="slds-button slds-button_brand"/>
+                <apex:commandButton value="{!$Label.DeleteAccount}" action="{!deleteAccount}" styleClass="slds-button slds-button_brand"/>
             </div>
         </apex:outputPanel>
         <apex:outputPanel rendered="{!sforceNav != null}">

--- a/src/pages/CON_DeleteContactOverride.page
+++ b/src/pages/CON_DeleteContactOverride.page
@@ -2,17 +2,25 @@
     <apex:slds />
     <apex:form styleClass="slds">
         <apex:outputPanel rendered="{!sforceNav == null}">
-            <c:UTIL_PageMessages />
-            <div class="slds-p-around_medium">
-                <apex:outputText value="{!helpDeleteAccountInstead}" rendered="{!NOT(shouldDeleteContactAlone)}" styleClass="slds-text-body_regular"/>
-            </div>
-            <div class="slds-button-group slds-p-left_medium">
-                <apex:outputLink target="_self" title="{!$Label.REL_Return_to_Contact}" value="/{!$CurrentPage.parameters.id}" styleClass="slds-button slds-button_brand">
+            <!-- PAGE HEADER -->
+            <c:UTIL_PageHeader headerLabel="{!$ObjectType.Contact.Label}"
+                               header="{!Contact.Name}"
+                               icon="contact_120" iconCategory="standard"
+                               showSaveBtn="false" cancelLabel="{!$Label.bdiBtnClose}"
+                               cancelAction="{!getRedirect}" cancelReRender="vfForm"/>
+
+            <!-- PAGE MESSAGE -->
+            <c:UTIL_PageMessages allowClose="false"/>
+            
+            <div class="slds-p-around_small">
+                <apex:outputLink target="_self" title="{!$Label.REL_Return_to_Contact}" value="/{!$CurrentPage.parameters.id}" styleClass="slds-button slds-button_neutral">
                     {!$Label.REL_Return_to_Contact}
                 </apex:outputLink>
-                <apex:commandButton value="{!$Label.Delete_Account}" action="{!deleteAccount}" rendered="{!NOT(shouldDeleteContactAlone)}" disabled="{!hasPageMessages}" styleClass="slds-button slds-button_neutral"/>
-                <apex:commandButton value="{!$Label.Delete_Contact_Leave_Account}" action="{!deleteContactOnly}" rendered="{!NOT(shouldDeleteContactAlone)}" disabled="{!hasPageMessages}" styleClass="slds-button slds-button_neutral"/>
+                <apex:commandButton value="{!$Label.Delete_Account}" action="{!deleteAccount}" rendered="{!NOT(shouldDeleteContactAlone)}" styleClass="slds-button slds-button_brand"/>
             </div>
+                <div class="slds-p-around_small slds-text-body_small">
+                    <apex:commandLink value="{!$Label.Delete_Contact_Leave_Account}" action="{!deleteContactOnly}" />
+                </div>
         </apex:outputPanel>
         <apex:outputPanel rendered="{!sforceNav != null}">
             <script type="text/javascript">

--- a/src/pages/CON_DeleteContactOverride.page
+++ b/src/pages/CON_DeleteContactOverride.page
@@ -6,11 +6,12 @@
             <div class="slds-p-around_medium">
                 <apex:outputText value="{!helpDeleteAccountInstead}" rendered="{!NOT(shouldDeleteContactAlone)}" styleClass="slds-text-body_regular"/>
             </div>
-            <div class="slds-button-group">
+            <div class="slds-button-group slds-p-left_medium">
                 <apex:outputLink target="_self" title="{!$Label.REL_Return_to_Contact}" value="/{!$CurrentPage.parameters.id}" styleClass="slds-button slds-button_brand">
                     {!$Label.REL_Return_to_Contact}
                 </apex:outputLink>
-                <apex:commandButton value="Delete Account" action="{!deleteAccount}" rendered="{!NOT(shouldDeleteContactAlone)}" disabled="{!hasPageMessages}" styleClass="slds-button slds-button_destructive"/>
+                <apex:commandButton value="{!$Label.Delete_Account}" action="{!deleteAccount}" rendered="{!NOT(shouldDeleteContactAlone)}" disabled="{!hasPageMessages}" styleClass="slds-button slds-button_neutral"/>
+                <apex:commandButton value="{!$Label.Delete_Contact_Leave_Account}" action="{!deleteContactOnly}" rendered="{!NOT(shouldDeleteContactAlone)}" disabled="{!hasPageMessages}" styleClass="slds-button slds-button_neutral"/>
             </div>
         </apex:outputPanel>
         <apex:outputPanel rendered="{!sforceNav != null}">


### PR DESCRIPTION
# Critical Changes

# Changes

- UI update on CON_DeleteContactOverride.page interstitial to achieve consistency with similar pages/modals elsewhere
- Edited ConfirmDeleteAccount custom label for clarity
- Added option to delete Contact and leave empty HH Account
- Added attribute to UTIL_PageMessages to allow hiding of cancel X
![deletecontactoverrideupdate](https://user-images.githubusercontent.com/12188165/31292837-c343f36a-aa89-11e7-8b2e-858238426461.png)


# Issues Closed

# New Metadata

- Delete_Contact_Leave_Account custom label
- Delete_Account custom label

# Deleted Metadata
