### PR TITLE
Peg underlying package versions at Winter 18 friendly versions

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -19,12 +19,16 @@ project:
     dependencies:
         # npo02 (includes npe01)
         - github: https://github.com/SalesforceFoundation/Households
+          tag: rel/3.8
         # npe03
         - github: https://github.com/SalesforceFoundation/Recurring_Donations
+          tag: rel/3.11
         # npe4
         - github: https://github.com/SalesforceFoundation/Relationships
+          tag: rel/3.7
         # npe5
         - github: https://github.com/SalesforceFoundation/Affiliations
+          tag: rel/3.6
 
 tasks:
     download_ldv_tests:

--- a/src/classes/ACCT_AccountMerge_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_AccountMerge_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_AccountMerge_TEST.cls-meta.xml
+++ b/src/classes/ACCT_AccountMerge_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_Accounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_Accounts_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_HHAccounts_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
+++ b/src/classes/ACCT_IndividualAccounts_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
+++ b/src/classes/ACCT_ViewOverride_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Account_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Account_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Addresses_TEST.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Addresses_TEST2.cls-meta.xml
+++ b/src/classes/ADDR_Addresses_TEST2.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_Contact_TDTM.cls-meta.xml
+++ b/src/classes/ADDR_Contact_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_CopyAddrHHObjBTN_CTRL.cls-meta.xml
+++ b/src/classes/ADDR_CopyAddrHHObjBTN_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls-meta.xml
+++ b/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
+++ b/src/classes/AFFL_Affiliations_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -13,7 +13,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/BDI_DataImport_BATCH.cls-meta.xml
+++ b/src/classes/BDI_DataImport_BATCH.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/BDI_DataImport_TEST.cls-meta.xml
+++ b/src/classes/BDI_DataImport_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -13,7 +13,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/BDI_DataImport_TEST2.cls-meta.xml
+++ b/src/classes/BDI_DataImport_TEST2.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/BDI_Donations.cls-meta.xml
+++ b/src/classes/BDI_Donations.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/BDI_Donations_TEST.cls-meta.xml
+++ b/src/classes/BDI_Donations_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/BDI_IMatchDonations.cls-meta.xml
+++ b/src/classes/BDI_IMatchDonations.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/BDI_MatchDonations.cls-meta.xml
+++ b/src/classes/BDI_MatchDonations.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CAO_Constants.cls-meta.xml
+++ b/src/classes/CAO_Constants.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CONV_Account_Conversion_BATCH.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_BATCH.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -13,7 +13,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CONV_Account_Conversion_BATCH_TEST.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_BATCH_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -13,7 +13,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CONV_Account_Conversion_CTRL.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CONV_Account_Conversion_CTRL_TEST.cls-meta.xml
+++ b/src/classes/CONV_Account_Conversion_CTRL_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ChangeAccount_TEST.cls-meta.xml
+++ b/src/classes/CON_ChangeAccount_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge.cls-meta.xml
+++ b/src/classes/CON_ContactMerge.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMergeTDTM_TEST.cls-meta.xml
+++ b/src/classes/CON_ContactMergeTDTM_TEST.cls-meta.xml
@@ -8,7 +8,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMergeTDTM_TEST2.cls-meta.xml
+++ b/src/classes/CON_ContactMergeTDTM_TEST2.cls-meta.xml
@@ -8,7 +8,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge_TDTM.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge_TEST.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_ContactMerge_TEST2.cls-meta.xml
+++ b/src/classes/CON_ContactMerge_TEST2.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_DeleteContactOverride_CTRL.cls-meta.xml
+++ b/src/classes/CON_DeleteContactOverride_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_DeleteContactOverride_TEST.cls-meta.xml
+++ b/src/classes/CON_DeleteContactOverride_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_DoNotContact_TDTM.cls-meta.xml
+++ b/src/classes/CON_DoNotContact_TDTM.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/CON_DoNotContact_TEST.cls-meta.xml
+++ b/src/classes/CON_DoNotContact_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/ERR_Handler_TEST.cls-meta.xml
+++ b/src/classes/ERR_Handler_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -13,7 +13,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_CampaignDedupeBTN_CTRL.cls-meta.xml
+++ b/src/classes/HH_CampaignDedupeBTN_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_CampaignDedupeBTN_TEST.cls-meta.xml
+++ b/src/classes/HH_CampaignDedupeBTN_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_Container_LCTRL.cls-meta.xml
+++ b/src/classes/HH_Container_LCTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_Container_TEST.cls-meta.xml
+++ b/src/classes/HH_Container_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_HouseholdNaming.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_HouseholdNaming_BATCH.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming_BATCH.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
+++ b/src/classes/HH_HouseholdNaming_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_Households_TDTM.cls-meta.xml
+++ b/src/classes/HH_Households_TDTM.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_Households_TEST.cls-meta.xml
+++ b/src/classes/HH_Households_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_ManageHH_CTRL.cls-meta.xml
+++ b/src/classes/HH_ManageHH_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_ManageHH_TEST.cls-meta.xml
+++ b/src/classes/HH_ManageHH_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_NameSpec.cls-meta.xml
+++ b/src/classes/HH_NameSpec.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_NameSpec_TEST.cls-meta.xml
+++ b/src/classes/HH_NameSpec_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TDTM.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
+++ b/src/classes/HH_OppContactRoles_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_CTRL.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
+++ b/src/classes/LD_LeadConvertOverride_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -13,7 +13,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/LVL_LevelAssignBATCH_TEST.cls-meta.xml
+++ b/src/classes/LVL_LevelAssignBATCH_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_CampaignMember_TEST.cls-meta.xml
+++ b/src/classes/OPP_CampaignMember_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
+++ b/src/classes/OPP_MatchingDonationsBTN_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
+++ b/src/classes/OPP_OpportunityContactRoles_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_OpportunityNaming.cls-meta.xml
+++ b/src/classes/OPP_OpportunityNaming.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/OPP_OpportunityNaming_TEST.cls-meta.xml
+++ b/src/classes/OPP_OpportunityNaming_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentCreator.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentCreator_BATCH.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator_BATCH.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentCreator_TEST.cls-meta.xml
+++ b/src/classes/PMT_PaymentCreator_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
+++ b/src/classes/PMT_PaymentWizard_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PSC_ManageSoftCredits_CTRL.cls-meta.xml
+++ b/src/classes/PSC_ManageSoftCredits_CTRL.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/PSC_ManageSoftCredits_TEST.cls-meta.xml
+++ b/src/classes/PSC_ManageSoftCredits_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RD_RecurringDonations_TEST.cls-meta.xml
+++ b/src/classes/RD_RecurringDonations_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/RLLP_OppHouseholdRollup_BATCH.cls-meta.xml
+++ b/src/classes/RLLP_OppHouseholdRollup_BATCH.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppPartialSoftCreditRollup.cls-meta.xml
+++ b/src/classes/RLLP_OppPartialSoftCreditRollup.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppPartialSoftCreditRollup_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppPartialSoftCreditRollup_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppRollup.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollupBATCH_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppRollup_TEST2.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_TEST2.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
+++ b/src/classes/RLLP_OppRollup_UTIL.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_InstallScript.cls-meta.xml
+++ b/src/classes/STG_InstallScript.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -23,7 +23,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_InstallScript_TEST.cls-meta.xml
+++ b/src/classes/STG_InstallScript_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -23,7 +23,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_Panel.cls-meta.xml
+++ b/src/classes/STG_Panel.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>

