### PR TITLE
Fix missing field in SOQL error when User Defined Rollups are enabled

### DIFF
--- a/src/classes/RLLP_OppAccRollup_BATCH.cls
+++ b/src/classes/RLLP_OppAccRollup_BATCH.cls
@@ -54,7 +54,8 @@ public class RLLP_OppAccRollup_BATCH implements Database.Batchable<SObject>, Sch
     * @description Batch start method and builds query for account rollups.
     ********************************************************************************************************/
     public database.Querylocator start(Database.BatchableContext bc) {
-        String acctQuery = oppRollupUtil.buildAccountQuery();        
+        RLLP_OppRollup_UTIL.setupUserRollupVars();
+        String acctQuery = oppRollupUtil.buildAccountQuery();
         return Database.getQueryLocator(acctQuery);
     }
     

--- a/src/classes/RLLP_OppContactRollup_BATCH.cls
+++ b/src/classes/RLLP_OppContactRollup_BATCH.cls
@@ -54,7 +54,8 @@ public class RLLP_OppContactRollup_BATCH implements Database.Batchable<SObject>,
     * @description Batch start method and builds query for contact rollups.
     ********************************************************************************************************/
     public database.Querylocator start(Database.BatchableContext bc) {
-        return Database.getQueryLocator(oppRollupUtil.buildContactQuery());      
+        RLLP_OppRollup_UTIL.setupUserRollupVars();
+        return Database.getQueryLocator(oppRollupUtil.buildContactQuery());
     }
     
     /*******************************************************************************************************

--- a/src/classes/RLLP_OppHouseholdRollup_BATCH.cls
+++ b/src/classes/RLLP_OppHouseholdRollup_BATCH.cls
@@ -54,7 +54,8 @@ public class RLLP_OppHouseholdRollup_BATCH implements Database.Batchable<SObject
     * @description Batch start method and builds query for household rollups.
     ********************************************************************************************************/
     public database.Querylocator start(Database.BatchableContext bc) {
-        return Database.getQueryLocator(oppRollupUtil.buildHouseholdQuery()); 
+        RLLP_OppRollup_UTIL.setupUserRollupVars();
+        return Database.getQueryLocator(oppRollupUtil.buildHouseholdQuery());
     }
     
     /*******************************************************************************************************


### PR DESCRIPTION
Re-initialize any UDR fields before executing the query to select Accounts, Contacts, or Households for the batch rollup. This is needed because the instance of RLLP_OppRollup_UTIL created in the batch job instantiation sets a static var that is thrown away before the batch start() method is executed by Salesforce.

# Critical Changes

# Changes

# Issues Closed

Fixes #2849 

# New Metadata

# Deleted Metadata
