### PR TITLE
UI - Allow configurable batch size for RecurringDonations

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -5218,6 +5218,14 @@ Once the process is 100% complete, you can safely leave or refresh this page.</v
 This process may take some time, but you can close this page and the process will continue in the background.</value>
     </labels>
     <labels>
+        <fullName>stgHelpRDBatchSize</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>RD Batch Size Settings Help Text</shortDescription>
+        <value>The number of records to process at a time when running the Recurring Donations batch job. The default size is 50. Reduce to a smaller number if the Recurring Donations batch job is failing due to system limits.</value>
+    </labels>
+    <labels>
         <fullName>stgHelpRDDisableScheduling</fullName>
         <categories>Settings</categories>
         <language>en_US</language>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -5223,7 +5223,7 @@ This process may take some time, but you can close this page and the process wil
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>RD Batch Size Settings Help Text</shortDescription>
-        <value>The number of records to process at a time when running the Recurring Donations batch job. The default size is 50. Reduce to a smaller number if the Recurring Donations batch job is failing due to system limits.</value>
+        <value>The number of records to process at a time when running the Recurring Donations batch job. The default size is 50. Reduce to a smaller number if the batch job is failing due to system limits.</value>
     </labels>
     <labels>
         <fullName>stgHelpRDDisableScheduling</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -5496,7 +5496,7 @@ To check your existing settings, go to Duplicate Rules under Setup. For any rule
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpRollupPrimaryContact</shortDescription>
-        <value>When this option is selected, Salesforce will ALWAYS roll up donor data to the Opportunity&apos;s Primary Contact, and corresponding Household Account or record, even if the Opportunity is not from an individual (i.e., from a company, a foundation, and so on). If left unselected, and the Opportunity&apos;s Account is an organization, only the organization will receive credit for the Opportunity.</value>
+        <value>When this option is selected, Salesforce will ALWAYS roll up donor data to the Opportunity&apos;s Primary Contact. Note that only the Account on the Opportunity will receive hard credit. So, if the Account Name on the Opportunity is an Organization, that Organization and the Primary Contact will receive hard credit; the Contact&apos;s Household or 1:1 Account will NOT receive hard credit. If left unselected, and the Opportunity&apos;s Account is an Organization, only the Organization will receive credit for the Opportunity.</value>
     </labels>
     <labels>
         <fullName>stgHelpSalesforceSetup</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1538,6 +1538,7 @@
         <members>stgHelpPrimaryContactBatch</members>
         <members>stgHelpRDAddCampaign</members>
         <members>stgHelpRDBatch</members>
+        <members>stgHelpRDBatchSize</members>
         <members>stgHelpRDDisableScheduling</members>
         <members>stgHelpRDFailures</members>
         <members>stgHelpRDFieldMap</members>

--- a/src/pages/STG_PanelRD.page
+++ b/src/pages/STG_PanelRD.page
@@ -20,6 +20,16 @@
                 </div>
             </div>
             <div class="slds-form-element">
+                <apex:outputLabel value="{!$ObjectType.npe03__Recurring_Donations_Settings__c.Fields.Recurring_Donation_Batch_Size__c.Label}" for="tbxRDBS" styleClass="slds-form-element__label" />
+                <div class="slds-form-element__control">
+                    <apex:outputField value="{!stgService.stgRD.Recurring_Donation_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:inputField value="{!stgService.stgRD.Recurring_Donation_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxRDBS" html-aria-describedby="{!$Component.tbxRDBSHelp}" styleClass="slds-input" />
+                    <apex:outputPanel id="tbxRDBSHelp" layout="block">
+                        <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpRDBatchSize}"/>
+                    </apex:outputPanel>
+                </div>
+            </div>
+            <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npe03__Recurring_Donations_Settings__c.Fields.npe03__Open_Opportunity_Behavior__c.Label}" for="slOOB" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgRD.npe03__Open_Opportunity_Behavior__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />


### PR DESCRIPTION
# Critical Changes

# Changes
The batch size for the Recurring Donations nightly scheduled job and bulk data process was previously hard coded to 50. You can now configure this value using the new **Recurring Donation Batch Size** field located in **NPSP Settings | Recurring Donations**. If this field is left blank, it will default to 50.

# Issues Closed

# New Metadata

# Deleted Metadata
