### PR TITLE
Rollups: Save Filter Groups & Filter Rule CMT Data

### DIFF
--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
@@ -119,7 +119,7 @@
                                              name="{!v.labels.name}"
                                              value="{!v.activeFilterGroup.label}"
                                              required="{! !v.isReadOnly}"
-                                             readonly="{!v.isReadOnly}"/>
+                                             readonly="{! v.isReadOnly}"/>
                         </lightning:layoutItem>
                     </lightning:layout>
 
@@ -260,31 +260,31 @@
                                 <!--START CONSTANT INPUT OPTIONS-->
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'text')}">
                                     <!--todo: see if text, date, datetime-local, time and number can be combined into one-->
-                                    <lightning:textarea aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.constantName}"
+                                    <lightning:textarea aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.value}"
                                                         required="true" label="{!v.labels.constant}" maxlength="300" />
                                 </aura:if>
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'date')}">
-                                    <lightning:input aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.constantName}"
+                                    <lightning:input aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.value}"
                                                      required="true" label="{!v.labels.constant}" type="date"/>
                                 </aura:if>
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'datetime-local')}">
-                                    <lightning:input aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.constantName}"
+                                    <lightning:input aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.value}"
                                                      required="true" label="{!v.labels.constant}" type="datetime-local"/>
                                 </aura:if>
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'time')}">
-                                    <lightning:input aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.constantName}"
+                                    <lightning:input aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.value}"
                                                      required="true" label="{!v.labels.constant}" type="time"/>
                                 </aura:if>
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'number')}">
-                                    <lightning:input class="slds-p-around_small" value="{!v.activeFilterRule.constantName}"
+                                    <lightning:input class="slds-p-around_small" value="{!v.activeFilterRule.value}"
                                                      required="true" label="{!v.labels.constant}" type="number" step="any"/>
                                 </aura:if>
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'picklist')}">
                                     <lightning:select aura:id="filterRuleField" class="slds-p-around_small" label="{!v.labels.constant}"
-                                                      required="true" value="{!v.activeFilterRule.constantName}">
+                                                      required="true" value="{!v.activeFilterRule.value}">
                                         <option value="" text=""/>
                                         <aura:iteration items="{!v.filterRuleConstantPicklist}" var="option">
-                                            <option value="{!option.value}" text="{!option.label}" selected="{!option.value == v.activeFilterRule.constantName}"/>
+                                            <option value="{!option.value}" text="{!option.label}" selected="{!option.value == v.activeFilterRule.value}"/>
                                         </aura:iteration>
                                     </lightning:select>
                                 </aura:if>
@@ -298,7 +298,7 @@
                         <aura:if isTrue="{!and((v.filterRuleMode != 'delete'), equals(v.filterRuleFieldType, 'multipicklist'))}">
                             <lightning:dualListbox aura:id="filterRuleField" label="" class="slds-p-around_small"
                                                    sourceLabel="{!'Available ' + v.labels.constant}" selectedLabel="{!'Selected ' + v.labels.constant}"
-                                                   options="{!v.filterRuleConstantPicklist}" value="{!v.activeFilterRule.constantName}"
+                                                   options="{!v.filterRuleConstantPicklist}" value="{!v.activeFilterRule.value}"
                                                    min="1"/>
                         </aura:if>
                     </lightning:layout>

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
@@ -44,7 +44,7 @@
     <aura:attribute name="cachedFilterGroup" type="Map"
                     description="The active filter group displayed. Only populated from Clone, View and Edit."/>
     <aura:attribute name="activeFilterRule" type="Map" description="Selected values for actively edited filter rule." access="public"
-                    default="{objectName: '', fieldName: '', operatorName: '', constant: ''}"/>
+                    default="{objectName: '', fieldName: '', operation: '', value: ''}"/>
     <aura:attribute name="mode" type="String" access="public"
                     description="The current mode of the component. Options are: view, edit, clone, or create."/>
     <aura:attribute name="isReadOnly" type="Boolean" default="true"
@@ -58,6 +58,8 @@
     <aura:attribute name="filterRuleFieldType" type="String" description="Determines type of field" default="text"/>
 
     <!-- private attributes -->
+    <aura:attribute name="deletedRuleList" type="List" description="Filter Rules that were deleted" access="private"/>
+    <aura:attribute name="isPageDirty" type="Boolean" default="false" access="private" description="True when there are changes to be saved"/>
     <aura:attribute name="filterRuleColumns" type="List" description="List of available filter rules" access="private"/>
     <aura:attribute name="filterRuleActionColumns" type="List" description="List of available filter rules" access="private"/>
     <aura:attribute name="operatorMap" type="Map" description="Map of operators with key value pairs of API names and labels" access="private"/>
@@ -186,7 +188,7 @@
                     <div class="slds-p-around_large">
                         <lightning:layout horizontalAlign="end">
                             <lightning:button label="{!v.labels.cancel}" variant="neutral" onclick="{!c.onCancel}"/>
-                            <lightning:button label="{!v.labels.save}" variant="brand" onclick="{!c.onSave}"/>
+                            <lightning:button label="{!v.labels.save}" variant="brand" onclick="{!c.onSaveFilterGroupAndRules}"/>
                         </lightning:layout>
                     </div>
                 </aura:if>
@@ -247,12 +249,12 @@
                         <aura:if isTrue="{!v.filterRuleMode != 'delete'}">
                             <lightning:layoutItem size="12" mediumDeviceSize="6" smallDeviceSize="12">
                                 <lightning:select aura:id="filterRuleField" class="slds-p-around_small" label="{!v.labels.operator}"
-                                                  value="{!v.activeFilterRule.operatorName}"
+                                                  value="{!v.activeFilterRule.operation}"
                                                   required="true"
                                                   onchange="{!c.onChangeFilterRuleOperator}">
                                     <option value="" text=""/>
                                     <aura:iteration items="{!v.filteredOperators}" var="option">
-                                        <option value="{!option.value}" text="{!option.label}" selected="{!option.value == v.activeFilterRule.operatorName}"/>
+                                        <option value="{!option.value}" text="{!option.label}" selected="{!option.value == v.activeFilterRule.operation}"/>
                                     </aura:iteration>
                                 </lightning:select>
                             </lightning:layoutItem>
@@ -309,7 +311,7 @@
                     <button class="slds-button slds-button_neutral"
                             onclick="{!c.cancelFilterRule}">{!v.labels.cancel}</button>
                     <button class="slds-button slds-button_brand"
-                            onclick="{!c.saveFilterRule}">{!if(v.filterRuleMode == 'delete', v.labels.delete, v.labels.save)}</button>
+                            onclick="{!c.onQueueFilterRuleSave}">{!if(v.filterRuleMode == 'delete', v.labels.delete, v.labels.save)}</button>
                 </footer>
             </div>
         </section>

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
@@ -117,7 +117,7 @@
                             <lightning:input aura:id="nameInput"
                                              label="{!v.labels.name}"
                                              name="{!v.labels.name}"
-                                             value="{!v.activeFilterGroup.MasterLabel}"
+                                             value="{!v.activeFilterGroup.label}"
                                              required="{! !v.isReadOnly}"
                                              readonly="{!v.isReadOnly}"/>
                         </lightning:layoutItem>
@@ -128,7 +128,7 @@
                             <lightning:textarea aura:id="descriptionInput"
                                                 label="{!v.labels.filterGroupDescription}"
                                                 name="{!v.labels.filterGroupDescription}"
-                                                value="{!v.activeFilterGroup.Description__c}"
+                                                value="{!v.activeFilterGroup.description}"
                                                 readonly="{!v.isReadOnly}"/>
                         </lightning:layoutItem>
                     </lightning:layout>

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
@@ -91,7 +91,7 @@
         <!--START SPINNER-->
         <div class="spinnerDiv">
             <!--Hide the spinner by default-->
-            <lightning:spinner aura:id="waitingSpinner" class="slds-hide" />
+            <lightning:spinner aura:id="waitingSpinner" />
         </div>
         <!--END SPINNER-->
 

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
@@ -22,7 +22,7 @@
             if (state === "SUCCESS") {
                 var data = helper.restructureResponse(response.getReturnValue());
                 var model = JSON.parse(data);
-                if(activeFilterGroupId){
+                if (activeFilterGroupId){
                     //note: the parsing is important to avoid a shared reference
                     cmp.set("v.activeFilterGroup", helper.restructureResponse(model.filterGroup));
                     cmp.set("v.cachedFilterGroup", helper.restructureResponse(model.filterGroup));
@@ -56,7 +56,9 @@
                 cmp.set("v.filterRuleColumns", filterRuleColumns);
                 cmp.set("v.filterRuleActionColumns", filterRuleActionColumns);
                 cmp.set("v.objectDetails", model.filterFieldsByDataType);
-                helper.filterRollupList(cmp, model.filterGroup.label, labels);
+                if (model.filterGroup) {
+                    helper.filterRollupList(cmp, model.filterGroup.label, labels);
+                }
                 helper.changeMode(cmp);
 
             }

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
@@ -3,6 +3,7 @@
      * @description: setup for the filter group component which sets the active filter group and datatable
      */
     doInit: function (cmp, event, helper) {
+
         //query for the active filter group
         var activeFilterGroupId = cmp.get("v.activeFilterGroupId");
         var objectList = cmp.get("v.detailObjects");
@@ -73,10 +74,10 @@
                     console.log("Unknown error");
                 }
             }
+            helper.toggleSpinner(cmp, false);
         });
 
         $A.enqueueAction(action);