--- a/src/classes/STG_PanelContactRoles_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelContactRoles_CTRL.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelContacts_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelContacts_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -18,7 +18,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelHealthCheck_TEST.cls-meta.xml
+++ b/src/classes/STG_PanelHealthCheck_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelHouseholds_CTRL.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelMembership_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelMembership_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelOppRollups_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelOppRollups_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelOpps_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelOpps_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelPaymentMapping_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelRenameHouseholds_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelRenameHouseholds_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_PanelUserRollup_CTRL.cls-meta.xml
+++ b/src/classes/STG_PanelUserRollup_CTRL.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_SettingsManager_TEST.cls-meta.xml
+++ b/src/classes/STG_SettingsManager_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -23,7 +23,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/STG_SettingsService.cls-meta.xml
+++ b/src/classes/STG_SettingsService.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -23,7 +23,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/TDTM_Runnable_TEST.cls-meta.xml
+++ b/src/classes/TDTM_Runnable_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettingsFacade.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -23,7 +23,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/UTIL_CustomSettings_API.cls-meta.xml
+++ b/src/classes/UTIL_CustomSettings_API.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -23,7 +23,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/UTIL_ListCustomSettingsFacade.cls-meta.xml
+++ b/src/classes/UTIL_ListCustomSettingsFacade.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -18,7 +18,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/UTIL_RecordTypeSettingsUpdate.cls-meta.xml
+++ b/src/classes/UTIL_RecordTypeSettingsUpdate.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/UTIL_RecordTypeSettingsUpdate_TEST.cls-meta.xml
+++ b/src/classes/UTIL_RecordTypeSettingsUpdate_TEST.cls-meta.xml
@@ -3,12 +3,12 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
+++ b/src/classes/UTIL_UnitTestData_TEST.cls-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <status>Active</status>

