### PR TITLE
Feature/trial config update

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -282,7 +282,9 @@ flows:
             1: 
                 task: update_dependencies
             2:
-                task: install_prod
+                task: install_managed
+            3:
+                task: update_admin_profile
 
 
     test_data_dev_org:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -276,6 +276,15 @@ flows:
             7:
                 task: deploy_dev_config_managed
 
+    update_prod:
+        description: 'Updates to latest managed release version of every package'
+        tasks:
+            1: 
+                task: update_dependencies
+            2:
+                task: install_prod
+
+
     test_data_dev_org:
         description: 'WARNING: This flow deletes all data first, then loads the complete test data set based on 100 Contacts into the target org.'
         tasks:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -283,8 +283,6 @@ flows:
                 task: update_dependencies
             2:
                 task: install_managed
-            3:
-                task: update_admin_profile
 
 
     test_data_dev_org:

--- a/orgs/trial.json
+++ b/orgs/trial.json
@@ -1,6 +1,6 @@
 {
   "orgName": "NPSP - Trial Org",
-  "template": "0TT1I000006QTru",
+  "template": "0TT1I000006QXHw",
   "orgPreferences" : {
     "enabled": [
       "ChatterEnabled",


### PR DESCRIPTION
Adds an `update_prod` flow that can be used to get a Trial Experience org to the latest managed release versions.

Usage (requires internal DevHub access)
```
> cci org scratch trial latest_trial
> cci flow run update_prod --org latest_trial
> cci org browser latest_trial
```

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
