### PR TITLE
Manage HH page now refreshes account page on save

### DIFF
--- a/src/aura/HH_Container/HH_ContainerHelper.js
+++ b/src/aura/HH_Container/HH_ContainerHelper.js
@@ -388,7 +388,8 @@
         if (typeof sforce === "undefined") {
             window.location.replace('/' + component.get('v.hhId'));
         } else {
-            sforce.one.navigateToSObject(component.get('v.hhId'));
+            // using back() instead of navigateToSObject() causes LEX to refresh related lists on the page.
+            sforce.one.back(true);
         }
     },
 


### PR DESCRIPTION
using sforce.one.back() instead of navigateToSObject() causes LEX to refresh related lists on the household account page.

# Critical Changes

# Changes

# Issues Closed
fixes #2930

# New Metadata

# Deleted Metadata
