### PR TITLE
add hasSampleData

### DIFF
--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,6 +1,7 @@
 {
   "orgName": "NPSP - Beta Test Org",
   "edition": "Developer",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/beta_middlesuffix.json
+++ b/orgs/beta_middlesuffix.json
@@ -1,6 +1,7 @@
 {
   "orgName": "NPSP - Beta Org - MiddleSuffix",
   "edition": "Developer",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/beta_multicurrency.json
+++ b/orgs/beta_multicurrency.json
@@ -2,6 +2,7 @@
   "orgName": "NPSP - Beta Org - Multicurrency",
   "edition": "Developer",
   "features": "MultiCurrency",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/browsertest_classic.json
+++ b/orgs/browsertest_classic.json
@@ -1,6 +1,7 @@
 {
   "orgName": "NPSP - Browsertest Org",
   "edition": "Developer",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,6 +1,7 @@
 {
   "orgName": "NPSP - Dev Workspace",
   "edition": "Developer",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/enterprise.json
+++ b/orgs/enterprise.json
@@ -1,6 +1,7 @@
 {
   "orgName": "NPSP - Enterprise Workspace",
   "edition": "Enterprise",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,6 +1,7 @@
 {
   "orgName": "NPSP - Feature Test Org",
   "edition": "Developer",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -2,6 +2,7 @@
   "orgName": "NPSP - Dev Workspace",
   "edition": "Developer",
   "instance": "CS46",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,6 +1,7 @@
 {
   "orgName": "NPSP - Release Test Org",
   "edition": "Developer",
+  "hasSampleData": "true",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",


### PR DESCRIPTION
Add hasSampleData flag to scratch org definitions for Winter 18 builds.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
