### PR TITLE
Removed with sharing from the class

### DIFF
--- a/src/classes/UTIL_DMLService.cls
+++ b/src/classes/UTIL_DMLService.cls
@@ -35,7 +35,7 @@
 * @description Service Class to handle DML actions.
 */
 
-public with sharing class UTIL_DMLService {
+public class UTIL_DMLService {
     public static final Boolean ALL_OR_NONE_TRUE = true;
     
 


### PR DESCRIPTION
# Critical Changes
We introduced an issue in release 3.115 that prevented users with certain profile and sharing settings from creating or editing some records. System Administrators were able to credit and edit records as always. This release fixes the issue and we apologize for any inconvenience.

# Changes

# Issues Closed
Fix #2875 

# New Metadata

# Deleted Metadata
