### PR TITLE
Invoke new Custom Labels in a test to resolve beta compile issue

### DIFF
--- a/src/classes/UTIL_Namespace_TEST.cls
+++ b/src/classes/UTIL_Namespace_TEST.cls
@@ -77,6 +77,8 @@ public with sharing class UTIL_Namespace_TEST {
         str = Label.Addr_Settings_Test_Response_Title;
         str = Label.Addr_Settings_Test_Title;
         str = Label.Addr_Verification_Batch_Status;
+        str = Label.DeleteAccount;
+        str = Label.DeleteContactLeaveAccount;
         str = Label.stgHHNameRefreshTitle;
         str = Label.stgLabelAfflSettings;
         str = Label.stgLabelBDESettings;


### PR DESCRIPTION
Custom Labels not used in unit tests will prevent beta build to be created, so in those cases add the Custom Label in UTIL_Namespace_TEST in order to create the beta build successfully.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