--- a/src/components/BDI_SettingsUI.component-meta.xml
+++ b/src/components/BDI_SettingsUI.component-meta.xml
@@ -5,7 +5,7 @@
     <label>BDI_SettingsUI</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -25,7 +25,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/RP_GettingStarted.component-meta.xml
+++ b/src/components/RP_GettingStarted.component-meta.xml
@@ -4,7 +4,7 @@
     <label>RP_GettingStarted</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/RP_GitHub.component-meta.xml
+++ b/src/components/RP_GitHub.component-meta.xml
@@ -4,7 +4,7 @@
     <label>RP_GitHub</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/RP_Youtube.component-meta.xml
+++ b/src/components/RP_Youtube.component-meta.xml
@@ -4,7 +4,7 @@
     <label>RP_Youtube</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/STG_DataBoundMultiSelect.component-meta.xml
+++ b/src/components/STG_DataBoundMultiSelect.component-meta.xml
@@ -5,7 +5,7 @@
     <label>STG_DataBoundMultiSelect</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -25,7 +25,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/STG_PageHeader.component-meta.xml
+++ b/src/components/STG_PageHeader.component-meta.xml
@@ -5,7 +5,7 @@
     <label>STG_PageHeader</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -25,7 +25,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_FormField.component-meta.xml
+++ b/src/components/UTIL_FormField.component-meta.xml
@@ -4,7 +4,7 @@
     <label>UTIL_FormField</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_InputField.component-meta.xml
+++ b/src/components/UTIL_InputField.component-meta.xml
@@ -4,7 +4,7 @@
     <label>UTIL_InputField</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_JobProgress.component-meta.xml
+++ b/src/components/UTIL_JobProgress.component-meta.xml
@@ -5,7 +5,7 @@
     <label>UTIL_JobProgress</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -25,7 +25,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_JobProgressLightning.component-meta.xml
+++ b/src/components/UTIL_JobProgressLightning.component-meta.xml
@@ -4,7 +4,7 @@
     <label>Job Progress Component</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_NavigateBack.component-meta.xml
+++ b/src/components/UTIL_NavigateBack.component-meta.xml
@@ -4,7 +4,7 @@
     <label>UTIL_NavigateBack</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_PageHeader.component-meta.xml