-
     },
 
     /**

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
@@ -15,7 +15,7 @@
         }
 
         var action = cmp.get("c.setupFilterGroupDetail");
-        action.setParams({groupId: activeFilterGroupId, objectNames: objectNames});
+        action.setParams({filterGroupId: activeFilterGroupId, objectNames: objectNames});
 
         action.setCallback(this, function (response) {
             var state = response.getState();

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
@@ -15,17 +15,21 @@
         }
 
         var action = cmp.get("c.setupFilterGroupDetail");
-        action.setParams({id: activeFilterGroupId, objectNames: objectNames});
+        action.setParams({groupId: activeFilterGroupId, objectNames: objectNames});
 
         action.setCallback(this, function (response) {
             var state = response.getState();
             if (state === "SUCCESS") {
-                var model = helper.restructureResponse(response.getReturnValue());
+                var data = helper.restructureResponse(response.getReturnValue());
+                var model = JSON.parse(data);
+// console.log(JSON.stringify(model));
                 if(activeFilterGroupId){
                     //note: the parsing is important to avoid a shared reference
                     cmp.set("v.activeFilterGroup", helper.restructureResponse(model.filterGroup));
                     cmp.set("v.cachedFilterGroup", helper.restructureResponse(model.filterGroup));
                 }
+console.log(model.filterGroup.description);
+console.log(model.filterGroup);
 
                 cmp.set("v.operatorMap", model.operators);
 
@@ -38,13 +42,13 @@
                 var filterRuleColumns = [{label: labels.object, fieldName: 'objectLabel', type: 'string'}
                     , {label: labels.field, fieldName: 'fieldLabel', type: 'string'}
                     , {label: labels.operator, fieldName: 'operationLabel', type: 'string'}
-                    , {label: labels.constant, fieldName: 'constantLabel', type: 'string'}
+                    , {label: labels.constant, fieldName: 'valueLabel', type: 'string'}
                 ];
 
                 var filterRuleActionColumns = [{label: labels.object, fieldName: 'objectLabel', type: 'string'}
                     , {label: labels.field, fieldName: 'fieldLabel', type: 'string'}
                     , {label: labels.operator, fieldName: 'operationLabel', type: 'string'}
-                    , {label: labels.constant, fieldName: 'constantLabel', type: 'string'}
+                    , {label: labels.constant, fieldName: 'valueLabel', type: 'string'}
                     , {type: 'action', typeAttributes: {rowActions: actions}}
                 ];
 
@@ -232,7 +236,7 @@
 
                 //special reformatting for multipicklist and semi-colon delimited lists
                 if (filterRule.operation === 'In_List' || filterRule.operation === 'Not_In_List') {
-                    filterRule.constantLabel = helper.reformatConstantLabel(cmp, filterRule.constantName, filterRule.operation);
+                    filterRule.valueLabel = helper.reformatvalueLabel(cmp, filterRule.value, filterRule.operation);
                 } else {
                     filterRule.valueLabel = filterRule.valueName;
                 }

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupController.js
@@ -37,13 +37,13 @@
 
                 var filterRuleColumns = [{label: labels.object, fieldName: 'objectLabel', type: 'string'}
                     , {label: labels.field, fieldName: 'fieldLabel', type: 'string'}
-                    , {label: labels.operator, fieldName: 'operatorLabel', type: 'string'}
+                    , {label: labels.operator, fieldName: 'operationLabel', type: 'string'}
                     , {label: labels.constant, fieldName: 'constantLabel', type: 'string'}
                 ];
 
                 var filterRuleActionColumns = [{label: labels.object, fieldName: 'objectLabel', type: 'string'}
                     , {label: labels.field, fieldName: 'fieldLabel', type: 'string'}
-                    , {label: labels.operator, fieldName: 'operatorLabel', type: 'string'}
+                    , {label: labels.operator, fieldName: 'operationLabel', type: 'string'}
                     , {label: labels.constant, fieldName: 'constantLabel', type: 'string'}
                     , {type: 'action', typeAttributes: {rowActions: actions}}
                 ];
@@ -53,7 +53,7 @@
                 cmp.set("v.filterRuleColumns", filterRuleColumns);
                 cmp.set("v.filterRuleActionColumns", filterRuleActionColumns);
                 cmp.set("v.objectDetails", model.filterFieldsByDataType);
-                helper.filterRollupList(cmp, model.filterGroup.MasterLabel, labels);
+                helper.filterRollupList(cmp, model.filterGroup.label, labels);
                 helper.changeMode(cmp);
 
             }
@@ -118,7 +118,7 @@
             helper.toggleFilterRuleModal(cmp);
             helper.resetFilterRuleFields(cmp, cleanRow.objectName);
             helper.resetFilterRuleOperators(cmp, cleanRow.fieldName);
-            helper.rerenderValue(cmp, cleanRow.operatorName);
+            helper.rerenderValue(cmp, cleanRow.operation);
 
         } else {
             //cautions user about deleting filter rule
@@ -167,7 +167,7 @@
     onChangeFilterRuleField: function(cmp, event, helper){
         var field = event.getSource().get("v.value");
         helper.resetFilterRuleOperators(cmp, field);
-        cmp.set("v.activeFilterRule.operatorName", "");
+        cmp.set("v.activeFilterRule.operation", "");
     },
 
     /**
@@ -205,7 +205,7 @@
             //sends the message to the parent cmp RollupsContainer
             var sendMessage = $A.get('e.ltng:sendMessage');
             sendMessage.setParams({
-                'message': activeFilterGroup.MasterLabel,
+                'message': activeFilterGroup.label,
                 'channel': 'nameChange'
             });
             sendMessage.fire();
@@ -228,13 +228,13 @@
                 //set field labels directly
                 filterRule.objectLabel = helper.retrieveFieldLabel(filterRule.objectName, cmp.get("v.detailObjects"));
                 filterRule.fieldLabel = helper.retrieveFieldLabel(filterRule.fieldName, cmp.get("v.filteredFields"));
-                filterRule.operatorLabel = helper.retrieveFieldLabel(filterRule.operatorName, cmp.get("v.filteredOperators"));
+                filterRule.operationLabel = helper.retrieveFieldLabel(filterRule.operation, cmp.get("v.filteredOperators"));
 
                 //special reformatting for multipicklist and semi-colon delimited lists
-                if (filterRule.operatorName === 'In_List' || filterRule.operatorName === 'Not_In_List') {
-                    filterRule.constantLabel = helper.reformatConstantLabel(cmp, filterRule.constantName, filterRule.operatorName);
+                if (filterRule.operation === 'In_List' || filterRule.operation === 'Not_In_List') {
+                    filterRule.constantLabel = helper.reformatConstantLabel(cmp, filterRule.constantName, filterRule.operation);
                 } else {
-                    filterRule.constantLabel = filterRule.constantName;
+                    filterRule.valueLabel = filterRule.valueName;
                 }
 
                 //if mode is create, just add to list, otherwise update the item in the existing list

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
@@ -303,12 +303,6 @@
                 filterGroupCMT.rules.push(deletedRuleList[i]);
             }
         }
-        // Ensure all rules are attached to the current FilterGroup
-        for (var i = 0; i < filterGroupCMT.rules.length; i++) {
-            filterGroupCMT.rules[i].filterGroupRecordName = filterGroupCMT.recordName;
-        }
-
-        console.log(JSON.stringify(filterGroupCMT));
 
         var action = cmp.get("c.saveFilterGroupAndRules");
         action.setParams({filterGroupCMT: JSON.stringify(filterGroupCMT)});
@@ -402,7 +396,7 @@
             canSave = false;
         } else if (!name) {
             canSave = false;
-        } else if (filterRuleList.length === 0) {
+        } else if (!filterRuleList || filterRuleList.length === 0) {
             canSave = false;
         }
 
@@ -422,7 +416,9 @@
         }, true);
 
         //check for duplicates
-        if (cmp.get("v.filterRuleMode") === 'create') {
+        if (!filterRuleList) {
+            // nothong to compare
+        } else if (cmp.get("v.filterRuleMode") === 'create') {
             //check for specific API names instead of the full row to avoid issues with the ID not matching
             for (var i = 0; i < filterRuleList.length; i++) {
                 if (filterRuleList[i].objectName === filterRule.objectName

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
@@ -18,6 +18,14 @@
                 cmp.set("v.activeFilterGroupId", null);
                 cmp.set("v.activeFilterGroup.recordId", null);
                 cmp.set("v.activeFilterGroup.recordName", null);
+
+                var filterRuleList = cmp.get("v.filterRuleList");
+                for (var i = 0; i < filterRuleList.length; i++) {
+                    filterRuleList[i].recordId = null;
+                    filterRuleList[i].recordName = null;
+                }
+                cmp.set("v.filterRuleList", filterRuleList);
+
                 cmp.set("v.isReadOnly", false);
             } else if (mode === "edit") {
                 cmp.set("v.isReadOnly", false);
@@ -181,7 +189,7 @@
                         var deployResult = JSON.parse(response.getReturnValue());
                         console.log('deployResult=' + deployResult);
                         // if there is a record id response
-                        if (deployResult && deployResult.completed === true && deployResult.rollupItem) {
+                        if (deployResult && deployResult.completed === true && deployResult.filterGroupItem) {
                             window.clearTimeout(poller);
                             helper.toggleSpinner(cmp, false);
                             helper.showToast(cmp, 'success', cmp.get("v.labels.filtersSaveProgress"), cmp.get("v.labels.filtersSaveSuccess"));
@@ -413,7 +421,7 @@
                 }*/
 
                 console.log('Calling pollForDeploymentStatus');
