### PR TITLE
FIX: Set the Lead Status input field as required on the Lead Conversion page.

### DIFF
--- a/src/pages/LD_LeadConvertOverride.page
+++ b/src/pages/LD_LeadConvertOverride.page
@@ -162,7 +162,7 @@
 
 
                     <div class="slds-form-element">
-                        <c:UTIL_FormField sObjType="Lead" sObj="{!l}" field="Status" labelOverride="{!$Label.leadConvertStatus}" id="leadstatus" />
+                        <c:UTIL_FormField sObjType="Lead" sObj="{!l}" field="Status" labelOverride="{!$Label.leadConvertStatus}" id="leadstatus" required="true" />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This fix was needed to resolve an issue with "-none-" being the default value for the lead status. The previous - and correct - behavior was that the default value was the default Closed status.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