+++ b/src/components/UTIL_PageHeader.component-meta.xml
@@ -4,7 +4,7 @@
     <label>UTIL_PageHeader</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_PageMessages.component-meta.xml
+++ b/src/components/UTIL_PageMessages.component-meta.xml
@@ -4,7 +4,7 @@
     <label>UTIL_PageMessages</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -24,7 +24,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_SoqlListView.component-meta.xml
+++ b/src/components/UTIL_SoqlListView.component-meta.xml
@@ -5,7 +5,7 @@
     <label>UTIL_SoqlListView</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -25,7 +25,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_Tooltip.component-meta.xml
+++ b/src/components/UTIL_Tooltip.component-meta.xml
@@ -5,7 +5,7 @@
     <label>UTIL_Tooltip</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -25,7 +25,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/components/UTIL_Typeahead.component-meta.xml
+++ b/src/components/UTIL_Typeahead.component-meta.xml
@@ -5,7 +5,7 @@
     <label>UTIL_Typeahead</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -25,7 +25,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexComponent>

--- a/src/pages/ACCT_ViewOverride.page-meta.xml
+++ b/src/pages/ACCT_ViewOverride.page-meta.xml
@@ -6,7 +6,7 @@
     <label>ACCT_ViewOverride</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/ADDR_CopyAddrHHObjBTN.page-meta.xml
+++ b/src/pages/ADDR_CopyAddrHHObjBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>ADDR_CopyAddrHHObjBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/ADDR_ValidatorBTN.page-meta.xml
+++ b/src/pages/ADDR_ValidatorBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>ADDR_ValidatorBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/ALLO_ManageAllocations.page-meta.xml
+++ b/src/pages/ALLO_ManageAllocations.page-meta.xml
@@ -6,7 +6,7 @@
     <label>ALLO_ManageAllocations</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/ALLO_RollupBTN.page-meta.xml
+++ b/src/pages/ALLO_RollupBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>ALLO_RollupBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/BDE_BatchEntry.page-meta.xml
+++ b/src/pages/BDE_BatchEntry.page-meta.xml
@@ -6,7 +6,7 @@
     <label>BDE_BatchEntry</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/BDI_BatchOverride.page-meta.xml
+++ b/src/pages/BDI_BatchOverride.page-meta.xml
@@ -6,7 +6,7 @@
     <label>BDI_BatchOverride</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/BDI_DataImport.page-meta.xml
+++ b/src/pages/BDI_DataImport.page-meta.xml
@@ -6,7 +6,7 @@
     <label>BDI_DataImport</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/BDI_DataImportDeleteBTN.page-meta.xml
+++ b/src/pages/BDI_DataImportDeleteBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>BDI_DataImportDeleteBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/CONV_Account_Conversion.page-meta.xml
+++ b/src/pages/CONV_Account_Conversion.page-meta.xml
@@ -6,7 +6,7 @@
     <label>CONV_Account_Conversion</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/CON_ContactMerge.page-meta.xml
+++ b/src/pages/CON_ContactMerge.page-meta.xml
@@ -6,7 +6,7 @@
     <label>CON_ContactMerge</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/CON_DeleteContactOverride.page-meta.xml
+++ b/src/pages/CON_DeleteContactOverride.page-meta.xml
@@ -6,7 +6,7 @@
     <label>CON_DeleteContactOverride</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/EP_ManageEPTemplate.page-meta.xml
+++ b/src/pages/EP_ManageEPTemplate.page-meta.xml
@@ -6,7 +6,7 @@
     <label>EP_ManageEPTemplate</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/HH_CampaignDedupeBTN.page-meta.xml
+++ b/src/pages/HH_CampaignDedupeBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>HH_CampaignDedupeBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/HH_ManageHH.page-meta.xml
+++ b/src/pages/HH_ManageHH.page-meta.xml
@@ -6,7 +6,7 @@
     <label>HH_ManageHH</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/HH_ManageHHAccount.page-meta.xml