-                // this.pollForDeploymentStatus(cmp, jobId, recordName, 0);
+                this.pollForDeploymentStatus(cmp, jobId, recordName, 0);
             } else if (state === "ERROR") {
 
                 var errors = response.getError();

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
@@ -329,8 +329,8 @@
      */
     validateFilterGroupFields: function(cmp) {
         var canSave = true;
-        var name = cmp.get("v.activeFilterGroup.MasterLabel");
-        var description = cmp.get("v.activeFilterGroup.Description__c");
+        var name = cmp.get("v.activeFilterGroup.label");
+        var description = cmp.get("v.activeFilterGroup.description");
         var filterRuleList = cmp.get("v.filterRuleList");
 
         cmp.find("nameInput").showHelpMessageIfInvalid();

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
@@ -217,9 +217,27 @@
 
                             cmp.set("v.filterRuleList", filterRuleList);
                             cmp.set("v.cachedFilterRuleList", filterRuleListCached);
+                            var rollupItems = cmp.get("v.rollupItems");
+
+                            // need to sent back an object with the following properties
+                            var filterGroupTableItem = {};
+                            filterGroupTableItem.label = model.filterGroup.label;
+                            filterGroupTableItem.description = model.filterGroup.description;
+                            filterGroupTableItem.name = model.filterGroup.recordName;
+                            filterGroupTableItem.recordId = model.filterGroup.recordId;
+                            if (filterRuleList) {
+                                filterGroupTableItem.countFilterRules = filterRuleList.length;
+                            } else {
+                                filterGroupTableItem.countFilterRules = 0;
+                            }
+                            if (rollupItems) {
+                                filterGroupTableItem.countRollups = rollupItems.length;
+                            } else {
+                                filterGroupTableItem.countRollups = 0;
+                            }
 
                             // Send a message with the changed or new Rollup to the RollupContainer Component
-                            helper.sendMessage(cmp, 'filterRecordChange', model);
+                            helper.sendMessage(cmp, 'filterRecordChange', filterGroupTableItem);
 
                         } else {
                             // No record id, so run call this method again to check in another 1 second
@@ -435,6 +453,20 @@
         });
         this.showToast(cmp, 'info', cmp.get("v.labels.filtersSaveProgress"), cmp.get("v.labels.filtersSaveProgress"));
         $A.enqueueAction(action);
+    },
+
+    /**
+     * @description Sends a lightning message to all listening components
+     * @param channel - intended channel to hear the message
+     * @param message - body of the message
+     */
+    sendMessage: function(cmp, channel, message){
+        var sendMessage = $A.get('e.ltng:sendMessage');
+        sendMessage.setParams({
+            'channel': channel,
+            'message': message
+        });
+        sendMessage.fire();
     },
 
     /**

--- a/src/aura/CRLP_Rollup/CRLP_Rollup.cmp
+++ b/src/aura/CRLP_Rollup/CRLP_Rollup.cmp
@@ -95,7 +95,7 @@
         <!--START SPINNER -->
         <div class="spinnerDiv">
             <!--Hide the spinner by default-->
-            <lightning:spinner aura:id="waitingSpinner" class="slds-hide" />
+            <lightning:spinner aura:id="waitingSpinner" />
         </div>
         <!--END SPINNER-->
 

--- a/src/aura/CRLP_Rollup/CRLP_RollupController.js
+++ b/src/aura/CRLP_Rollup/CRLP_RollupController.js
@@ -28,7 +28,6 @@
 
         action.setParams({rollupId: activeRollupId, targetObjectNames: summaryNames, detailObjectNames: detailNames});
 
-        helper.toggleSpinner(cmp, true);
         action.setCallback(this, function (response) {
             var state = response.getState();
             if (state === "SUCCESS") {

--- a/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
+++ b/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
@@ -28,7 +28,7 @@
         //update filter group list to contain none as a first option
         //note: unshift can't be used here due to an issue with bound values
         var filterGroups = cmp.get("v.filterGroups");
-        var tempList = [{"name": cmp.get("v.labels.na"), "label": cmp.get("v.labels.na")}];
+        var tempList = [{"name": "", "label": cmp.get("v.labels.na")}];
         tempList = tempList.concat(filterGroups);
         cmp.set("v.filterGroups", tempList);
 

--- a/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
+++ b/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
@@ -52,6 +52,8 @@
                 cmp.set("v.isReadOnly", true);
             } else if (mode === "clone") {
                 cmp.set("v.activeRollupId", null);
+                cmp.set("v.activeRollup.recordId", null);
+                cmp.set("v.activeRollup.recordName", null);
                 cmp.set("v.isReadOnly", false);
                 var newSummary = this.uniqueSummaryFieldCheck(cmp, cmp.get("v.summaryFields"));
                 cmp.set("v.summaryFields", newSummary);
@@ -928,14 +930,13 @@
                 counter++;
                 console.log('setTimeout(' + jobId + ',' + recordName + '):' + counter);
                 var action = cmp.get("c.getDeploymentStatus");
-                action.setParams({jobId: jobId, recordName: recordName});
+                action.setParams({jobId: jobId, recordName: recordName, objectType: 'Rollup'});
                 action.setCallback(this, function (response) {
                     console.log('getDeploymentStatus.callback');
                     var state = response.getState();
                     if (state === "SUCCESS") {
-                        // Response will be a deployResult wrapper class
-                        var deployResult = response.getReturnValue();
-                        deployResult = helper.restructureResponse(deployResult);
+                        // Response will be a serialized deployResult wrapper class
+                        var deployResult = JSON.parse(response.getReturnValue());
                         console.log('deployResult=' + deployResult);
                         // if there is a record id response
                         if (deployResult && deployResult.completed === true && deployResult.rollupItem) {
@@ -944,8 +945,8 @@
                             helper.showToast(cmp, 'success', cmp.get("v.labels.rollupSaveProgress"), cmp.get("v.labels.rollupSaveSuccess"));
 
                             // Save the inserted/updated record id
-                            cmp.set("v.activeRollupId", deployResult.rollupItem.id);
-                            cmp.set("v.activeRollup.id", deployResult.rollupItem.id);
+                            cmp.set("v.activeRollupId", deployResult.rollupItem.recordId);
+                            cmp.set("v.activeRollup.id", deployResult.rollupItem.recordId);
 
                             // for a new record, copy the activeRollup map to the cachedRollup map
                             if (cmp.get("v.cachedRollup") && cmp.get("v.cachedRollup.recordName")) {

--- a/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainerController.js
+++ b/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainerController.js
@@ -177,7 +177,7 @@
             var rollupsList = cmp.get("v.rollupList");
             var newItem = true;
             for (var i = 0; i < rollupsList.length; i++) {
-                if (rollupsList[i].id === message.id) {
+                if (rollupsList[i].recordId === message.id) {
                     // if the Id matches, update that record
                     console.log("Replace Row for " + message.id);
                     rollupsList[i] = message;
@@ -225,7 +225,7 @@
 
         if(action.name !== 'delete'){
             cmp.set("v.detailMode", action.name);
-            cmp.set("v.activeRecordId", row.id);
+            cmp.set("v.activeRecordId", row.recordId);
             //check which grid is displayed
             if(isRollupsGrid){
                 cmp.set("v.isRollupsGrid", false);

--- a/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainerController.js
+++ b/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainerController.js
@@ -172,14 +172,15 @@
             activeRecord.MasterLabel = message;
 
             cmp.set("v.activeRecord", activeRecord);
+
         } else if (channel === 'rollupRecordChange') {
-            // message will inserted or updated the Rollup__mdt record
+            // message will inserted or updated the RollupCMT object
             var rollupsList = cmp.get("v.rollupList");
             var newItem = true;
             for (var i = 0; i < rollupsList.length; i++) {
-                if (rollupsList[i].recordId === message.id) {
+                if (rollupsList[i].recordId === message.recordId) {
                     // if the Id matches, update that record
-                    console.log("Replace Row for " + message.id);
+                    console.log("Replace Row for " + message.recordId);
                     rollupsList[i] = message;
                     newItem = false;
                 }
@@ -188,6 +189,23 @@
                 rollupsList.push(message);
             }
             cmp.set("v.rollupList", rollupsList);
+
+        } else if (channel === 'filterRecordChange') {
+            // message will inserted or updated the FilterGroupCMT object
+            var filterGroupList = cmp.get("v.filterGroupList");
+            var newItem = true;
+            for (var i = 0; i < filterGroupList.length; i++) {
+                if (filterGroupList[i].recordId === message.recordId) {
+                    // if the Id matches, update that record
+                    console.log("Replace Row for " + message.recordId);
+                    filterGroupList[i] = message;
+                    newItem = false;
+                }
+            }
+            if (newItem === true) {
+                filterGroupList.push(message);
+            }
+            cmp.set("v.filterGroupList", filterGroupList);
         }
     },
 

--- a/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainerController.js
+++ b/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainerController.js
@@ -1,5 +1,6 @@
 ({
-    /* @description: setup for rollup app including cached rollups, filter groups, and labels for the app
+    /**
+    * @description: setup for rollup app including cached rollups, filter groups, and labels for the app
     */
     doInit: function (cmp, event, helper) {
         var action = cmp.get("c.setupRollupGrid");
@@ -79,17 +80,18 @@
         $A.enqueueAction(action);
     },
 
-    /* @description: calls the helper function to display the filter group grid and resets shared sorting information
-    */
+    /**
+     * @description: calls the helper function to display the filter group grid and resets shared sorting information
+     */
     displayFilterGroupsGrid: function(cmp, event, helper){
         helper.displayFilterGroupsGrid(cmp);
         cmp.set("v.sortedBy", "");
         cmp.set("v.sortedDirection", "asc");
     },
 
