### PR TITLE
Redo PR 2844

### DIFF
--- a/src/classes/ADDR_Cicero_TEST.cls
+++ b/src/classes/ADDR_Cicero_TEST.cls
@@ -330,4 +330,99 @@ public with sharing class ADDR_Cicero_TEST {
 
 	}
 
+    /*********************************************************************************************************
+    * @description Tests that user can choose to not have the Cicero response overwrite their address.
+    */
+    private static testmethod void doesNotOverwriteAddr() {
+        if (strTestOnly != '*' && strTestOnly != 'NewContactsNoAccounts') return;
+
+        list<Address__c> listAddr = new list<Address__c>();
+        Address__c addr = new Address__c();
+        addr.MailingStreet__c = '';
+        addr.MailingCity__c = 'san francisco';
+        addr.MailingState__c = 'ca';
+        addr.MailingPostalCode__c = '94105';
+        listAddr.add(addr);
+
+        ADDR_Cicero_Validator cicero = new ADDR_Cicero_Validator();
+        Addr_Verification_Settings__c settings = new Addr_Verification_Settings__c();
+        settings.Auth_Token__c = 'foo';  // we need a fake token or we won't validate
+        settings.Address_Verification_Endpoint__c = 'bar';
+        settings.Prevent_Address_Overwrite__c = true;
+        List<Address__c> listAddrVerified = cicero.verifyRecords(listAddr, settings);
+
+        system.assertEquals(1, listAddrVerified.size());
+        system.assertEquals(true, listAddrVerified[0].Verified__c);
+        system.assertEquals('', listAddrVerified[0].MailingStreet__c);
+        system.assertEquals('san francisco', listAddrVerified[0].MailingCity__c);
+        system.assertEquals('ca', listAddrVerified[0].MailingState__c);
+        system.assertEquals('94105', listAddrVerified[0].MailingPostalCode__c);
+        system.assertEquals('17', listAddrVerified[0].State_Lower_District__c);
+        system.assertEquals('11', listAddrVerified[0].State_Upper_District__c);
+
+    }
+    /*********************************************************************************************************
+    * @description Tests that user can allow Cicero response to overwrite the provided address.
+    */
+    private static testmethod void doesOverwriteAddr() {
+        if (strTestOnly != '*' && strTestOnly != 'NewContactsNoAccounts') return;
+
+        list<Address__c> listAddr = new list<Address__c>();
+        Address__c addr = new Address__c();
+        addr.MailingStreet__c = '1 market';
+        addr.MailingCity__c = '';
+        addr.MailingState__c = 'ca';
+        addr.MailingPostalCode__c = '94105';
+        listAddr.add(addr);
+
+        ADDR_Cicero_Validator cicero = new ADDR_Cicero_Validator();
+        Addr_Verification_Settings__c settings = new Addr_Verification_Settings__c();
+        settings.Auth_Token__c = 'foo';  // we need a fake token or we won't validate
+        settings.Address_Verification_Endpoint__c = 'bar';
+        settings.Prevent_Address_Overwrite__c = false;
+        List<Address__c> listAddrVerified = cicero.verifyRecords(listAddr, settings);
+
+        system.assertEquals(1, listAddrVerified.size());
+        system.assertEquals(true, listAddrVerified[0].Verified__c);
+        system.assertEquals('1 Market St #300', listAddrVerified[0].MailingStreet__c);
+        system.assertEquals('San Francisco', listAddrVerified[0].MailingCity__c);
+        system.assertEquals('CA', listAddrVerified[0].MailingState__c);
+        system.assertEquals('94105', listAddrVerified[0].MailingPostalCode__c);
+        system.assertEquals('17', listAddrVerified[0].State_Lower_District__c);
+        system.assertEquals('11', listAddrVerified[0].State_Upper_District__c);
+
+    }
+    /*********************************************************************************************************
+    * @description Tests that user can choose to not have the Cicero response overwrite their provided address, but if
+    * certain fields are blank then a default value will still be inserted.
+    */
+    private static testmethod void doesOverwriteBlankAddr() {
+        if (strTestOnly != '*' && strTestOnly != 'NewContactsNoAccounts') return;
+
+        list<Address__c> listAddr = new list<Address__c>();
+        Address__c addr = new Address__c();
+        addr.MailingStreet__c = '1 market';
+        addr.MailingCity__c = '';
+        addr.MailingState__c = '';
+        addr.MailingPostalCode__c = '94105';
+        listAddr.add(addr);
+
+        ADDR_Cicero_Validator cicero = new ADDR_Cicero_Validator();
+        Addr_Verification_Settings__c settings = new Addr_Verification_Settings__c();
+        settings.Auth_Token__c = 'foo';  // we need a fake token or we won't validate
+        settings.Address_Verification_Endpoint__c = 'bar';
+        settings.Prevent_Address_Overwrite__c = true;
+        List<Address__c> listAddrVerified = cicero.verifyRecords(listAddr, settings);
+
+        system.assertEquals(1, listAddrVerified.size());
+        system.assertEquals(true, listAddrVerified[0].Verified__c);
+        system.assertEquals('1 market', listAddrVerified[0].MailingStreet__c);
+        system.assertEquals('San Francisco', listAddrVerified[0].MailingCity__c);
+        system.assertEquals('CA', listAddrVerified[0].MailingState__c);
+        system.assertEquals('94105', listAddrVerified[0].MailingPostalCode__c);
+        system.assertEquals('17', listAddrVerified[0].State_Lower_District__c);
+        system.assertEquals('11', listAddrVerified[0].State_Upper_District__c);
+
+    }
+
 }

