### PR TITLE
Respect object permissions when deleting allocations

### DIFF
--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -224,9 +224,16 @@ public with sharing class ALLO_ManageAllocations_CTRL {
 
     /** @description Removes a row from the page, and adds to the list for deletion once the user saves.*/
     public pageReference delRow() {
+        Boolean hasId = listAllo[rowNumber].id != null;
+
         //add to deletion list if the allocation has an id
-        if (listAllo[rowNumber].id!=null)
+        if (hasId) {
+            if (!isDeletable()) {
+                addDelExceptionMessage();
+                return null;
+            }
             listAlloForDelete.add(listAllo[rowNumber]);
+        }
         listAllo.remove(rowNumber);
 
         return null;
@@ -289,6 +296,19 @@ public with sharing class ALLO_ManageAllocations_CTRL {
     /** @description Returns the thousands separator character in use for the Users current Locale setting */
     public String getThousandsSeparator() {
         return (1000).format().subString(1,2);
+    }
+
+    private Boolean isDeletable() {
+        return UTIL_Describe.getObjectDescribe(UTIL_Namespace.StrTokenNSPrefix('Allocation__c')).isDeletable();
+    }
+
+    private void addDelExceptionMessage() {
+        ApexPages.addMessage(
+            new ApexPages.Message(
+                    ApexPages.Severity.WARNING,
+                    String.format(
+                        System.Label.exceptionDeletePermission,
+                        new String[]{UTIL_Describe.getObjectLabel(UTIL_Namespace.StrTokenNSPrefix('Allocation__c'))})));
     }
 
 }

--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -57,7 +57,8 @@ public with sharing class ALLO_ManageAllocations_CTRL {
     private sObjectType sObjType;
     /** @description List of allocations to delete when the user clicks Save.*/
     public list<Allocation__c> listAlloForDelete = new list<Allocation__c>();
-
+    /** @description after successful save set to true to redirect page */
+    public Boolean redirect {get; set;}
     /** @description The id of the parent object; Opportunity, Campaign, or Recurring Donation.*/
     public id parentId {get;set;}
     /** @description The parent opportunity, if we're dealing with opportunity allocations.*/
@@ -241,10 +242,6 @@ public with sharing class ALLO_ManageAllocations_CTRL {
 
     /** @description Saves changes and returns user to parent object detail page.*/
     public pageReference saveClose() {
-        pageReference source = new pageReference('/'+parentId);
-        source.setRedirect(true);
-        source.getParameters().put('t',''+(System.currentTimeMillis()));
-        
         list<Allocation__c> listAlloForInsert = new list<Allocation__c>();
         list<Allocation__c> listAlloForUpdate = new list<Allocation__c>();
 
@@ -262,7 +259,7 @@ public with sharing class ALLO_ManageAllocations_CTRL {
 
                 //allow user to delete all GAUs and save with one empty GAU
                 if (listAllo.size()==1 && listAllo[0].General_Accounting_Unit__c==null && listAllo[0].Amount__c==null && listAllo[0].Percent__c==null)
-                    return source;
+                    redirect = true;
             }
             if (!listAlloForUpdate.isEmpty()) {
                 TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.flag.ALLOC, false);
@@ -273,13 +270,13 @@ public with sharing class ALLO_ManageAllocations_CTRL {
                 insert listAlloForInsert;
             }
             
-            return source;
+            redirect = true;
         } catch (Exception e) {
             Database.rollback(sp);
 
             ApexPages.addMessages(e);
-            return null;
         }
+        return null;
     }
 
     /** @description Discards all changes and returns user to parent object detail page.*/

--- a/src/classes/ALLO_ManageAllocations_TEST.cls
+++ b/src/classes/ALLO_ManageAllocations_TEST.cls
@@ -303,7 +303,7 @@ private class ALLO_ManageAllocations_TEST {
         retPage = ctrl.saveClose();
         Test.stopTest();
 
-        System.assertNotEquals(null, retPage, 'The return page on success should be provided. Page messages: ' + ApexPages.getMessages());
+        System.assert(ctrl.redirect, 'The page redirect should be set to true. Page messages: ' + ApexPages.getMessages());
 
         actualAllocationsById = new Map<Id, Allocation__c>([SELECT Percent__c, Amount__c FROM Allocation__c WHERE Campaign__c = :campaign.id]);
         System.assertEquals(3, actualAllocationsById.size(), 'New Allocations should be created: ' + actualAllocationsById.values());

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2034,6 +2034,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Only one object lookup can be populated per Engagement Plan.</value>
     </labels>
     <labels>
+        <fullName>exceptionDeletePermission</fullName>
+        <categories>Error</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>exceptionDeletePermission</shortDescription>
+        <value>You do not have permissions to delete {0}.</value>
+    </labels>
+    <labels>
         <fullName>exceptionRequiredField</fullName>
         <categories>Error</categories>
         <language>en_US</language>

--- a/src/objects/Allocation__c.object
+++ b/src/objects/Allocation__c.object
@@ -126,9 +126,9 @@
         <externalId>false</externalId>
         <inlineHelpText>Percent of opportunity amount to allocate to this general accounting unit. Modifying an opportunity amount of a percent based allocation will modify the allocation amount.</inlineHelpText>
         <label>Percent</label>
-        <precision>5</precision>
+        <precision>9</precision>
         <required>false</required>
-        <scale>2</scale>
+        <scale>6</scale>
         <trackTrending>false</trackTrending>
         <type>Percent</type>
     </fields>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1149,6 +1149,7 @@
         <members>engagementPlanCantEdit</members>
         <members>engagementPlanNoLookups</members>
         <members>engagementPlanTwoLookups</members>
+        <members>exceptionDeletePermission</members>
         <members>exceptionRequiredField</members>
         <members>exceptionValidationRule</members>
         <members>flsError</members>

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -163,7 +163,7 @@
                         <tr class="slds-text-heading_label">
                             <th scope="col"><span class="slds-truncate">{!$ObjectType.Allocation__c.Fields.General_Accounting_Unit__c.Label}</span></th>
                             <th scope="col" width="250px"><span class="slds-truncate">{!$ObjectType.Allocation__c.Fields.Amount__c.Label}</span></th>
-                            <th scope="col" width="130px"><span class="slds-truncate">{!$ObjectType.Allocation__c.Fields.Percent__c.Label}</span></th>
+                            <th scope="col" width="150px"><span class="slds-truncate">{!$ObjectType.Allocation__c.Fields.Percent__c.Label}</span></th>
                             <th scope="col" width="200px"></th>
                         </tr>
                     </thead>

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -197,7 +197,7 @@
                                     </div>
                                 </td>
                                 <td>
-                                    <apex:commandButton styleClass="slds-button slds-button_destructive" value="{!$Label.alloDeleteRow}" id="delRowBTN" title="{!$Label.alloDeleteRow}" action="{!delRow}" reRender="theTable" immediate="true">
+                                    <apex:commandButton styleClass="slds-button slds-button_destructive" value="{!$Label.alloDeleteRow}" id="delRowBTN" title="{!$Label.alloDeleteRow}" action="{!delRow}" reRender="theForm" immediate="true">
                                         <span class="slds-form-element__label slds-assistive-text">Delete Row {!cnt}</span>
                                         <apex:param name="rowForDel" value="{!cnt}" assignTo="{!rowNumber}"/>
                                     </apex:commandButton>

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -152,9 +152,9 @@
             <c:UTIL_NavigateBack recordId="{!parentId}" redirect="{!redirect}"/>
             <!-- PAGE HEADER -->
             <c:UTIL_PageHeader showBreadcrumb="true" parentEntityLabel="{!objectLabelPlural}"
-                parentAction="javascript:window.urlHome();" parentRecordName="{!objectName}"
-                parentRecordAction="/{!parentId}" header="{!pageTitle}" icon="custom_120" iconCategory="standard"
-                cancelAction="{!cancel}" saveAction="{!saveClose}" saveDisabled="{!OR(NOT(isSupportedObject),(opp!=null&&parentAmount==0))}"/>
+                parentAction="javascript:window.urlHome();" parentRecordName="{!objectName}" parentRecordAction="/{!parentId}"
+                header="{!pageTitle}" icon="custom_120" iconCategory="standard" cancelAction="{!cancel}"
+                saveAction="{!saveClose}" saveReRender="theForm" saveDisabled="{!OR(NOT(isSupportedObject),(opp!=null&&parentAmount==0))}"/>
             <c:UTIL_PageMessages />
             <div>
                 <apex:outputPanel id="theTable">

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -149,6 +149,7 @@
     </script>
     <apex:form id="theForm">
         <div class="slds-scope">
+            <c:UTIL_NavigateBack recordId="{!parentId}" redirect="{!redirect}"/>
             <!-- PAGE HEADER -->
             <c:UTIL_PageHeader showBreadcrumb="true" parentEntityLabel="{!objectLabelPlural}"
                 parentAction="javascript:window.urlHome();" parentRecordName="{!objectName}"


### PR DESCRIPTION
# Critical Changes

# Changes
- GAU Allocations now allow percentages with up to 6 decimal places. Previously, you could use up to 2 decimal places.
- You can now change GAU Allocations on Opportunities from a percentage to an amount. To do this, remove the value from the percent field and add a new value to the amount field.

# Issues Closed
 - Fixes #2921
 - Fixes #2960 

# New Metadata

# Deleted Metadata
