### PR TITLE
Mark required fields on page

### DIFF
--- a/src/components/UTIL_FormField.component
+++ b/src/components/UTIL_FormField.component
@@ -56,15 +56,19 @@
         rendered="{!($ObjectType[sObjType].fields[field].updateable
                     || $ObjectType[sObjType].fields[field].createable && sObj['Id']=='') && $ObjectType[sObjType].fields[field].type != 'boolean'}">        
         <apex:outputLabel for="inputX" styleClass="slds-form-element__label" rendered="{!showLabel == true && ftype!='boolean'}" id="lblInputField">
-            <apex:outputText rendered="{!required}" id="lblInputFieldRequired">
+            <apex:outputText rendered="{!required || NOT($ObjectType[sObjType].fields[field].nillable)}" id="lblInputFieldRequired">
                 <abbr class="slds-required" title="{!$Label.lblRequired}">*</abbr>
             </apex:outputText>
             <apex:outputText rendered="{!showLabel == true}" value="{!label}"/>
         </apex:outputLabel>
         <div class="slds-form-element__control">
-            <c:UTIL_InputField field="{!field}" sObj="{!sObj}" sObjType="{!sObjType}" onchange="{!onchange}" actSupAction="{!actSupAction}"
-                actSupReRender="{!actSupReRender}" actSup="{!actSup}" actSupStatus="{!actSupStatus}" actSupImmediate="{!actSupImmediate}"
-                required="{!required}" id="inputx"/>
+            <c:UTIL_InputField field="{!field}" sObj="{!sObj}" sObjType="{!sObjType}" 
+                onchange="{!onchange}" actSupAction="{!actSupAction}"
+                actSupReRender="{!actSupReRender}" actSup="{!actSup}" 
+                actSupStatus="{!actSupStatus}" actSupImmediate="{!actSupImmediate}"
+                required="{!required || NOT($ObjectType[sObjType].fields[field].nillable)}" 
+                id="inputx"
+            />
         </div>
     </apex:outputPanel>
 

--- a/src/components/UTIL_FormField.component
+++ b/src/components/UTIL_FormField.component
@@ -3,7 +3,7 @@
     <apex:attribute name="sObj" type="sObject" description="The sObject the field belongs to." required="true"/>
     <apex:attribute name="sObjType" type="String" description="The sObject type." required="true"/>
     <apex:attribute name="onchange" type="String"  default="" description="On change event."/>
-    <apex:attribute name="required" type="Boolean" default="" description="When true marks the field as required, otherwise, the field is marked as required based on isNillable()." />
+    <apex:attribute name="required" type="Boolean" default="" description="When true marks the field as required, otherwise, the field is marked as required based on 'nillable' value." />
     <apex:attribute name="styleClass" type="String" default="" description="The style to apply to the outer form element." />
     <apex:attribute name="labelOverride" type="String" default="" description="Override the standard field label with this text" />
     <apex:attribute name="showLabel" type="Boolean" default="true" description="When false, hide the field label" />

--- a/src/components/UTIL_FormField.component
+++ b/src/components/UTIL_FormField.component
@@ -3,7 +3,7 @@
     <apex:attribute name="sObj" type="sObject" description="The sObject the field belongs to." required="true"/>
     <apex:attribute name="sObjType" type="String" description="The sObject type." required="true"/>
     <apex:attribute name="onchange" type="String"  default="" description="On change event."/>
-    <apex:attribute name="required" type="Boolean" default="false" description="When true marks the field as required, defaults to false." />
+    <apex:attribute name="required" type="Boolean" default="" description="When true marks the field as required, otherwise, the field is marked as required based on isNillable()." />
     <apex:attribute name="styleClass" type="String" default="" description="The style to apply to the outer form element." />
     <apex:attribute name="labelOverride" type="String" default="" description="Override the standard field label with this text" />
     <apex:attribute name="showLabel" type="Boolean" default="true" description="When false, hide the field label" />
@@ -22,7 +22,10 @@
     <!-- The fixup style class to apply to dependent and date fields -->
     <apex:variable var="fixup"
         value="{!IF(dependent, IF(ftype=='picklist', ' dependentPicklistFixup', ' dependentMultiPicklistFixup'),'')}"/>
-
+    <!-- Determine if the field will be marked as required -->
+    <apex:variable var="isRequired"
+        value="{!IF(required == true, true, NOT($ObjectType[sObjType].fields[field].nillable))}"
+    />
     <!-- The field label to be displayed -->
     <apex:variable var="label" value="{!$ObjectType[sObjType].fields[field].label}" rendered="{!labelOverride == ''}"/>
     <apex:variable var="label" value="{!labelOverride}" rendered="{!labelOverride != ''}"/>
@@ -56,7 +59,7 @@
         rendered="{!($ObjectType[sObjType].fields[field].updateable
                     || $ObjectType[sObjType].fields[field].createable && sObj['Id']=='') && $ObjectType[sObjType].fields[field].type != 'boolean'}">        
         <apex:outputLabel for="inputX" styleClass="slds-form-element__label" rendered="{!showLabel == true && ftype!='boolean'}" id="lblInputField">
-            <apex:outputText rendered="{!required || NOT($ObjectType[sObjType].fields[field].nillable)}" id="lblInputFieldRequired">
+            <apex:outputText rendered="{!isRequired}" id="lblInputFieldRequired">
                 <abbr class="slds-required" title="{!$Label.lblRequired}">*</abbr>
             </apex:outputText>
             <apex:outputText rendered="{!showLabel == true}" value="{!label}"/>
@@ -66,7 +69,7 @@
                 onchange="{!onchange}" actSupAction="{!actSupAction}"
                 actSupReRender="{!actSupReRender}" actSup="{!actSup}" 
                 actSupStatus="{!actSupStatus}" actSupImmediate="{!actSupImmediate}"
-                required="{!required || NOT($ObjectType[sObjType].fields[field].nillable)}" 
+                required="{!isRequired}" 
                 id="inputx"
             />
         </div>


### PR DESCRIPTION
Currently some required fields are not marked as required on our custom pages. If a value is not provided, an error will be raised at DB level as expected and save will fail. To fix the issue, we'll check if a field is not nillable, and if so, mark it as required. This means the required attribute on the form is still optional and the required value does not have to be passed in.

# Critical Changes

# Changes

# Issues Closed
Fixes #2813

# New Metadata

# Deleted Metadata