--- a/src/classes/ADDR_Cicero_Validator.cls
+++ b/src/classes/ADDR_Cicero_Validator.cls
@@ -196,14 +196,23 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
 
                             if (district.district_type == 'STATE_LOWER')
                                 addr.State_Lower_District__c = district.district_id;
+
+                            if (district.district_type == 'LOCAL')
+                                addr.Administrative_Area__c = district.district_id;
                         }
-                    
-                        addr.MailingStreet__c = candidate.match_addr.split(',')[0].trim();
-                        addr.MailingCity__c = candidate.match_city;
-                        addr.MailingState__c = candidate.match_region;
-                        addr.MailingPostalCode__c = candidate.match_postal;
-                        if (!String.isBlank(lastFourPostalDigits)) {
-                            addr.MailingPostalCode__c += '-' + lastFourPostalDigits;
+
+                        if(!settings.Prevent_Address_Overwrite__c){
+                            addr.MailingStreet__c = candidate.match_addr.split(',')[0].trim();
+                            addr.MailingCity__c = candidate.match_city;
+                            addr.MailingState__c = candidate.match_region;
+                            addr.MailingPostalCode__c = candidate.match_postal;
+                            if (!String.isBlank(lastFourPostalDigits)) {
+                                addr.MailingPostalCode__c += '-' + lastFourPostalDigits;
+                            }
+                        } else {
+                            if(String.isBlank(addr.MailingCity__c)) addr.MailingCity__c = candidate.match_city;
+                            if(String.isBlank(addr.MailingState__c)) addr.MailingState__c = candidate.match_region;
+                            if(String.isBlank(addr.MailingPostalCode__c)) addr.MailingPostalCode__c = candidate.match_postal;
                         }
                         addr.County_Name__c  = candidate.match_subregion;
 

--- a/src/objects/Addr_Verification_Settings__c.object
+++ b/src/objects/Addr_Verification_Settings__c.object
@@ -60,6 +60,16 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Prevent_Address_Overwrite__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Prevent Address Overwrite Checkbox</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Prevents the Cicero API from overwriting Addresses during verification. If an Address field is blank, Cicero updates it.</inlineHelpText>
+        <label>Prevent Address Overwrite</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>Reject_Ambiguous_Addresses__c</fullName>
         <defaultValue>false</defaultValue>
         <description>Reject Ambiguous Addresses</description>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Cumulus</fullName>
     <types>
@@ -54,6 +54,7 @@
         <members>BDE_BatchEntry_TEST</members>
         <members>BDI_BatchOverride_CTRL</members>
         <members>BDI_BatchOverride_TEST</members>
+        <members>BDI_ContactService</members>
         <members>BDI_DataImportAPI_TEST</members>
         <members>BDI_DataImportBatch_SCHED</members>
         <members>BDI_DataImportBatch_SEL</members>
@@ -61,6 +62,7 @@
         <members>BDI_DataImportCTRL_TEST</members>
         <members>BDI_DataImportDeleteBTN_CTRL</members>
         <members>BDI_DataImportDeleteBTN_TEST</members>
+        <members>BDI_DataImportService</members>
         <members>BDI_DataImport_API</members>
         <members>BDI_DataImport_BATCH</members>
         <members>BDI_DataImport_CTRL</members>
@@ -71,6 +73,8 @@
         <members>BDI_IMatchDonations</members>
         <members>BDI_IPostProcess</members>
         <members>BDI_MatchDonations</members>
+        <members>BDI_PerfLogger</members>
+        <members>BDI_PerfLogger_TEST</members>
         <members>BDI_PostProcess_TEST</members>
         <members>BDI_SettingsUI_CTRL</members>
         <members>BDI_SettingsUI_TEST</members>
@@ -130,10 +134,10 @@
         <members>HH_Container_TEST</members>
         <members>HH_HHObject_TDTM</members>
         <members>HH_HouseholdNaming</members>
-        <members>HH_HouseholdNaming_BATCH</members>
-        <members>HH_HouseholdNaming_TEST</members>
         <members>HH_HouseholdNamingSettingValidator</members>
         <members>HH_HouseholdNamingSettingValidator_TEST</members>
+        <members>HH_HouseholdNaming_BATCH</members>
+        <members>HH_HouseholdNaming_TEST</members>
         <members>HH_Households</members>
         <members>HH_Households_TDTM</members>
         <members>HH_Households_TEST</members>
@@ -215,12 +219,12 @@
         <members>RLLP_OppRollup_TEST2</members>
         <members>RLLP_OppRollup_UTIL</members>
         <members>RLLP_OppSoftCreditRollup_BATCH</members>
+        <members>RP_Constants</members>
         <members>RP_GettingStartedController</members>
         <members>RP_GettingStartedTest</members>
         <members>RP_GitHubClient</members>
         <members>RP_GitHubController</members>
         <members>RP_GitHubTest</members>
-        <members>RP_Constants</members>
         <members>RP_GitHubTestMock</members>
         <members>RP_HTTPClient</members>
         <members>RP_YoutubeClient</members>
@@ -277,8 +281,8 @@
         <members>STG_UninstallScript_TEST</members>
         <members>TDTM_Config_API</members>
         <members>TDTM_Config_API_Test</members>
-        <members>TDTM_DefaultConfig</members>
         <members>TDTM_DMLgt200_TEST</members>
+        <members>TDTM_DefaultConfig</members>
         <members>TDTM_ObjectDataGateway</members>
         <members>TDTM_ProcessControl</members>
         <members>TDTM_Runnable</members>
@@ -310,6 +314,8 @@
         <members>UTIL_Namespace</members>
         <members>UTIL_Namespace_TEST</members>
         <members>UTIL_PageMessages_CTRL</members>
+        <members>UTIL_PerfLogger</members>
+        <members>UTIL_PerfLogger_TEST</members>
         <members>UTIL_Profile</members>
         <members>UTIL_Profile_TEST</members>
         <members>UTIL_Query</members>
@@ -325,12 +331,6 @@
         <members>UTIL_UnitTestData_TEST</members>
         <members>UTIL_Version_API</members>
         <members>UTIL_iSoqlListViewConsumer</members>
-        <members>BDI_DataImportService</members>
-        <members>BDI_PerfLogger</members>
-        <members>BDI_ContactService</members>
-        <members>UTIL_PerfLogger</members>
-        <members>UTIL_PerfLogger_TEST</members>
-        <members>BDI_PerfLogger_TEST</members>
         <name>ApexClass</name>
     </types>
     <types>
@@ -511,6 +511,7 @@
         <members>Addr_Verification_Settings__c.Auth_Token__c</members>
         <members>Addr_Verification_Settings__c.Class__c</members>
         <members>Addr_Verification_Settings__c.Enable_Automatic_Verification__c</members>
+        <members>Addr_Verification_Settings__c.Prevent_Address_Overwrite__c</members>
         <members>Addr_Verification_Settings__c.Reject_Ambiguous_Addresses__c</members>
         <members>Addr_Verification_Settings__c.Timeout__c</members>
         <members>Addr_Verification_Settings__c.Using_SmartyStreets__c</members>
@@ -986,6 +987,29 @@
         <members>REL_RECenter</members>
         <members>REL_Return_to_Contact</members>
         <members>REL_View_Contact_Record</members>
+        <members>RP_CustomerJourneyLinkLabel</members>
+        <members>RP_DeeperParagraph</members>
+        <members>RP_DeeperSubtitle</members>
+        <members>RP_GettingStarted</members>
+        <members>RP_GitHubSubtitle</members>
+        <members>RP_GitHubTitle</members>
+        <members>RP_NpspLinkLabel</members>
+        <members>RP_ProductNameLabel</members>
+        <members>RP_ReleaseGitHub</members>
+        <members>RP_ReleaseNotesLink</members>
+        <members>RP_Remote_Site_Settings_Deactivated</members>
+        <members>RP_SalesforceOrgLinkLabel</members>
+        <members>RP_SubTitle</members>
+        <members>RP_Title</members>
+        <members>RP_TrailheadLinkLabel</members>
+        <members>RP_TrailheadParagraph</members>
+        <members>RP_TrailheadSubtitle</members>
+        <members>RP_USParagraph</members>
+        <members>RP_UsHubLinkLabel</members>
+        <members>RP_UsSubtitle</members>
+        <members>RP_Videos</members>
+        <members>RP_WebinarLinkLabel</members>
+        <members>RP_YoutubeChannel</members>
         <members>RecurringDonationAccountAndContactError</members>
         <members>Saved</members>
         <members>Settings_not_Saved</members>
@@ -1280,10 +1304,10 @@
         <members>lblNoHHMergePermissions</members>
         <members>lblPostalCode</members>
         <members>lblProgress</members>
-        <members>lblStatus</members>
         <members>lblRequired</members>
         <members>lblSalutation</members>
         <members>lblState</members>
+        <members>lblStatus</members>
         <members>lblStreet</members>
         <members>lblYouAreHere</members>
         <members>leadConvertAccountName</members>
@@ -1381,29 +1405,6 @@
         <members>pscManageSoftCreditsType</members>
         <members>pscManageSoftCreditsUnaccounted</members>
         <members>pscManageSoftCreditsValidateTotals</members>
-        <members>RP_CustomerJourneyLinkLabel</members>
-        <members>RP_DeeperParagraph</members>
-        <members>RP_DeeperSubtitle</members>
-        <members>RP_GettingStarted</members>
-        <members>RP_GitHubSubtitle</members>
-        <members>RP_GitHubTitle</members>
-        <members>RP_NpspLinkLabel</members>
-        <members>RP_ProductNameLabel</members>
-        <members>RP_ReleaseGitHub</members>
-        <members>RP_ReleaseNotesLink</members>
-        <members>RP_Remote_Site_Settings_Deactivated</members>
-        <members>RP_SalesforceOrgLinkLabel</members>
-        <members>RP_SubTitle</members>
-        <members>RP_Title</members>
-        <members>RP_TrailheadLinkLabel</members>
-        <members>RP_TrailheadParagraph</members>
-        <members>RP_TrailheadSubtitle</members>
-        <members>RP_UsHubLinkLabel</members>
-        <members>RP_USParagraph</members>
-        <members>RP_UsSubtitle</members>
-        <members>RP_Videos</members>
-        <members>RP_WebinarLinkLabel</members>
-        <members>RP_YoutubeChannel</members>
         <members>sendAcknowledgmentFailedStatus</members>
         <members>sendAcknowledgmentFailureReasons</members>
         <members>sendAcknowledgmentFireStatus</members>

--- a/src/pages/STG_PanelAddrVerification.page
+++ b/src/pages/STG_PanelAddrVerification.page
@@ -24,6 +24,12 @@
                 j$('[id$=iAuthTokenDiv]').show();
                 j$('[id$=iBatchVerifyDiv]').hide();
             }
