### PR TITLE
Configurable Recurring Donation Batch Size

### DIFF
--- a/src/classes/RD_RecurringDonations_BATCH.cls
+++ b/src/classes/RD_RecurringDonations_BATCH.cls
@@ -55,6 +55,12 @@ Schedulable {
     * @description Count of RD's that hit errors while processing
     */ 
     public Integer failuresCount = 0;
+
+    /*******************************************************************************************************
+    * @description Batch size for Apex Job. Uses default of 50 if Custom Setting is null.
+    */
+    public Integer batchSize = (UTIL_CustomSettingsFacade.getRecurringDonationsSettings().Recurring_Donation_Batch_Size__c <> null) ? UTIL_CustomSettingsFacade.getRecurringDonationsSettings().Recurring_Donation_Batch_Size__c.intValue() : 50;
+
     
     /*******************************************************************************************************
     * @description Class constructor
@@ -69,7 +75,7 @@ Schedulable {
     * @description Executes the RD Batch process.
     */ 
     public void execute(SchedulableContext context) {
-        Database.executeBatch(new RD_RecurringDonations_BATCH(), 50); 
+        Database.executeBatch(new RD_RecurringDonations_BATCH(), batchSize); 
     }
     
     /*******************************************************************************************************

--- a/src/classes/STG_PanelRDBatch_CTRL.cls
+++ b/src/classes/STG_PanelRDBatch_CTRL.cls
@@ -51,6 +51,10 @@ public with sharing class STG_PanelRDBatch_CTRL extends STG_Panel {
     * @description Whether the batch process is currently running  
     */
     public boolean isRunningBatch { get; set; }
+
+    /* @description Batch size of Recurring Donations Apex job  
+    */
+    public Integer batchSize = (UTIL_CustomSettingsFacade.getRecurringDonationsSettings().Recurring_Donation_Batch_Size__c <> null) ? UTIL_CustomSettingsFacade.getRecurringDonationsSettings().Recurring_Donation_Batch_Size__c.intValue() : 50;
     
     /*********************************************************************************************************
     * @description Action Method to execute the RD Batch process
@@ -62,7 +66,7 @@ public with sharing class STG_PanelRDBatch_CTRL extends STG_Panel {
 	    	isRunningBatch = true;
 	        
 	        //call the batch job, processing 50 at a time 
-	        Id batchInstanceId = Database.executeBatch(new RD_RecurringDonations_BATCH(), 50); 
+	        Id batchInstanceId = Database.executeBatch(new RD_RecurringDonations_BATCH(), batchSize); 
         }
         catch(Exception e) {
             Database.rollback(sp);

--- a/src/classes/STG_PanelRDBatch_CTRL.cls
+++ b/src/classes/STG_PanelRDBatch_CTRL.cls
@@ -51,10 +51,6 @@ public with sharing class STG_PanelRDBatch_CTRL extends STG_Panel {
     * @description Whether the batch process is currently running  
     */
     public boolean isRunningBatch { get; set; }
-
-    /* @description Batch size of Recurring Donations Apex job  
-    */
-    public Integer batchSize = (UTIL_CustomSettingsFacade.getRecurringDonationsSettings().Recurring_Donation_Batch_Size__c <> null) ? UTIL_CustomSettingsFacade.getRecurringDonationsSettings().Recurring_Donation_Batch_Size__c.intValue() : 50;
     
     /*********************************************************************************************************
     * @description Action Method to execute the RD Batch process
@@ -65,8 +61,10 @@ public with sharing class STG_PanelRDBatch_CTRL extends STG_Panel {
         try {
 	    	isRunningBatch = true;
 	        
-	        //call the batch job, processing 50 at a time 
-	        Id batchInstanceId = Database.executeBatch(new RD_RecurringDonations_BATCH(), batchSize); 
+	        // Call the batch job, using the Recurring Donations Batch Size field in Custom Settings
+            RD_RecurringDonations_BATCH rdb = new RD_RecurringDonations_BATCH();
+            Id batchInstanceId = Database.executeBatch(rdb, rdb.batchSize);
+	         
         }
         catch(Exception e) {
             Database.rollback(sp);

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -538,6 +538,7 @@ public without sharing class UTIL_CustomSettingsFacade {
             rds.npe03__Enable_Update_Check__c = true;
             //rds.npe03__Error_Email_Notifications__c = 'All Sys Admins'; *This field has been moved to the ERR_Settings__c custom setting
             rds.npe03__Maximum_Donations__c = 50;
+            rds.Recurring_Donation_Batch_Size__c = 50;
             rds.npe03__Opportunity_Forecast_Months__c = 12;
             rds.npe03__Update_Check_Interval__c = 90;
             rds.npe03__Open_Opportunity_Behavior__c = RD_RecurringDonations.RecurringDonationCloseOptions.Mark_Opportunities_Closed_Lost.name();
@@ -771,7 +772,8 @@ public without sharing class UTIL_CustomSettingsFacade {
         recurringDonationsSettings.npe03__Maximum_Donations__c = mySettings.npe03__Maximum_Donations__c;
         recurringDonationsSettings.npe03__Open_Opportunity_Behavior__c = mySettings.npe03__Open_Opportunity_Behavior__c;
         recurringDonationsSettings.npe03__Add_Campaign_to_All_Opportunites__c = mySettings.npe03__Add_Campaign_to_All_Opportunites__c;
-        recurringDonationsSettings.npe03__Error_Email_Notifications__c = mySettings.npe03__Error_Email_Notifications__c;  
+        recurringDonationsSettings.npe03__Error_Email_Notifications__c = mySettings.npe03__Error_Email_Notifications__c;
+        recurringDonationsSettings.Recurring_Donation_Batch_Size__c = mySettings.Recurring_Donation_Batch_Size__c;  
         orgRecurringDonationsSettings = recurringDonationsSettings;
         return recurringDonationsSettings;
     }

--- a/src/objects/npe03__Recurring_Donations_Settings__c.object
+++ b/src/objects/npe03__Recurring_Donations_Settings__c.object
@@ -3,9 +3,9 @@
     <fields>
         <fullName>Recurring_Donation_Batch_Size__c</fullName>
         <defaultValue>50</defaultValue>
-        <description>The number of records processed at a time when running the Recurring Donations job. The default size is 50. Reduce to a smaller number if the Recurring Donation job is failing due to system limits.</description>
+        <description>The number of records to process at a time when running the Recurring Donations batch job. The default size is 50. Reduce to a smaller number if the Recurring Donations batch job is failing due to system limits.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The number of records processed at a time when running the Recurring Donations job. The default size is 50. Reduce to a smaller number if the Recurring Donation job is failing due to system limits.</inlineHelpText>
+        <inlineHelpText>The number of records to process at a time when running the Recurring Donations batch job. The default size is 50. Reduce to a smaller number if the Recurring Donations batch job is failing due to system limits.</inlineHelpText>
         <label>Recurring Donation Batch Size</label>
         <precision>18</precision>
         <required>false</required>

--- a/src/objects/npe03__Recurring_Donations_Settings__c.object
+++ b/src/objects/npe03__Recurring_Donations_Settings__c.object
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>Recurring_Donation_Batch_Size__c</fullName>
+        <defaultValue>50</defaultValue>
+        <description>The number of records processed at a time when running the Recurring Donations job. The default size is 50. Reduce to a smaller number if the Recurring Donation job is failing due to system limits.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The number of records processed at a time when running the Recurring Donations job. The default size is 50. Reduce to a smaller number if the Recurring Donation job is failing due to system limits.</inlineHelpText>
+        <label>Recurring Donation Batch Size</label>
+        <precision>18</precision>
+        <required>false</required>
+        <scale>0</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+</CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -879,6 +879,7 @@
         <members>npe01__OppPayment__c.Payment_Acknowledged_Date__c</members>
         <members>npe01__OppPayment__c.Payment_Acknowledgment_Status__c</members>
         <members>npe03__Recurring_Donation__c.Always_Use_Last_Day_Of_Month__c</members>
+        <members>npe03__Recurring_Donation__c.Recurring_Donation_Batch_Size__c</members>
         <members>npe4__Relationship_Settings__c.Enable_Custom_Field_Sync__c</members>
         <members>npo02__Household__c.Number_of_Household_Members__c</members>
         <members>npo02__Households_Settings__c.Matched_Donor_Role__c</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -879,7 +879,7 @@
         <members>npe01__OppPayment__c.Payment_Acknowledged_Date__c</members>
         <members>npe01__OppPayment__c.Payment_Acknowledgment_Status__c</members>
         <members>npe03__Recurring_Donation__c.Always_Use_Last_Day_Of_Month__c</members>
-        <members>npe03__Recurring_Donation__c.Recurring_Donation_Batch_Size__c</members>
+        <members>npe03__Recurring_Donations_Settings__c.Recurring_Donation_Batch_Size__c</members>
         <members>npe4__Relationship_Settings__c.Enable_Custom_Field_Sync__c</members>
         <members>npo02__Household__c.Number_of_Household_Members__c</members>
         <members>npo02__Households_Settings__c.Matched_Donor_Role__c</members>


### PR DESCRIPTION
Added Custom Setting field to allow Recurring Donation Batch Size to be configurable. The nightly scheduled job and bulk data process both use this custom setting for the batch size. If no custom setting field value is present, it defaults to 50. The default for the custom setting field is also 50.

# Critical Changes

# Changes

- The batch size for the Recurring Donations nightly scheduled job and bulk data process was previously hard coded to 50. You can now configure this value using the new **Recurring Donation Batch Size** field located in **Setup | Custom Settings | Recurring Donations Settings**. If this field is left blank, it will default to 50.

# Issues Closed
Fixes #2610

# New Metadata
npe03__Recurring_Donations_Settings__c. Recurring_Donation_Batch_Size__c
# Deleted Metadata
