### PR TITLE
Cicero verification administration field and labeling update

### DIFF
--- a/src/classes/ADDR_Cicero_Validator.cls
+++ b/src/classes/ADDR_Cicero_Validator.cls
@@ -189,17 +189,11 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
                             if (district.district_type == 'NATIONAL_LOWER') {
                                 addr.Congressional_District__c = district.district_id;
                                 addr.MailingCountry__c = district.country;
-                            }
-
-                            if (district.district_type == 'STATE_UPPER') {
+                            } else if (district.district_type == 'STATE_UPPER') {
                                 addr.State_Upper_District__c = district.district_id;
-                            }
-
-                            if (district.district_type == 'STATE_LOWER') {
+                            } else if (district.district_type == 'STATE_LOWER') {
                                 addr.State_Lower_District__c = district.district_id;
-                            }
-
-                            if (district.district_type == 'LOCAL' && district.subtype != 'COUNTY') {
+                            } else if (district.district_type == 'LOCAL' && district.subtype != 'COUNTY') {
                                 addr.Administrative_Area__c = district.district_id;
                             }
                         }

--- a/src/classes/ADDR_Cicero_Validator.cls
+++ b/src/classes/ADDR_Cicero_Validator.cls
@@ -191,14 +191,17 @@ public with sharing class ADDR_Cicero_Validator implements ADDR_IValidator {
                                 addr.MailingCountry__c = district.country;
                             }
 
-                            if (district.district_type == 'STATE_UPPER')
+                            if (district.district_type == 'STATE_UPPER') {
                                 addr.State_Upper_District__c = district.district_id;
+                            }
 
-                            if (district.district_type == 'STATE_LOWER')
+                            if (district.district_type == 'STATE_LOWER') {
                                 addr.State_Lower_District__c = district.district_id;
+                            }
 
-                            if (district.district_type == 'LOCAL')
+                            if (district.district_type == 'LOCAL' && district.subtype != 'COUNTY') {
                                 addr.Administrative_Area__c = district.district_id;
+                            }
                         }
 
                         if(!settings.Prevent_Address_Overwrite__c){

--- a/src/objects/Addr_Verification_Settings__c.object
+++ b/src/objects/Addr_Verification_Settings__c.object
@@ -64,7 +64,7 @@
         <defaultValue>false</defaultValue>
         <description>Prevent Address Overwrite Checkbox</description>
         <externalId>false</externalId>
-        <inlineHelpText>Prevents the Cicero API from overwriting Addresses during verification. If an Address field is blank, Cicero updates it.</inlineHelpText>
+        <inlineHelpText>Prevents the Cicero API from overwriting Addresses during verification.</inlineHelpText>
         <label>Prevent Address Overwrite</label>
         <trackTrending>false</trackTrending>
         <type>Checkbox</type>


### PR DESCRIPTION
# Critical Changes

# Changes
- We fixed an issue with Cicero Address Verification where the Administrative Area field was sometimes incorrectly populating with the county.

# Issues Closed

# New Metadata

# Deleted Metadata