+
+            if(selection=='Cicero'){
+                j$('[id$=iPreventAddressOverwriteDiv]').show();
+            } else {
+                j$('[id$=iPreventAddressOverwriteDiv]').hide();
+            }
         }
 
         j$(document).ready(function() {
@@ -162,6 +168,17 @@
                         <apex:inputCheckbox value="{!addrVerifsettings.Reject_Ambiguous_Addresses__c}" rendered="{!isReadOnlyMode}" disabled="true" id="iReject_Ambiguous_Addresses__cO" html-aria-describedby="{!$Component.iReject_Ambiguous_Addresses__cHelp}" styleClass="slds-checkbox"/>
                         <apex:outputPanel id="iReject_Ambiguous_Addresses__cHelp" layout="block">
                             <apex:outputText value="{!$ObjectType.Addr_Verification_Settings__c.fields.Reject_Ambiguous_Addresses__c.inlineHelpText}" styleClass="slds-form-element__help" />
+                        </apex:outputPanel>
+                    </div>
+                </div>
+                <div id="iPreventAddressOverwriteDiv" class="slds-form-element">
+                    <apex:outputLabel value="{!$ObjectType.Addr_Verification_Settings__c.fields.Prevent_Address_Overwrite__c.Label}" for="iPrevent_Address_Overwrite__c"
+                                      styleClass="slds-form-element__label"/>
+                    <div class="slds-form-element__control">
+                        <apex:inputCheckbox value="{!addrVerifsettings.Prevent_Address_Overwrite__c}" rendered="{!isEditMode}" id="iPrevent_Address_Overwrite__c" html-aria-describedby="{!$Component.iPrevent_Address_Overwrite__cHelp}" styleClass="slds-checkbox"/>
+                        <apex:inputCheckbox value="{!addrVerifsettings.Prevent_Address_Overwrite__c}" rendered="{!isReadOnlyMode}" disabled="true" id="iPrevent_Address_Overwrite__c0" html-aria-describedby="{!$Component.iPrevent_Address_Overwrite__cHelp}" styleClass="slds-checkbox"/>
+                        <apex:outputPanel id="iPrevent_Address_Overwrite__cHelp" layout="block">
+                            <apex:outputText value="{!$ObjectType.Addr_Verification_Settings__c.fields.Prevent_Address_Overwrite__c.inlineHelpText}" styleClass="slds-form-element__help" />
                         </apex:outputPanel>
                     </div>
                 </div>


### PR DESCRIPTION
This is a "redo" of https://github.com/SalesforceFoundation/Cumulus/pull/2844

We had to revert this change in order to do a bug fix release. @randi274 please use this PR to merge after the bug fix release has been created.

# Critical Changes

# Changes

- There is a new checkbox in NPSP Settings, under People | Addresses, called **Prevent Address Overwrite**. This checkbox only appears if you enable Automatic Verification and select Cicero as the Verification Service. Selecting the checkbox prevents the Cicero API from overwriting Addresses during verification. If an Address field is blank, Cicero will update it.
# Issues Closed

- Fixes #1686
- Fixes #2538 

# New Metadata

# Deleted Metadata