-    /* @description: resets the active record to ensure there is no leftover data and applies filtered summary object to the creation of a new rollup if applicable
-    */
-
+    /**
+     * @description: resets the active record to ensure there is no leftover data and applies filtered summary object to the creation of a new rollup if applicable
+     */
     displayNewRollupForm: function (cmp, event, helper) {
         cmp.set("v.activeRecord", {});
         cmp.set("v.activeRecord.label", cmp.get("v.labels.rollupNew"));
@@ -105,8 +107,9 @@
         cmp.set("v.detailMode", "create");
     },
 
-    /* @description: resets the active record and toggles the grid and detail views
-    */
+    /**
+     *  @description: resets the active record and toggles the grid and detail views
+     */
     displayNewFilterGroupForm: function (cmp, event, helper) {
         cmp.set("v.activeRecord", {});
         cmp.set("v.isFilterGroupsGrid", false);
@@ -115,23 +118,26 @@
         cmp.set("v.detailMode", "create");
     },
 
-    /* @description: calls the helper function to display the rollups grid and resets shared sorting information
-    */
+    /**
+     * @description: calls the helper function to display the rollups grid and resets shared sorting information
+     */
     displayRollupsGrid: function(cmp, event, helper){
         helper.displayRollupsGrid(cmp);
         cmp.set("v.sortedBy", "");
         cmp.set("v.sortedDirection", "asc");
     },
 
-    /* @description: filters visible rollups by the summary object picklist
-    */
+    /**
+     * @description: filters visible rollups by the summary object picklist
+     */
     filterBySummaryObject: function(cmp, event, helper){
         var object = cmp.find("selectSummaryObject").get("v.value");
         helper.filterData(cmp, object);
     },
 
-    /* @description: switches to selected grid with correct width after hearing cancel event from rollup or filter group detail
-    */
+    /**
+     * @description: switches to selected grid with correct width after hearing cancel event from rollup or filter group detail
+     */
     handleCancelEvent: function(cmp, event, helper){
         var labels = cmp.get("v.labels");
         var breadcrumbName = event.getSource().get('v.name');
@@ -149,9 +155,10 @@
         }
     },
 
-    /* @description: handles the ltng:message event
-    * currently listens for the rollup name change on the Rollup cmp since this doesn't bind correctly
-    */
+    /**
+     * @description: handles the ltng:message event
+     * currently listens for the rollup name change on the Rollup cmp since this doesn't bind correctly
+     */
     handleMessage: function(cmp, event, helper){
         var message = event.getParam("message");
         var channel = event.getParam("channel");
@@ -184,8 +191,9 @@
         }
     },
 
-    /* @description: handles the selection of a specific rollup from the filter group view and then return to filter group
-    */
+    /**
+     * @description: handles the selection of a specific rollup from the filter group view and then return to filter group
+     */
     handleNavigateEvent: function(cmp, event, helper){
         var id = event.getParam('id');
         var lastId = event.getParam('lastId');
@@ -207,8 +215,9 @@
 
     },
 
-    /* @description: handles the selected action in the either grid
-    */
+    /**
+     * @description: handles the selected action in the either grid
+     */
     handleRowAction: function(cmp, event, helper){
         var action = event.getParam('action');
         var row = event.getParam('row');
@@ -248,8 +257,9 @@
         }
     },
 
-    /* @description: used in the breadcrumb to return to the filter group grid from the filter group detail view
-    */
+    /**
+     *  @description: used in the breadcrumb to return to the filter group grid from the filter group detail view
+     */
     returnToFilterGroup: function(cmp, event, helper){
         cmp.set("v.activeRecordId", cmp.get("v.lastActiveRecordId"));
         cmp.set("v.lastActiveRecordId", null);
@@ -257,15 +267,17 @@
         cmp.set("v.isFilterGroupDetail", true);
     },
 
-    /* @description: changes the mode from the edit or clone buttons
-    */
+    /**
+     *  @description: changes the mode from the edit or clone buttons
+     */
     setMode: function(cmp, event, helper) {
         var name = event.getSource().get("v.name");
         cmp.set("v.detailMode", name);
     },
 
-    /* @description: sorts the data in either grid by the field name and current direction
-    */
+    /**
+     *  @description: sorts the data in either grid by the field name and current direction
+     */
     sortByColumns: function(cmp, event, helper){
         var col = event.getParam();
         var fieldName = event.getParam('fieldName');
@@ -289,9 +301,10 @@
 
     },
 
-    /* @description: toggles a modal popup and backdrop
-    */
+    /**
+     *  @description: toggles a modal popup and backdrop
+     */
     toggleFilterRuleModal: function(cmp, event, helper){
         helper.toggleFilterRuleModal(cmp);
-    },
+    }
 })