+++ b/src/pages/HH_ManageHHAccount.page-meta.xml
@@ -6,7 +6,7 @@
     <label>HH_ManageHHAccount</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/HH_ManageHousehold.page-meta.xml
+++ b/src/pages/HH_ManageHousehold.page-meta.xml
@@ -6,7 +6,7 @@
     <label>HH_ManageHousehold</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/LD_LeadConvertOverride.page-meta.xml
+++ b/src/pages/LD_LeadConvertOverride.page-meta.xml
@@ -6,7 +6,7 @@
     <label>LD_LeadConvertOverride</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/LVL_LevelEdit.page-meta.xml
+++ b/src/pages/LVL_LevelEdit.page-meta.xml
@@ -6,7 +6,7 @@
     <label>LVL_LevelEdit</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/MTCH_FindGifts.page-meta.xml
+++ b/src/pages/MTCH_FindGifts.page-meta.xml
@@ -6,7 +6,7 @@
     <label>MTCH_FindGifts</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/NPSP_Resources.page-meta.xml
+++ b/src/pages/NPSP_Resources.page-meta.xml
@@ -6,7 +6,7 @@
     <label>NPSP Resources</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
+++ b/src/pages/OPP_MatchingDonationsBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>OPP_MatchingDonationsBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/OPP_OpportunityNamingBTN.page-meta.xml
+++ b/src/pages/OPP_OpportunityNamingBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>OPP_OpportunityNamingBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/OPP_SendAcknowledgmentBTN.page-meta.xml
+++ b/src/pages/OPP_SendAcknowledgmentBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>OPP_SendAcknowledgmentBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/PMT_PaymentWizard.page-meta.xml
+++ b/src/pages/PMT_PaymentWizard.page-meta.xml
@@ -6,7 +6,7 @@
     <label>PMT_PaymentWizard</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/PSC_ManageSoftCredits.page-meta.xml
+++ b/src/pages/PSC_ManageSoftCredits.page-meta.xml
@@ -6,7 +6,7 @@
     <label>PSC_ManageSoftCredits</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/RD_AddDonationsBTN.page-meta.xml
+++ b/src/pages/RD_AddDonationsBTN.page-meta.xml
@@ -6,7 +6,7 @@
     <label>RD_AddDonationsBTN</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/REL_RelationshipsViewer.page-meta.xml
+++ b/src/pages/REL_RelationshipsViewer.page-meta.xml
@@ -6,7 +6,7 @@
     <label>REL_RelationshipsViewer</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/RP_Resources.page-meta.xml
+++ b/src/pages/RP_Resources.page-meta.xml
@@ -6,7 +6,7 @@
     <label>RP_Resources</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelAddrVerification.page-meta.xml
+++ b/src/pages/STG_PanelAddrVerification.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelAddrVerification</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelAffiliations.page-meta.xml
+++ b/src/pages/STG_PanelAffiliations.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelAffiliations</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelAlloBatch.page-meta.xml
+++ b/src/pages/STG_PanelAlloBatch.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelAlloBatch</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelAllocations.page-meta.xml
+++ b/src/pages/STG_PanelAllocations.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelAllocations</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelBDE.page-meta.xml
+++ b/src/pages/STG_PanelBDE.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelBDE</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelContactRoles.page-meta.xml
+++ b/src/pages/STG_PanelContactRoles.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelContactRoles</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelContacts.page-meta.xml
+++ b/src/pages/STG_PanelContacts.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelContacts</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelCreatePayments.page-meta.xml
+++ b/src/pages/STG_PanelCreatePayments.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelCreatePayments</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelERR.page-meta.xml
+++ b/src/pages/STG_PanelERR.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelERR</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelErrorLog.page-meta.xml
+++ b/src/pages/STG_PanelErrorLog.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelErrorLog</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelHealthCheck.page-meta.xml
+++ b/src/pages/STG_PanelHealthCheck.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelHealthCheck</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelHome.page-meta.xml
+++ b/src/pages/STG_PanelHome.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelHome</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelHouseholds.page-meta.xml
+++ b/src/pages/STG_PanelHouseholds.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelHouseholds</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelLeads.page-meta.xml
+++ b/src/pages/STG_PanelLeads.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelLeads</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelLvlAssignBatch.page-meta.xml
+++ b/src/pages/STG_PanelLvlAssignBatch.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelLvlAssignBatch</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelMakeDefaultAllocations.page-meta.xml
+++ b/src/pages/STG_PanelMakeDefaultAllocations.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelMakeDefaultAllocations</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelMembership.page-meta.xml
+++ b/src/pages/STG_PanelMembership.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelMembership</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOppBatch.page-meta.xml
+++ b/src/pages/STG_PanelOppBatch.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelOppBatch</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOppCampaignMembers.page-meta.xml
+++ b/src/pages/STG_PanelOppCampaignMembers.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelOppCampaignMembers</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOppNaming.page-meta.xml
+++ b/src/pages/STG_PanelOppNaming.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelOppNaming</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOppNamingBatch.page-meta.xml
+++ b/src/pages/STG_PanelOppNamingBatch.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelOppNamingBatch</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOppRollups.page-meta.xml
+++ b/src/pages/STG_PanelOppRollups.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelOppRollups</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelOpps.page-meta.xml
+++ b/src/pages/STG_PanelOpps.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelOpps</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelPaymentMapping.page-meta.xml
+++ b/src/pages/STG_PanelPaymentMapping.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelPaymentMapping</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRD.page-meta.xml
+++ b/src/pages/STG_PanelRD.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRD</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRDBatch.page-meta.xml
+++ b/src/pages/STG_PanelRDBatch.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRDBatch</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomFieldMapping.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRDCustomFieldMapping</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
+++ b/src/pages/STG_PanelRDCustomInstallment.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRDCustomInstallment</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRel.page-meta.xml
+++ b/src/pages/STG_PanelRel.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRel</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRelAuto.page-meta.xml
+++ b/src/pages/STG_PanelRelAuto.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRelAuto</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRelReciprocal.page-meta.xml
+++ b/src/pages/STG_PanelRelReciprocal.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRelReciprocal</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelRenameHouseholds.page-meta.xml
+++ b/src/pages/STG_PanelRenameHouseholds.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelRenameHouseholds</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelSchedule.page-meta.xml
+++ b/src/pages/STG_PanelSchedule.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelSchedule</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelTDTM.page-meta.xml
+++ b/src/pages/STG_PanelTDTM.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelTDTM</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelUpdatePrimaryContact.page-meta.xml
+++ b/src/pages/STG_PanelUpdatePrimaryContact.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelUpdatePrimaryContact</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_PanelUserRollup.page-meta.xml
+++ b/src/pages/STG_PanelUserRollup.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_PanelUserRollup</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/pages/STG_SettingsManager.page-meta.xml
+++ b/src/pages/STG_SettingsManager.page-meta.xml
@@ -6,7 +6,7 @@
     <label>STG_SettingsManager</label>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>7</minorNumber>
+        <minorNumber>6</minorNumber>
         <namespace>npe01</namespace>
     </packageVersions>
     <packageVersions>
@@ -26,7 +26,7 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
 </ApexPage>

--- a/src/triggers/TDTM_HouseholdObject.trigger-meta.xml
+++ b/src/triggers/TDTM_HouseholdObject.trigger-meta.xml
@@ -3,7 +3,7 @@
     <apiVersion>37.0</apiVersion>
     <packageVersions>
         <majorNumber>3</majorNumber>
-        <minorNumber>9</minorNumber>
+        <minorNumber>8</minorNumber>
         <namespace>npo02</namespace>
     </packageVersions>
     <status>Active</status>


### PR DESCRIPTION
This is a temporary fix for builds until the Spring 18 R2 this Friday

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