--- a/src/classes/CMT_FilterRule_SEL.cls
+++ b/src/classes/CMT_FilterRule_SEL.cls
@@ -101,6 +101,21 @@ public without sharing class CMT_FilterRule_SEL {
     }
 
     /**
+     * @description Queries a single Rollup Definition using the specified DeveloperName
+     * @return Record Id or null
+     */
+    public static Id getFilterGroupIdByDeveloperName(String developerName) {
+
+        for (Filter_Group__mdt fg : cachedFilterGroups) {
+            if (developerName == fg.DeveloperName) {
+                return fg.Id;
+            }
+        }
+        return null;
+
+    }
+
+    /**
      * @description Creates a list of all fields for a given object that are referenced in any way on an
      *  existing FilterRule. This list can be used when building a query of the needed fields to retrieve
      *  for an object.

--- a/src/classes/CMT_FilterRule_SEL.cls
+++ b/src/classes/CMT_FilterRule_SEL.cls
@@ -44,11 +44,8 @@ public without sharing class CMT_FilterRule_SEL {
     private static List<Filter_Group__mdt> cachedFilterGroups {
         get {
             if (cachedFilterGroups == null) {
-                cachedFilterGroups = [SELECT Id
-                        , MasterLabel
-                        , DeveloperName
-                        , Description__c
-                        , (SELECT Id FROM Filter_Rules__r)
+                cachedFilterGroups = [SELECT Id, MasterLabel, DeveloperName, Description__c,
+                            (SELECT Id, Is_Deleted__c FROM Filter_Rules__r)
                         FROM Filter_Group__mdt
                         WHERE Is_Deleted__c = false
                         ORDER BY MasterLabel];
@@ -62,7 +59,7 @@ public without sharing class CMT_FilterRule_SEL {
         get {
             if (cachedFilterRules == null) {
                 cachedFilterRules = [SELECT Id, MasterLabel, DeveloperName, Filter_Group__r.DeveloperName,
-                                Filter_Group__c, Field__r.QualifiedApiName, Field__r.MasterLabel,
+                                Filter_Group__c, Field__r.QualifiedApiName, Field__r.MasterLabel, Is_Deleted__c,
                                 Object__r.QualifiedApiName, Object__r.MasterLabel, Operator__c, Constant__c
                         FROM Filter_Rule__mdt
                         WHERE Is_Deleted__c = false

--- a/src/classes/CRLP_ConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_ConfigBuilder_SVC.cls
@@ -58,6 +58,7 @@ public class CRLP_ConfigBuilder_SVC {
         for (CRLP_RollupCMT.FilterGroup fg : groupsAndRules) {
             groups.add(fg.getMetadataRecord());
             for (CRLP_RollupCMT.FilterRule fr : fg.rules) {
+                fr.filterGroupRecordName = fg.recordName;
                 rules.add(fr.getMetadataRecord());
             }
         }

--- a/src/classes/CRLP_RollupCMT.cls
+++ b/src/classes/CRLP_RollupCMT.cls
@@ -94,7 +94,7 @@ public class CRLP_RollupCMT {
             // Setup custom metadata to be created or updated in the subscriber org.
             Metadata.CustomMetadata customMd = new Metadata.CustomMetadata();
             customMd.fullName = mdTypeName + '.' + this.recordName.left(40).removeEnd('_');
-            customMd.label = this.label;
+            customMd.label = this.label.left(40);
             customMd.protected_x = IS_PROTECTED;
 
             Map<String, Object> fldValues;
@@ -197,7 +197,7 @@ public class CRLP_RollupCMT {
             // Setup custom metadata to be created or updated in the subscriber org.
             Metadata.CustomMetadata customMd = new Metadata.CustomMetadata();
             customMd.fullName = mdTypeName + '.' + this.recordName.left(40).removeEnd('_');
-            customMd.label = this.label;
+            customMd.label = this.label.left(40);
             customMd.protected_x = IS_PROTECTED;
 
             Map<String, Object> fldValues;
@@ -326,7 +326,7 @@ public class CRLP_RollupCMT {
             // Setup custom metadata to be created or updated in the subscriber org.
             Metadata.CustomMetadata customMd = new Metadata.CustomMetadata();
             customMd.fullName = mdTypeName + '.' + this.recordName.left(40).removeEnd('_');
-            customMd.label = this.label;
+            customMd.label = this.label.left(40);
             customMd.protected_x = IS_PROTECTED;
 
             Map<String, Object> fldValues;

--- a/src/classes/CRLP_RollupCMT.cls
+++ b/src/classes/CRLP_RollupCMT.cls
@@ -183,7 +183,11 @@ public class CRLP_RollupCMT {
             String mdTypeName = CRLP_RollupCMT.MetadataObject.Filter_Rule.Name() + '__mdt';
 
             if (this.label == null) {
-                this.label = (this.filterGroupRecordName.left(20) + 'Rule: ' + this.objectName + '.' + this.fieldName +
+                String prefix = this.filterGroupRecordName;
+                if (prefix.countMatches('_') > 1) {
+                    prefix = prefix.split('_')[0] + '_' + prefix.split('_')[1];
+                }
+                this.label = abbreviateForSpace(prefix.left(20).removeEnd('_') + '_Rule: ' + /*this.objectName + '.' + */this.fieldName +
                         ' ' + this.operation).left(40);
             }
             if (this.recordName == null) {
@@ -368,9 +372,7 @@ public class CRLP_RollupCMT {
     public static String generateRecordName(String label, Boolean makeUnique) {
 
         // Shorten specific words
-        String recordName = label.replace('General Accounting Unit', 'GAU').replace('Account', 'Acct').
-                replace('Contact', 'Cnct').replace('Recurring Donation', 'RD').
-                replace('number', 'num').replace(' of ', '').replace('count', 'cnt');
+        String recordName = abbreviateForSpace(label);
 
         // replace all special characters and double underscores
         recordName = label.replaceAll('[^\\w]+', '_').replaceAll('_+', '_');
@@ -415,5 +417,17 @@ public class CRLP_RollupCMT {
      */
     private static String combineObjectAndField(String objName, String fieldName) {
         return objName + (fieldName != null ? '.' + fieldName : '');
+    }
+
+    private static String abbreviateForSpace(String txt) {
+        return txt.replace('General Accounting Unit', 'GAU').
+                replace('Opportunity', 'Opp').
+                replace('Account', 'Acct').
+                replace('Contact', 'Cnct').
+                replace('Recurring Donation', 'RD').
+                replace('Partial Soft Credit', 'PSC').
+                replace('Payment', 'Pmt').
+                replace('npsp__', '').replace('npe01__', '').replace('npe03__', '').replace('__c', '').
+                replace('number', 'num').replace('count', 'cnt').replace('total', 'sum').replace(' of ', '');
     }
 }

--- a/src/classes/CRLP_RollupCMT.cls
+++ b/src/classes/CRLP_RollupCMT.cls
@@ -54,6 +54,7 @@ public class CRLP_RollupCMT {
      */
     public class FilterGroup {
         public String recordName;
+        public String recordId;
         public String label;
         public String description;
         public Boolean isDeleted;
@@ -71,6 +72,7 @@ public class CRLP_RollupCMT {
             this.isDeleted = groupRecord.Is_Deleted__c;
             this.description = groupRecord.Description__c;
             this.rules = new List<FilterRule>();
+            this.recordId = groupRecord.Id;
         }
 
         /**
@@ -126,12 +128,17 @@ public class CRLP_RollupCMT {
      */
     public class FilterRule {
         public String recordName;
+        public String recordId;
         public String label;
         public String filterGroupRecordName;
         public String objectName;
+        public String objectLabel;
         public String fieldName;
+        public String fieldLabel;
         public String operation;
+        public String operationLabel;
         public String value;
+        public String valueLabel;
         public Boolean isDeleted;
 
         public FilterRule(String filterGroupRecordName, String label) {
@@ -153,6 +160,14 @@ public class CRLP_RollupCMT {
             }
             this.value = filterRule.Constant__c;
             this.isDeleted = filterRule.Is_Deleted__c;
+            this.recordId = filterRule.Id;
+
+            try {
+                this.objectLabel = filterRule.Object__r.MasterLabel;
+                this.fieldLabel = filterRule.Field__r.MasterLabel;
+                this.operationLabel = this.operation; // will to be updated in the RollupUI lgic
+                this.valueLabel = (this.value != null ? this.value.replace(';', ';\n') : null);
+            } catch (Exception ex) {}
         }
 
         /**

--- a/src/classes/CRLP_RollupCMT.cls
+++ b/src/classes/CRLP_RollupCMT.cls
@@ -57,7 +57,7 @@ public class CRLP_RollupCMT {
         public String recordId;
         public String label;
         public String description;
-        public Boolean isDeleted;
+        public Boolean isDeleted = false;
         public List<FilterRule> rules;
 
         public FilterGroup(String label) {
@@ -69,10 +69,12 @@ public class CRLP_RollupCMT {
         public FilterGroup(Filter_Group__mdt groupRecord) {
             this.label = groupRecord.MasterLabel;
             this.recordName = groupRecord.DeveloperName;
-            this.isDeleted = groupRecord.Is_Deleted__c;
             this.description = groupRecord.Description__c;
             this.rules = new List<FilterRule>();
-            this.recordId = groupRecord.Id;
+            try {
+                this.recordId = groupRecord.Id;
+                this.isDeleted = groupRecord.Is_Deleted__c;
+            } catch (Exception ex) {}
         }
 
         /**
@@ -139,7 +141,7 @@ public class CRLP_RollupCMT {
         public String operationLabel;
         public String value;
         public String valueLabel;
-        public Boolean isDeleted;
+        public Boolean isDeleted = false;
 
         public FilterRule(String filterGroupRecordName, String label) {
             this.label = label.trim();
@@ -159,7 +161,6 @@ public class CRLP_RollupCMT {
                 this.fieldName = filterRule.Field__r.QualifiedApiName;
             }
             this.value = filterRule.Constant__c;
-            this.isDeleted = filterRule.Is_Deleted__c;
             this.recordId = filterRule.Id;
 
             try {
@@ -167,6 +168,7 @@ public class CRLP_RollupCMT {
                 this.fieldLabel = filterRule.Field__r.MasterLabel;
                 this.operationLabel = this.operation; // will to be updated in the RollupUI lgic
                 this.valueLabel = (this.value != null ? this.value.replace(';', ';\n') : null);
+                this.isDeleted = filterRule.Is_Deleted__c;
             } catch (Exception ex) {}
         }
 

--- a/src/classes/CRLP_RollupCMT.cls
+++ b/src/classes/CRLP_RollupCMT.cls
@@ -329,6 +329,11 @@ public class CRLP_RollupCMT {
             customMd.label = this.label.left(40);
             customMd.protected_x = IS_PROTECTED;
 
+            // Convert an empty string ('') value into null for the entity reference to save properly.
+            if (String.isEmpty(this.filterGroupRecordName)) {
+                this.filterGroupRecordName = null;
+            }
+
             Map<String, Object> fldValues;
             if (this.isDeleted != true) {
                 fldValues = new Map<String, Object>{

--- a/src/classes/CRLP_RollupCMT.cls
+++ b/src/classes/CRLP_RollupCMT.cls
@@ -423,11 +423,14 @@ public class CRLP_RollupCMT {
         return txt.replace('General Accounting Unit', 'GAU').
                 replace('Opportunity', 'Opp').
                 replace('Account', 'Acct').
-                replace('Contact', 'Cnct').
+                replace('Contact', 'Con').
                 replace('Recurring Donation', 'RD').
                 replace('Partial Soft Credit', 'PSC').
+                replace('Allocations', 'Allo').
                 replace('Payment', 'Pmt').
                 replace('npsp__', '').replace('npe01__', '').replace('npe03__', '').replace('__c', '').
+                replace('soft credit', 'sftCr').replace('hard credit', 'hrdCr').
+                replace('#', 'num').replace('year', 'yr').
                 replace('number', 'num').replace('count', 'cnt').replace('total', 'sum').replace(' of ', '');
     }
 }

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -74,7 +74,7 @@ public with sharing class CRLP_RollupUI_SVC {
     /*******************************************************************************************************
     * @description a class to hold only the required information from the filter_rule__mdt records for the filter group detail.
     */
-    public class FilterRulesTableItem{
+    /*public class FilterRulesTableItem{
         @AuraEnabled public String objectLabel;
         @AuraEnabled public String objectName;
         @AuraEnabled public String fieldLabel;
@@ -84,7 +84,7 @@ public with sharing class CRLP_RollupUI_SVC {
         @AuraEnabled public String constantName;
         @AuraEnabled public String constantLabel;
         @AuraEnabled public Id id;
-    }
+    }*/
 
     /*******************************************************************************************************
     * @description Creates a model to collect both the RollupTableItems and the labels used on the page to minimize server trips.
@@ -114,8 +114,8 @@ public with sharing class CRLP_RollupUI_SVC {
     * Filter rules need to be flattened for use within the lightning:datatable.
     */
     public class FilterGroupModel {
-        @AuraEnabled public Filter_Group__mdt filterGroup;
-        @AuraEnabled public List<FilterRulesTableItem> filterRuleList;
+        @AuraEnabled public CRLP_RollupCMT.FilterGroup filterGroup;
+        @AuraEnabled public List<CRLP_RollupCMT.FilterRule> filterRuleList;
         @AuraEnabled public Map<String,String> operators;
         @AuraEnabled public Map<String,List<Map<String,String>>> filterFieldsByDataType;
 
@@ -287,29 +287,20 @@ public with sharing class CRLP_RollupUI_SVC {
     */
 
     @AuraEnabled
-    public static FilterGroupModel setupFilterGroupDetail(Id id, List<String> objectNames) {
+    public static FilterGroupModel setupFilterGroupDetail(Id groupId, List<String> objectNames) {
 
-        List<FilterRulesTableItem> mdtTableList = new List<FilterRulesTableItem>();
+        List<CRLP_RollupCMT.FilterRule> mdtTableList = new List<CRLP_RollupCMT.FilterRule>();
         Map<String,String> operators = getfilterRuleOperations();
 
-        Filter_Group__mdt filterGroup = CMT_FilterRule_SEL.getFilterGroupsById().get(id);
+        Filter_Group__mdt filterGroup = CMT_FilterRule_SEL.getFilterGroupsById().get(groupId);
 
         List<Filter_Rule__mdt> mdtList = CMT_FilterRule_SEL.getFilterRulesByGroup().get(filterGroup.Id);
 
         for(Integer i=0; i<mdtList.size(); i++) {
-            FilterRulesTableItem item = new FilterRulesTableItem();
+            CRLP_RollupCMT.FilterRule ruleItem = new CRLP_RollupCMT.FilterRule(mdtList[i]);
+            ruleItem.operationLabel = operators.get(ruleItem.operation);
 
-            item.constantName = mdtList[i].Constant__c;
-            item.constantLabel = item.constantName.replace(';', ';\n');
-            item.operatorName = mdtList[i].Operator__c;
-            item.operatorLabel = operators.get(mdtList[i].Operator__c);
-            item.fieldLabel = mdtList[i].Field__r.MasterLabel;
-            item.fieldName = mdtList[i].Field__r.QualifiedApiName;
-            item.objectLabel = mdtList[i].Object__r.MasterLabel;
-            item.objectName = mdtList[i].Object__r.QualifiedApiName;
-            item.id = mdtList[i].id;
-
-            mdtTableList.add(item);
+            mdtTableList.add(ruleItem);
         }
 
         Map<String,List<Map<String,String>>> objNameToFieldTypeMap = new Map<String,List<Map<String,String>>>();
@@ -321,7 +312,7 @@ public with sharing class CRLP_RollupUI_SVC {
 
         FilterGroupModel model = new FilterGroupModel();
 
-        model.filterGroup = filterGroup;
+        model.filterGroup = new CRLP_RollupCMT.FilterGroup(filterGroup);
         model.filterRuleList = mdtTableList;
         model.operators = operators;
         model.filterFieldsByDataType = objNameToFieldTypeMap;

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -286,35 +286,29 @@ public with sharing class CRLP_RollupUI_SVC {
     * @return A serialized instance of the FilterGroupModel inner class
     */
     @AuraEnabled
-    public static String setupFilterGroupDetail(Id groupId, List<String> objectNames) {
-
-        List<CRLP_RollupCMT.FilterRule> mdtTableList = new List<CRLP_RollupCMT.FilterRule>();
-        Map<String,String> operators = getfilterRuleOperations();
-
-        Filter_Group__mdt filterGroup = CMT_FilterRule_SEL.getFilterGroupsById().get(groupId);
-
-        List<Filter_Rule__mdt> mdtList = CMT_FilterRule_SEL.getFilterRulesByGroup().get(filterGroup.Id);
-
-        for(Integer i=0; i<mdtList.size(); i++) {
-            CRLP_RollupCMT.FilterRule ruleItem = new CRLP_RollupCMT.FilterRule(mdtList[i]);
-            ruleItem.operationLabel = operators.get(ruleItem.operation);
-
-            mdtTableList.add(ruleItem);
-        }
+    public static String setupFilterGroupDetail(String groupId, List<String> objectNames) {
 
         Map<String,List<Map<String,String>>> objNameToFieldTypeMap = new Map<String,List<Map<String,String>>>();
-
         for(String obj : objectNames){
             List<Map<String, String>> detailNameToFieldTypeObj = UTIL_Describe.getAllFieldsWithType(obj);
             objNameToFieldTypeMap.put(obj, detailNameToFieldTypeObj);
         }
 
         FilterGroupModel model = new FilterGroupModel();
-
-        model.filterGroup = new CRLP_RollupCMT.FilterGroup(filterGroup);
-        model.filterRuleList = mdtTableList;
-        model.operators = operators;
+        model.operators = getfilterRuleOperations();
         model.filterFieldsByDataType = objNameToFieldTypeMap;
+        model.filterRuleList = new List<CRLP_RollupCMT.FilterRule>();
+
+        if(!String.isEmpty(groupId)) {
+            Filter_Group__mdt filterGroup = CMT_FilterRule_SEL.getFilterGroupsById().get(groupId);
+            model.filterGroup = new CRLP_RollupCMT.FilterGroup(filterGroup);
+
+            for(Filter_Rule__mdt fr: CMT_FilterRule_SEL.getFilterRulesByGroup().get(filterGroup.Id)) {
+                CRLP_RollupCMT.FilterRule ruleItem = new CRLP_RollupCMT.FilterRule(fr);
+                ruleItem.operationLabel = model.operators.get(ruleItem.operation);
+                model.filterRuleList.add(ruleItem);
+            }
+        }
 
         //serialize to avoid passing inner classes, which is technically unsupported
         String modelString = JSON.serialize(model);

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -55,7 +55,7 @@ public with sharing class CRLP_RollupUI_SVC {
         @AuraEnabled public String recordName;
         @AuraEnabled public String summaryObject;
         @AuraEnabled public String summaryObjectApiName;
-        @AuraEnabled public Id id;
+        @AuraEnabled public String recordId;
 
     }
 
@@ -68,23 +68,8 @@ public with sharing class CRLP_RollupUI_SVC {
         @AuraEnabled public Integer countFilterRules;
         @AuraEnabled public Integer countRollups;
         @AuraEnabled public String name;
-        @AuraEnabled public Id id;
+        @AuraEnabled public String recordId;
     }
-
-    /*******************************************************************************************************
-    * @description a class to hold only the required information from the filter_rule__mdt records for the filter group detail.
-    */
-    /*public class FilterRulesTableItem{
-        @AuraEnabled public String objectLabel;
-        @AuraEnabled public String objectName;
-        @AuraEnabled public String fieldLabel;
-        @AuraEnabled public String fieldName;
-        @AuraEnabled public String operatorName;
-        @AuraEnabled public String operatorLabel;
-        @AuraEnabled public String constantName;
-        @AuraEnabled public String constantLabel;
-        @AuraEnabled public Id id;
-    }*/
 
     /*******************************************************************************************************
     * @description Creates a model to collect both the RollupTableItems and the labels used on the page to minimize server trips.
@@ -230,7 +215,7 @@ public with sharing class CRLP_RollupUI_SVC {
         } else {
             item.activeIcon = 'utility:close';
         }
-        item.id = rlp.Id;
+        item.recordId = rlp.Id;
         return item;
     }
 
@@ -254,7 +239,7 @@ public with sharing class CRLP_RollupUI_SVC {
             item.description = mdtList[i].Description__c;
             item.countFilterRules = mdtList[i].Filter_Rules__r.size();
             item.countRollups = (rollupsByFilterGroup.containsKey(mdtList[i].Id) ? rollupsByFilterGroup.get(mdtList[i].Id).size() : 0);
-            item.id = mdtList[i].Id;
+            item.recordId = mdtList[i].Id;
 
             mdtTableList.add(item);
         }
@@ -286,7 +271,7 @@ public with sharing class CRLP_RollupUI_SVC {
     * @return A serialized instance of the FilterGroupModel inner class
     */
     @AuraEnabled
-    public static String setupFilterGroupDetail(String groupId, List<String> objectNames) {
+    public static String setupFilterGroupDetail(String filterGroupId, List<String> objectNames) {
 
         Map<String,List<Map<String,String>>> objNameToFieldTypeMap = new Map<String,List<Map<String,String>>>();
         for(String obj : objectNames){
@@ -294,25 +279,36 @@ public with sharing class CRLP_RollupUI_SVC {
             objNameToFieldTypeMap.put(obj, detailNameToFieldTypeObj);
         }
 
-        FilterGroupModel model = new FilterGroupModel();
+        FilterGroupModel model = createFilterGroupModel(filterGroupId);
         model.operators = getfilterRuleOperations();
         model.filterFieldsByDataType = objNameToFieldTypeMap;
-        model.filterRuleList = new List<CRLP_RollupCMT.FilterRule>();
-
-        if(!String.isEmpty(groupId)) {
-            Filter_Group__mdt filterGroup = CMT_FilterRule_SEL.getFilterGroupsById().get(groupId);
-            model.filterGroup = new CRLP_RollupCMT.FilterGroup(filterGroup);
-
-            for(Filter_Rule__mdt fr: CMT_FilterRule_SEL.getFilterRulesByGroup().get(filterGroup.Id)) {
-                CRLP_RollupCMT.FilterRule ruleItem = new CRLP_RollupCMT.FilterRule(fr);
-                ruleItem.operationLabel = model.operators.get(ruleItem.operation);
-                model.filterRuleList.add(ruleItem);
-            }
-        }
 
         //serialize to avoid passing inner classes, which is technically unsupported
         String modelString = JSON.serialize(model);
         return modelString;
+    }
+
+    /**
+     * @description Build a FilterGroupModel wrapper for a given FilterGroup Id
+     * @param filterGroupId
+     * @return FilterGroupModel with just the FilterGroup and FilterRuleList properties populated
+     */
+    private static FilterGroupModel createFilterGroupModel(Id filterGroupId) {
+        FilterGroupModel model = new FilterGroupModel();
+        model.filterRuleList = new List<CRLP_RollupCMT.FilterRule>();
+        if (!String.isEmpty(filterGroupId)) {
+            Filter_Group__mdt filterGroup = CMT_FilterRule_SEL.getFilterGroupsById().get(filterGroupId);
+            model.filterGroup = new CRLP_RollupCMT.FilterGroup(filterGroup);
+
+            Map<String,String> operatorMap = getfilterRuleOperations();
+            for(Filter_Rule__mdt fr: CMT_FilterRule_SEL.getFilterRulesByGroup().get(filterGroup.Id)) {
+                CRLP_RollupCMT.FilterRule ruleItem = new CRLP_RollupCMT.FilterRule(fr);
+                ruleItem.operationLabel = operatorMap.get(ruleItem.operation);
+                model.filterRuleList.add(ruleItem);
+            }
+        }
+
+        return model;
     }
 
     /*******************************************************************************************************
@@ -582,11 +578,11 @@ public with sharing class CRLP_RollupUI_SVC {
      * This method queries for the DeveloperName and returns the record Id (if there is a match) or null
      * @param jobId CMT Deployment Job Id to check the status for
      * @param recordName Rollup__mdt.DeveloperName to query for if the job has completed
-     * TODO Refactor this to work for FilterGroup+FilterRule as well as for Rollups
+     * @param objectType 'Rollup' or 'Filter'
      * @return DeploymentResult
      */
     @AuraEnabled
-    public static DeploymentResult getDeploymentStatus(String jobId, String recordName) {
+    public static String getDeploymentStatus(String jobId, String recordName, String objectType) {
         Customizable_Rollup_Settings__c crs = UTIL_CustomSettingsFacade.getCustomizableRollupSettings();
         System.debug(crs);
         if (crs.CMT_API_Status__c != null) {
@@ -595,11 +591,17 @@ public with sharing class CRLP_RollupUI_SVC {
                 String result = deploymentStatus.get(jobId);
                 if (result == Metadata.DeployStatus.Succeeded.name()) {
                     try {
-                        Id rollupId = CRLP_Rollup_SEL.getRollupIdByDeveloperName(recordName);
                         DeploymentResult response = new DeploymentResult();
-                        response.completed = true;
-                        response.rollupItem = createRollupItem(CRLP_Rollup_SEL.getRollupById(rollupId));
-                        return response;
+                        if (objectType == 'Rollup') {
+                            Id rollupId = CRLP_Rollup_SEL.getRollupIdByDeveloperName(recordName);
+                            response.completed = true;
+                            response.rollupItem = createRollupItem(CRLP_Rollup_SEL.getRollupById(rollupId));
+                        } else if (objectType == 'Filter') {
+                            Id groupId = CMT_FilterRule_SEL.getFilterGroupIdByDeveloperName(recordName);
+                            response.completed = true;
+                            response.filterGroupItem = createFilterGroupModel(groupId);
+                        }
+                        return JSON.serialize(response);
                     } catch (Exception ex) {
                         // error retrieving the metadata record
                         throw new AuraHandledException(ex.getMessage());

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -283,11 +283,10 @@ public with sharing class CRLP_RollupUI_SVC {
     /*******************************************************************************************************
     * @description Fetches a single FilterGroup__mdt record by Id and associated FilterRule__mdt records.
     * @param id the filter group ID
-    * @return a FilterGroup__mdt record and related FilterRule__mdt records.
+    * @return A serialized instance of the FilterGroupModel inner class
     */
-
     @AuraEnabled
-    public static FilterGroupModel setupFilterGroupDetail(Id groupId, List<String> objectNames) {
+    public static String setupFilterGroupDetail(Id groupId, List<String> objectNames) {
 
         List<CRLP_RollupCMT.FilterRule> mdtTableList = new List<CRLP_RollupCMT.FilterRule>();
         Map<String,String> operators = getfilterRuleOperations();
@@ -317,9 +316,10 @@ public with sharing class CRLP_RollupUI_SVC {
         model.operators = operators;
         model.filterFieldsByDataType = objNameToFieldTypeMap;
 
-        return model;
+        //serialize to avoid passing inner classes, which is technically unsupported
+        String modelString = JSON.serialize(model);
+        return modelString;
     }
-
 
     /*******************************************************************************************************
     * @description Queries from the Rollup operations to fetch all rollup operation values.

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -293,7 +293,7 @@ public with sharing class CRLP_RollupUI_SVC {
      * @param filterGroupId
      * @return FilterGroupModel with just the FilterGroup and FilterRuleList properties populated
      */
-    private static FilterGroupModel createFilterGroupModel(Id filterGroupId) {
+    private static FilterGroupModel createFilterGroupModel(String filterGroupId) {
         FilterGroupModel model = new FilterGroupModel();
         model.filterRuleList = new List<CRLP_RollupCMT.FilterRule>();
         if (!String.isEmpty(filterGroupId)) {
@@ -517,20 +517,6 @@ public with sharing class CRLP_RollupUI_SVC {
             // For new records, the RecordName property will be null by default. The process of deploying the
             // CMT data will generate a unique RecordName to use for the new record.
             CRLP_RollupCMT.Rollup rollupCMTObj = (CRLP_RollupCMT.Rollup) JSON.deserialize(rollupCMT, CRLP_RollupCMT.Rollup.class);
-
-            // TODO Remove this code after the UI properly sets the fields. For need it to test inserting new rollups
-            if (rollupCMTObj.amountObject == null) {
-                rollupCMTObj.amountObject = 'Opportunity';
-            }
-            if (rollupCMTObj.dateObject == null) {
-                rollupCMTObj.dateObject = 'Opportunity';
-            }
-            if (rollupCMTObj.detailObject == null) {
-                rollupCMTObj.detailObject = 'Opportunity';
-            }
-            if (String.isEmpty(rollupCMTObj.filterGroupRecordName)) {
-                rollupCMTObj.filterGroupRecordName = null;
-            }
 
             // Queue up the deployment
             CRLP_ConfigBuilder_SVC.queueRollupConfigForDeploy(new List<CRLP_RollupCMT.Rollup>{rollupCMTObj});

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -528,6 +528,9 @@ public with sharing class CRLP_RollupUI_SVC {
             if (rollupCMTObj.detailObject == null) {
                 rollupCMTObj.detailObject = 'Opportunity';
             }
+            if (String.isEmpty(rollupCMTObj.filterGroupRecordName)) {
+                rollupCMTObj.filterGroupRecordName = null;
+            }
 
             // Queue up the deployment
             CRLP_ConfigBuilder_SVC.queueRollupConfigForDeploy(new List<CRLP_RollupCMT.Rollup>{rollupCMTObj});

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -439,6 +439,10 @@ public with sharing class CRLP_RollupUI_SVC {
                 'filterRuleDuplicate' => Label.CMT_FilterRuleDuplicateError,
                 'filterRuleLabel' => Schema.SObjectType.Filter_Rule__mdt.getLabel(),
                 'filterRuleLabelPlural' => Schema.SObjectType.Filter_Rule__mdt.getLabelPlural(),
+                'filtersSaveProgress' => String.format(System.Label.CRLP_SaveProgress, new List<String>{Schema.SObjectType.Filter_Group__mdt.getLabel()}),
+                'filtersSaveSuccess' => String.format(System.Label.CRLP_SaveSuccess, new List<String>{Schema.SObjectType.Filter_Group__mdt.getLabel()}),
+                'filtersSaveFail' => String.format(System.Label.CRLP_SaveError, new List<String>{Schema.SObjectType.Filter_Group__mdt.getLabel()}),
+                'filtersSaveTimeout' => String.format(System.Label.CRLP_SaveTimeout, new List<String>{Schema.SObjectType.Filter_Group__mdt.getLabel()}),
                 'hardCredit' => Label.CRLP_HardCredit,
                 'info' => Label.PageMessagesInfo,
                 'integer' => Schema.Rollup__mdt.Integer__c.getDescribe().getLabel(),
@@ -470,6 +474,7 @@ public with sharing class CRLP_RollupUI_SVC {
                 'objectOpportunity' => Schema.SObjectType.Opportunity.getName(),
                 'objectPartialSoftCredit' => Schema.SObjectType.Partial_Soft_Credit__c.getName(),
                 'objectRD' => Schema.SObjectType.npe03__Recurring_Donation__c.getName(),
+                'ok' => Label.stgLabelOK,
                 'operation' => Schema.Rollup__mdt.Operation__c.getDescribe().getLabel(),
                 'operator' => Schema.Filter_Rule__mdt.Operator__c.getDescribe().getLabel(),
                 'picklistLabelLastYear' => Label.stgLabelYearPicklistLastYear,
@@ -482,13 +487,11 @@ public with sharing class CRLP_RollupUI_SVC {
                 'rollupsByFilterGroup' => Label.CRLP_RollupsByFilterGroup,
                 'rollupSummaryTitle' => Label.CRLP_RollupSummary,
                 'rollupType' => Label.CRLP_RollupType,
+                'rollupSaveProgress' => String.format(System.Label.CRLP_SaveProgress, new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
+                'rollupSaveSuccess' => String.format(System.Label.CRLP_SaveSuccess, new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
+                'rollupSaveFail' => String.format(System.Label.CRLP_SaveError, new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
+                'rollupSaveTimeout' => String.format(System.Label.CRLP_SaveTimeout, new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
                 'save' => Label.stgBtnSave,
-                /* TODO Refactor this to use custom labels when have all save logic in place */
-                'rollupSaveProgress' => String.format('Saving the {0}', new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
-                'rollupSaveSuccess' => String.format('{0} Successfully Saved', new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
-                'rollupSaveFail' => String.format('Error saving the {0}', new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
-                'rollupSaveTimeout' => String.format('Saving the {0} has timed out. Please see the Customizable Rollups documentation for more information.',
-                        new List<String>{Schema.SObjectType.Rollup__mdt.getLabel()}),
                 'saveAndNew' => Label.lvlBtnSaveAndNew,
                 'selectOne' => Label.stgSelectOne,
                 'selectAll' => Label.conMergeSelectAll,
@@ -496,10 +499,9 @@ public with sharing class CRLP_RollupUI_SVC {
                 'success' => Label.PageMessagesConfirm,
                 'summaryField' => Schema.Rollup__mdt.Summary_Field__c.getDescribe().getLabel(),
                 'summaryObject' => Schema.Rollup__mdt.Summary_Object__c.getDescribe().getLabel(),
-                'ok' => Label.stgLabelOK,
+                'timeBoundOperationType' => Schema.Rollup__mdt.Time_Bound_Operation_Type__c.getDescribe().getLabel(),
                 'useFiscalYear' => Schema.Rollup__mdt.Use_Fiscal_Year__c.getDescribe().getLabel(),
                 'view' => Label.stgLabelView,
-                'timeBoundOperationType' => Schema.Rollup__mdt.Time_Bound_Operation_Type__c.getDescribe().getLabel(),
                 'warning' => Label.PageMessagesWarning
             };
 
@@ -543,11 +545,40 @@ public with sharing class CRLP_RollupUI_SVC {
             // Trigger the asynchronous deployment process
             String jobId = CRLP_ConfigBuilder_SVC.deployedQueuedMetadataTypes();
 
-            // Return the unique record DeveloperName value
+            // Return the unique record DeveloperName value of the Rollup__mdt record
             return jobId + '-' + rollupCMTObj.recordName;
         } catch (Exception ex) {
+            ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             throw new AuraHandledException('ERROR: ' + ex.getMessage() + '\n' + ex.getStackTraceString());
 
+        }
+    }
+
+    /*******************************************************************************************************
+     * @description Handle the save (insert/update) of a Rollup__mdt record
+     * @param rollupCMT Stringified structure of a CRLP_RollupCMT.Rollup wrapper class
+     * @return {JobId}-{DeveloperName} - ASync Job Id - Developer name of the newly inserted or updated
+     * record; or an error message. The {DeveloperName} value can be used by the JS to retrieve the record after
+     * the insert (deployment) completes.
+     */
+    @AuraEnabled
+    public static String saveFilterGroupAndRules(String filterGroupCMT) {
+        try {
+            // For new records, the RecordName property will be null by default. The process of deploying the
+            // CMT data will generate a unique RecordName to use for the new record.
+            CRLP_RollupCMT.FilterGroup filterGroupCMTObj = (CRLP_RollupCMT.FilterGroup) JSON.deserialize(filterGroupCMT, CRLP_RollupCMT.FilterGroup.class);
+
+            // Queue up the deployment
+            CRLP_ConfigBuilder_SVC.queueRollupConfigForDeploy(new List<CRLP_RollupCMT.FilterGroup>{filterGroupCMTObj});
+
+            // Trigger the asynchronous deployment process
+            String jobId = CRLP_ConfigBuilder_SVC.deployedQueuedMetadataTypes();
+
+            // Return the unique record DeveloperName value of the FilterGroup__mdt record
+            return jobId + '-' + filterGroupCMTObj.recordName;
+        } catch (Exception ex) {
+            ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+            throw new AuraHandledException('ERROR: ' + ex.getMessage() + '\n' + ex.getStackTraceString());
         }
     }
 

--- a/src/classes/CRLP_RollupUI_TEST.cls
+++ b/src/classes/CRLP_RollupUI_TEST.cls
@@ -149,12 +149,12 @@ public class CRLP_RollupUI_TEST {
     /*********************************************************************************************************
     * @description Tests getDeploymentStatus()
     */
-    public static testMethod void testGetDeploymentStatus() {
+    public static testMethod void testGetDeploymentStatus_Rollup() {
 
         // Create the test CMDT data
         mockRollupCMTValues();
 
-        //test a failure
+        // Rest a failure
         UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
                 Customizable_Rollups_Enabled__c = true,
                 CMT_API_Status__c = '{ "jobId" : "Some Text" }'
@@ -162,19 +162,21 @@ public class CRLP_RollupUI_TEST {
 
         try {
             // we know this will fail because the rollupName is not found
-            CRLP_RollupUI_SVC.getDeploymentStatus('jobId', 'rollupName');
+            CRLP_RollupUI_SVC.getDeploymentStatus('jobId', 'rollupName', 'Rollup');
         } catch (Exception e) {
             System.assertNotEquals(null, e.getMessage());
         }
 
-        //test a success
+        // Test a success
         UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
                 Customizable_Rollups_Enabled__c = true,
                 CMT_API_Status__c = '{ "jobId" : "'+Metadata.DeployStatus.Succeeded.name()+'" }'
         ));
 
         String recordName = CRLP_Rollup_SEL.cachedRollups[0].DeveloperName;
-        CRLP_RollupUI_SVC.DeploymentResult response = CRLP_RollupUI_SVC.getDeploymentStatus('jobId', recordName);
+        String resultString = CRLP_RollupUI_SVC.getDeploymentStatus('jobId', recordName, 'Rollup');
+        System.debug(resultString);
+        CRLP_RollupUI_SVC.DeploymentResult response = (CRLP_RollupUI_SVC.DeploymentResult)JSON.deserialize(resultString, CRLP_RollupUI_SVC.DeploymentResult.class);
 
         System.assertNotEquals(null, response);
 

--- a/src/classes/CRLP_RollupUI_TEST.cls
+++ b/src/classes/CRLP_RollupUI_TEST.cls
@@ -77,7 +77,8 @@ public class CRLP_RollupUI_TEST {
 
         List<String> objectList = new List<String>{'Opportunity'};
 
-        CRLP_RollupUI_SVC.FilterGroupModel filterGroupModel = CRLP_RollupUI_SVC.setupFilterGroupDetail(filterGroup.recordId, objectList);
+        String modelString = CRLP_RollupUI_SVC.setupFilterGroupDetail(filterGroup.recordId, objectList);
+        CRLP_RollupUI_SVC.FilterGroupModel filterGroupModel = (CRLP_RollupUI_SVC.FilterGroupModel)JSON.deserialize(modelString, CRLP_RollupUI_SVC.FilterGroupModel.class);
 
         System.assertEquals(filterGroup.recordName,filterGroupModel.filterGroup.recordName, 'The Filter Group should match what was passed in');
         System.assertEquals(3,filterGroupModel.filterRuleList.size(), 'There should be 3 Filter Rules');

--- a/src/classes/CRLP_RollupUI_TEST.cls
+++ b/src/classes/CRLP_RollupUI_TEST.cls
@@ -72,13 +72,14 @@ public class CRLP_RollupUI_TEST {
         // Create the test CMDT data
         mockRollupCMTValues();
 
-        Filter_Group__mdt filterGroup = CMT_FilterRule_SEL.cachedFilterGroups[0];
+        Filter_Group__mdt filterGroupMdt = CMT_FilterRule_SEL.cachedFilterGroups[0];
+        CRLP_RollupCMT.FilterGroup filterGroup = new CRLP_RollupCMT.FilterGroup(filterGroupMdt);
 
         List<String> objectList = new List<String>{'Opportunity'};
 
-        CRLP_RollupUI_SVC.FilterGroupModel filterGroupModel = CRLP_RollupUI_SVC.setupFilterGroupDetail(filterGroup.Id, objectList);
+        CRLP_RollupUI_SVC.FilterGroupModel filterGroupModel = CRLP_RollupUI_SVC.setupFilterGroupDetail(filterGroup.recordId, objectList);
 
-        System.assertEquals(filterGroup,filterGroupModel.filterGroup, 'The Filter Group should match what was passed in');
+        System.assertEquals(filterGroup.recordName,filterGroupModel.filterGroup.recordName, 'The Filter Group should match what was passed in');
         System.assertEquals(3,filterGroupModel.filterRuleList.size(), 'There should be 3 Filter Rules');
         System.assertEquals(13,filterGroupModel.operators.size(), 'There should be 13 operators');
         System.assertEquals(objectList.size(),filterGroupModel.filterFieldsByDataType.size(), 'There should be one entry for each object passed in');

--- a/src/classes/CRLP_Rollup_SEL.cls
+++ b/src/classes/CRLP_Rollup_SEL.cls
@@ -135,15 +135,12 @@ public class CRLP_Rollup_SEL {
      */
     public static Id getRollupIdByDeveloperName(String developerName) {
 
-        Rollup__mdt rollup = new Rollup__mdt();
         for (Rollup__mdt rlp : cachedRollups) {
             if (developerName == rlp.DeveloperName) {
-                rollup = rlp;
-                break;
+                return rlp.Id;
             }
         }
-        return rollup.Id;
-
+        return null;
     }
 
     /**

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -853,6 +853,38 @@
         <value>Rollup Type</value>
     </labels>
     <labels>
+        <fullName>CRLP_SaveError</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Error Deploying Customizable Rollup data</shortDescription>
+        <value>Error saving the {0}</value>
+    </labels>
+    <labels>
+        <fullName>CRLP_SaveProgress</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Saving Progress Message</shortDescription>
+        <value>Saving the {0}</value>
+    </labels>
+    <labels>
+        <fullName>CRLP_SaveSuccess</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Successfully Saved</shortDescription>
+        <value>{0} Successfully Saved</value>
+    </labels>
+    <labels>
+        <fullName>CRLP_SaveTimeout</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Timeout error message</shortDescription>
+        <value>Saving the {0} has timed out. Please see the Customizable Rollups documentation for more information.</value>
+    </labels>
+    <labels>
         <fullName>CRLP_SoftCredit</fullName>
         <categories>Settings</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1113,6 +1113,10 @@
         <members>CRLP_RollupNew</members>
         <members>CRLP_RollupSummary</members>
         <members>CRLP_RollupType</members>
+        <members>CRLP_SaveError</members>
+        <members>CRLP_SaveProgress</members>
+        <members>CRLP_SaveSuccess</members>
+        <members>CRLP_SaveTimeout</members>
         <members>CRLP_SoftCredit</members>
         <members>CampaignMemberStatusOmit</members>
         <members>CascadeDeletionError</members>


### PR DESCRIPTION
# Critical Changes

* Change the FilterGroupModel inner class to use `CRLP_RollupCMT.FilterGroup`
* Refactor all use of the FilterGroupRuleItem to use `CRLP_RollupCMT.FilterRule`

# Changes

# Issues Closed

# New Metadata

*Custom Labels:*
* CRLP_SaveError
* CRLP_SaveProgress
* CRLP_SaveSuccess
* CRLP_SaveTimeout

# Deleted Metadata
