### PR TITLE
Feature/automated soft credits  affiliations

### DIFF
--- a/src/classes/OPP_AutomatedSoftCreditsService.cls
+++ b/src/classes/OPP_AutomatedSoftCreditsService.cls
@@ -53,7 +53,7 @@ public class OPP_AutomatedSoftCreditsService {
 
     /*********************************************************************************************************
     * @description Calls the methods that handle creating Opportunity Contact Roles for Relationship records.
-    * @param primaryContactIdToOpportunityId Map of Primary Contact to List of Opportunities.
+    * @param primaryContactIdToOpportunityIds Map of Primary Contact to List of Opportunities.
     * @return List<OpportunityContactRole> The newly created Opportunity Contact Role records.
     **********************************************************************************************************/
     public static List<OpportunityContactRole>  createRelationshipOCRs(Map<Id, List<Id>> primaryContactIdToOpportunityIds) {
@@ -72,7 +72,8 @@ public class OPP_AutomatedSoftCreditsService {
     * @param primaryContactIds The Opportunities' Primary Contacts.
     * @return Map<Id, List<npe4__Relationship__c>> Map of the Primary Contact to its Relationship records.
     **********************************************************************************************************/
-    public static Map<Id, List<npe4__Relationship__c>> retrieveRelationships(Set<Id> primaryContactIds) {
+    @testVisible
+    private static Map<Id, List<npe4__Relationship__c>> retrieveRelationships(Set<Id> primaryContactIds) {
         Map<Id, List<npe4__Relationship__c>> primaryContactToRelationships = new Map<Id, List<npe4__Relationship__c>>();
 
         if (primaryContactIds.isEmpty()) {
@@ -103,12 +104,13 @@ public class OPP_AutomatedSoftCreditsService {
 
     /*********************************************************************************************************
     * @description Builds Opportunity Contact Role records for the Primary Contact's Relationships.
-    * @param primaryContactIdToOpportunity Map of Primary Contact to List of Opportunities.
+    * @param primaryContactIdToOpportunityIds Map of Primary Contact to List of Opportunities.
     * @param primaryContactToRelatedContacts Map of Primary Contact to Relationship records.
     * @return List<OpportunityContactRole> List of the Opportunity Contact Role records for Related Contacts.
     **********************************************************************************************************/
-    public static List<OpportunityContactRole> buildRelationshipOCRs(Map<Id, List<Id>> primaryContactIdToOpportunityIds,
-                                                                     Map<Id, List<npe4__Relationship__c>> primaryContactToRelatedContacts) {
+    @testVisible
+    private static List<OpportunityContactRole> buildRelationshipOCRs(Map<Id, List<Id>> primaryContactIdToOpportunityIds,
+                                                                      Map<Id, List<npe4__Relationship__c>> primaryContactToRelatedContacts) {
         List<OpportunityContactRole> relationshipOCRs = new List<OpportunityContactRole>();
 
         if (primaryContactIdToOpportunityIds.isEmpty()) {
@@ -139,11 +141,102 @@ public class OPP_AutomatedSoftCreditsService {
 
 
     /*********************************************************************************************************
+    * @description Calls the methods that handle creating Opportunity Contact Roles for Affiliation records.
+    * @param accountIdToOpportunityIds Map of Account Id to List of Opportunities.
+    * @return List<OpportunityContactRole> The newly created Opportunity Contact Role records.
+    **********************************************************************************************************/
+    public static List<OpportunityContactRole> createAffiliationOCRs(Map<Id, List<Id>> accountIdToOpportunityIds) {
+        // Retrieve Affiliations for Account
+        Map<Id, List<npe5__Affiliation__c>> accountToRelatedContacts = retrieveAffiliations(accountIdToOpportunityIds.keySet());
+
+        // Create Opportunity Contact Roles (OCR) records for the Related Contacts
+        List<OpportunityContactRole> affiliationOCRs = buildAffiliationOCRs(accountIdToOpportunityIds, accountToRelatedContacts);
+
+        return affiliationOCRs;
+    }
+
+
+    /*********************************************************************************************************
+    * @description Retrieves the Affiliation records for the Opportunity's associated Account.
+    * @param accountIds The Opportunities' Account Ids.
+    * @return Map<Id, List<npe5__Affiliation__c>> Map of the Account to its Affiliation records.
+    **********************************************************************************************************/
+    @testVisible
+    private static Map<Id, List<npe5__Affiliation__c>> retrieveAffiliations(Set<Id> accountIds) {
+        Map<Id, List<npe5__Affiliation__c>> accountToAffiliations = new Map<Id, List<npe5__Affiliation__c>>();
+
+        if (accountIds.isEmpty()) {
+            return accountToAffiliations;
+        }
+
+        List<npe5__Affiliation__c> allAffiliations
+            = new List<npe5__Affiliation__c>([SELECT Id, Name, npe5__Organization__c, npe5__Contact__c, Related_Opportunity_Contact_Role__c
+                                                FROM npe5__Affiliation__c
+                                                WHERE npe5__Organization__c IN :accountIds]);
+
+        // Process the records that have a value in the Related_Opportunity_Contact_Role__c field
+        for (npe5__Affiliation__c eachAffiliation : allAffiliations) {
+            if (eachAffiliation.Related_Opportunity_Contact_Role__c != null
+                && !eachAffiliation.Related_Opportunity_Contact_Role__c.containsIgnoreCase(RELATED_OPPORTUNITY_CONTACT_ROLE_NONE)) {
+                if (accountToAffiliations.containsKey(eachAffiliation.npe5__Organization__c)) {
+                    List<npe5__Affiliation__c> affiliations = accountToAffiliations.get(eachAffiliation.npe5__Organization__c);
+                    affiliations.add(eachAffiliation);
+                } else {
+                    accountToAffiliations.put(eachAffiliation.npe5__Organization__c, new List<npe5__Affiliation__c>{ eachAffiliation });
+                }
+            }
+        }
+
+        return accountToAffiliations;
+    }
+
+
+    /*********************************************************************************************************
+    * @description Builds Opportunity Contact Role records for the Account's Affiliations.
+    * @param accountIdToOpportunityIds Map of Account to List of Opportunities.
+    * @param accountToRelatedContacts Map of Account to Affiliation records.
+    * @return List<OpportunityContactRole> List of the Opportunity Contact Role records for Related Contacts.
+    **********************************************************************************************************/
+    @testVisible
+    private static List<OpportunityContactRole> buildAffiliationOCRs(Map<Id, List<Id>> accountIdToOpportunityIds,
+                                                                     Map<Id, List<npe5__Affiliation__c>> accountToRelatedContacts) {
+
+        List<OpportunityContactRole> affiliationOCRs = new List<OpportunityContactRole>();
+
+        if (accountIdToOpportunityIds.isEmpty()) {
+            return affiliationOCRs;
+        }
+
+        Map<Id, List<OpportunityContactRole>> opportunityIdToOCR = retrieveOpportunityContactRoles(accountIdToOpportunityIds.values());
+
+        for (Id accountKey : accountToRelatedContacts.keySet()) {
+            List<Id> opportunityIds = accountIdToOpportunityIds.get(accountKey);
+            for (npe5__Affiliation__c eachAffiliation : accountToRelatedContacts.get(accountKey)) {
+                for (Id eachOpportunityId : opportunityIds) {
+                    if (!isDuplicateOCR(opportunityIdToOCR.get(eachOpportunityId),
+                                        eachAffiliation.npe5__Contact__c, eachAffiliation.Related_Opportunity_Contact_Role__c)) {
+                        OpportunityContactRole ocr = new OpportunityContactRole();
+                        ocr.OpportunityId = eachOpportunityId;
+                        ocr.ContactId = eachAffiliation.npe5__Contact__c;
+                        ocr.Role = eachAffiliation.Related_Opportunity_Contact_Role__c;
+
+                        affiliationOCRs.add(ocr);
+                    }
+                }
+            }
+        }
+
+        return affiliationOCRs;
+    }
+
+
+    /*********************************************************************************************************
     * @description Retrieves the Opportunity Contact Role records related to the Opportunities.
     * @param opportunityIds List of Lists of Opportunity Ids.
     * @return Map<Id, List<OpportunityContactRole>> Map of the Opportunity to Opportunity Contact Roles.
     **********************************************************************************************************/
-    public static Map<Id, List<OpportunityContactRole>> retrieveOpportunityContactRoles(List<List<Id>> opportunityIds) {
+    @testVisible
+    private static Map<Id, List<OpportunityContactRole>> retrieveOpportunityContactRoles(List<List<Id>> opportunityIds) {
         Map<Id, List<OpportunityContactRole>> opportunityIdToOCR = new Map<Id, List<OpportunityContactRole>>();
         List<Id> allOpportunityIds = new List<Id>();
 
@@ -180,22 +273,23 @@ public class OPP_AutomatedSoftCreditsService {
     * @param role The role value that's being evaluated in the duplicate check.
     * @return Boolean The result of determining if the currentRelationship record is a duplicate.
     **********************************************************************************************************/
-    public static Boolean isDuplicateOCR(List<OpportunityContactRole> currentOCRs, Id relatedContact, String role) {
-        Boolean isDuplicateRelationship = false;
+    @testVisible
+    private static Boolean isDuplicateOCR(List<OpportunityContactRole> currentOCRs, Id relatedContact, String role) {
+        Boolean isDuplicate = false;
 
-        if (currentOCRs.isEmpty()) {
-            return isDuplicateRelationship;
+        if (currentOCRs == null || currentOCRs.isEmpty()) {
+            return isDuplicate;
         }
 
         for (OpportunityContactRole eachOCR : currentOCRs) {
             if (eachOCR.ContactId ==  relatedContact
                 && eachOCR.Role == role) {
-                isDuplicateRelationship = true;
+                isDuplicate = true;
                 break;
             }
         }
 
-        return isDuplicateRelationship;
+        return isDuplicate;
     }
 
 

--- a/src/classes/OPP_AutomatedSoftCreditsService_TEST.cls
+++ b/src/classes/OPP_AutomatedSoftCreditsService_TEST.cls
@@ -45,6 +45,7 @@ private class OPP_AutomatedSoftCreditsService_TEST {
     private static final String RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_SOFT_CREDIT = 'Soft Credit';
     private static final String RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_SOLICITOR = 'Solicitor';
     private static final String RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_TRIBUTE = 'Tribute';
+    private static final String RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_MATCHING_GIFT= 'Matching Gift';
 
 
     /*********************************************************************************************************
@@ -53,15 +54,26 @@ private class OPP_AutomatedSoftCreditsService_TEST {
     * @return void
     **********************************************************************************************************/
     @testSetup static void createAutomatedSoftCreditsData() {
-        List<Contact> testContacts = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(5);
+        Account acct1 = new Account(Name = 'Organization Account1');
+        Account acct2 = new Account(Name = 'Organization Account2');
+        acct1.npe01__SYSTEMIsIndividual__c = false;
+        acct2.npe01__SYSTEMIsIndividual__c = false;
+        insert new List<Account>{ acct1, acct2 };
+
+        List<Contact> testContacts = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(7);
         testContacts[0].FirstName = 'Primary0';
         testContacts[1].FirstName = 'Primary1';
         testContacts[2].FirstName = 'Related2';
         testContacts[3].FirstName = 'Related3';
         testContacts[4].FirstName = 'Related4';
+        testContacts[5].FirstName = 'Affiliation5';
+        testContacts[5].AccountId = acct1.Id;
+        testContacts[6].FirstName = 'Affiliation6';
+        testContacts[6].AccountId = acct2.Id;
         insert testContacts;
         testContacts = [SELECT Id, AccountId, FirstName, LastName FROM Contact];
 
+        // Create Relationships
         npe4__Relationship__c testCon0ToTestCon1
                 = new npe4__Relationship__c(npe4__Contact__c = testContacts[0].Id,
                                             npe4__RelatedContact__c = testContacts[1].Id,
@@ -101,6 +113,40 @@ private class OPP_AutomatedSoftCreditsService_TEST {
             = new List<npe4__Relationship__c>{ testCon0ToTestCon1, testCon0ToTestCon2, testCon0ToTestCon3, testCon1ToTestCon3, testCon1ToTestCon4 };
         insert testRelationships;
 
+        // Create Affiliations
+        npe5__Affiliation__c testCon5AccountToTestCon2
+            = new npe5__Affiliation__c(npe5__Organization__c = testContacts[5].AccountId,
+                                       npe5__Contact__c = testContacts[2].Id,
+                                       npe5__Role__c = RELATIONSHIP_TYPE_PARTNER,
+                                       npe5__Status__c = RELATIONSHIP_STATUS_CURRENT,
+                                       Related_Opportunity_Contact_Role__c = RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_SOFT_CREDIT);
+
+        npe5__Affiliation__c testCon5AccountToTestCon4
+            = new npe5__Affiliation__c(npe5__Organization__c = testContacts[5].AccountId,
+                                       npe5__Contact__c = testContacts[4].Id,
+                                       npe5__Role__c = RELATIONSHIP_TYPE_PARTNER,
+                                       npe5__Status__c = RELATIONSHIP_STATUS_CURRENT,
+                                       Related_Opportunity_Contact_Role__c = RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_MATCHING_GIFT);
+
+        npe5__Affiliation__c testCon6AccountToTestCon3
+            = new npe5__Affiliation__c(npe5__Organization__c = testContacts[6].AccountId,
+                                       npe5__Contact__c = testContacts[3].Id,
+                                       npe5__Role__c = RELATIONSHIP_TYPE_PARTNER,
+                                       npe5__Status__c = RELATIONSHIP_STATUS_CURRENT,
+                                       Related_Opportunity_Contact_Role__c = RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_TRIBUTE);
+
+        npe5__Affiliation__c testCon6AccountToTestCon2
+            = new npe5__Affiliation__c(npe5__Organization__c = testContacts[6].AccountId,
+                                       npe5__Contact__c = testContacts[2].Id,
+                                       npe5__Role__c = RELATIONSHIP_TYPE_PARTNER,
+                                       npe5__Status__c = RELATIONSHIP_STATUS_CURRENT,
+                                       Related_Opportunity_Contact_Role__c = null);
+
+        List<npe5__Affiliation__c> testAccountAffiliations
+            = new List<npe5__Affiliation__c>{ testCon5AccountToTestCon2, testCon5AccountToTestCon4, testCon6AccountToTestCon3, testCon6AccountToTestCon2 };
+        insert testAccountAffiliations;
+
+        // Create Opportunities
         List<Opportunity> testOpptys = UTIL_UnitTestData_TEST.OppsForContactWithAccountList(testContacts, null, UTIL_UnitTestData_TEST.getClosedWonStage(),
                                                                                             System.today(), 100, null, null);
         insert testOpptys;
@@ -212,7 +258,7 @@ private class OPP_AutomatedSoftCreditsService_TEST {
     private static testMethod void testBuildRelationshipOCRs() {
         List<OpportunityContactRole> creatededOCRs = new List<OpportunityContactRole>();
 
-        Map<Id, List<Id>> primaryContactIdToOpportunityId = new Map<Id, List<Id>>();
+        Map<Id, List<Id>> primaryContactIdToOpportunityIds = new Map<Id, List<Id>>();
         Map<Id, List<npe4__Relationship__c>> relationshipRecords = new Map<Id, List<npe4__Relationship__c>>();
 
         Contact testCon0 = [SELECT Id FROM Contact WHERE FirstName = 'Primary0'][0];
@@ -220,10 +266,10 @@ private class OPP_AutomatedSoftCreditsService_TEST {
 
         List<Opportunity> opptys = [SELECT Id, Primary_Contact__c FROM Opportunity];
         for (Opportunity eachOppty : opptys) {
-            primaryContactIdToOpportunityId.put(eachOppty.Primary_Contact__c, new List<Id>{ eachOppty.Id });
+            primaryContactIdToOpportunityIds.put(eachOppty.Primary_Contact__c, new List<Id>{ eachOppty.Id });
         }
 
-        relationshipRecords = OPP_AutomatedSoftCreditsService.retrieveRelationships(primaryContactIdToOpportunityId.keySet());
+        relationshipRecords = OPP_AutomatedSoftCreditsService.retrieveRelationships(primaryContactIdToOpportunityIds.keySet());
         System.assertEquals(2, relationshipRecords.size());
         System.assertEquals(2, relationshipRecords.get(testCon0.Id).size());
         System.assertEquals(1, relationshipRecords.get(testCon1.Id).size());
@@ -231,9 +277,9 @@ private class OPP_AutomatedSoftCreditsService_TEST {
         Test.startTest();
 
         List<OpportunityContactRole> retrievedOCRs = [SELECT Id, ContactId, Role FROM OpportunityContactRole];
-        System.assertEquals(8, retrievedOCRs.size()); // Five OCRs for the Opportunities' Primary Contacts and three OCRs for the Relationships
+        System.assertEquals(13, retrievedOCRs.size()); // Five OCRs for the Opportunities' Primary Contacts and three OCRs for the Relationships
 
-        creatededOCRs = OPP_AutomatedSoftCreditsService.buildRelationshipOCRs(primaryContactIdToOpportunityId, relationshipRecords);
+        creatededOCRs = OPP_AutomatedSoftCreditsService.buildRelationshipOCRs(primaryContactIdToOpportunityIds, relationshipRecords);
         System.assertEquals(0, creatededOCRs.size()); // Confirm no duplicate OCRs were created
 
         // Update Relationship records
@@ -242,7 +288,107 @@ private class OPP_AutomatedSoftCreditsService_TEST {
         testCon0Relationships[1].Related_Opportunity_Contact_Role__c = RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_SOLICITOR;
         update testCon0Relationships;
 
-        creatededOCRs = OPP_AutomatedSoftCreditsService.buildRelationshipOCRs(primaryContactIdToOpportunityId, relationshipRecords);
+        creatededOCRs = OPP_AutomatedSoftCreditsService.buildRelationshipOCRs(primaryContactIdToOpportunityIds, relationshipRecords);
+
+        Test.stopTest();
+
+        System.assertEquals(2, creatededOCRs.size()); // Confirm new OCR records were created
+    }
+
+
+    /*********************************************************************************************************
+    * @description Tests that Opportunity Contact Role records are created for the Opportunity's Account's
+    *               Related Contacts.
+    * verify:
+    *   Opportunity Contact Role records created for Related Contacts.
+    * @return void
+    **********************************************************************************************************/
+    private static testMethod void testCreateAffiliationOCRs() {
+        Test.startTest();
+
+        Contact testCon = [SELECT Id, AccountId FROM Contact WHERE FirstName = 'Affiliation5'][0];
+        Account testAcount = [SELECT Id, npe01__SYSTEMIsIndividual__c FROM Account WHERE Id = :testCon.AccountId][0];
+        System.assertEquals(false, testAcount.npe01__SYSTEMIsIndividual__c);
+        List<OpportunityContactRole> retrievedOCR
+            = [SELECT Id, ContactId, Role
+                FROM OpportunityContactRole
+                WHERE ContactId = :testCon.Id
+                AND Role = :RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_SOFT_CREDIT];
+
+        System.assertEquals(1, retrievedOCR.size());
+
+        Test.stopTest();
+
+        System.assertEquals(testCon.Id, retrievedOCR[0].ContactId);
+    }
+
+
+    /*********************************************************************************************************
+    * @description Tests the retrieval of Affiliation records for the Opportunity's Account.
+    * verify:
+    *   Affiliation records were retrieved.
+    * @return void
+    **********************************************************************************************************/
+    private static testMethod void testRetrieveAffiliations() {
+        Map<Id, List<npe5__Affiliation__c>> affiliationRecords = new Map<Id, List<npe5__Affiliation__c>>();
+
+        Contact testCon0 = [SELECT AccountId FROM Contact WHERE FirstName = 'Affiliation5'][0];
+        Contact testCon1 = [SELECT AccountId FROM Contact WHERE FirstName = 'Affiliation6'][0];
+        Set<Id> testConsAccounts = new Set<Id>{ testCon0.AccountId, testCon1.AccountId };
+
+        Test.startTest();
+
+        affiliationRecords = OPP_AutomatedSoftCreditsService.retrieveAffiliations(testConsAccounts);
+
+        Test.stopTest();
+
+        System.assertEquals(2, affiliationRecords.size());
+        System.assertEquals(2, affiliationRecords.get(testCon0.AccountId).size());
+    }
+
+
+    /*********************************************************************************************************
+    * @description Tests the Opportunity Contact Role records were created with the expected values.
+    * verify:
+    *   Opportunity Contact Role records created with expected values.
+    * @return void
+    **********************************************************************************************************/
+    private static testMethod void testBuildAffiliationOCRs() {
+        List<OpportunityContactRole> creatededOCRs = new List<OpportunityContactRole>();
+
+        Map<Id, List<Id>> accountIdToOpportunityIds = new Map<Id, List<Id>>();
+        Map<Id, List<npe5__Affiliation__c>> affiliationRecords = new Map<Id, List<npe5__Affiliation__c>>();
+
+        Contact testCon0 = [SELECT AccountId FROM Contact WHERE FirstName = 'Affiliation5'][0];
+        Contact testCon1 = [SELECT AccountId FROM Contact WHERE FirstName = 'Affiliation6'][0];
+        List<Id> testAccoutIds = new List<Id>{ testCon0.AccountId, testCon1.AccountId };
+
+        List<Opportunity> opptys = [SELECT Id, AccountId FROM Opportunity WHERE AccountId IN :testAccoutIds];
+        for (Opportunity eachOppty : opptys) {
+            accountIdToOpportunityIds.put(eachOppty.AccountId, new List<Id>{ eachOppty.Id });
+        }
+        System.assertEquals(2, accountIdToOpportunityIds.size());
+
+        affiliationRecords = OPP_AutomatedSoftCreditsService.retrieveAffiliations(accountIdToOpportunityIds.keySet());
+        System.assertEquals(2, affiliationRecords.size());
+        System.assertEquals(2, affiliationRecords.get(testCon0.AccountId).size());
+        System.assertEquals(1, affiliationRecords.get(testCon1.AccountId).size());
+
+        Test.startTest();
+
+        List<OpportunityContactRole> retrievedOCRs = [SELECT Id, ContactId, Role FROM OpportunityContactRole];
+        System.assertEquals(13, retrievedOCRs.size()); // Seven OCRs for the Opportunities and six OCRs for Relationship and Affiliations
+
+        creatededOCRs = OPP_AutomatedSoftCreditsService.buildAffiliationOCRs(accountIdToOpportunityIds, affiliationRecords);
+        System.assertEquals(0, creatededOCRs.size()); // Confirm no duplicate OCRs were created
+
+        // Update Affiliation records
+        List<npe5__Affiliation__c> testCon0Affiliations = affiliationRecords.get(testCon0.AccountId);
+        testCon0Affiliations[0].Related_Opportunity_Contact_Role__c = RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_SOLICITOR;
+        testCon0Affiliations[1].Related_Opportunity_Contact_Role__c = RELATIONSHIP_OPPORTUNITY_CONTACT_ROLE_SOLICITOR;
+        update testCon0Affiliations;
+
+        creatededOCRs = OPP_AutomatedSoftCreditsService.buildAffiliationOCRs(accountIdToOpportunityIds, affiliationRecords);
 
         Test.stopTest();
 

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -227,7 +227,10 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         Map<Id, Account> oppAccountDetails = populateAccountDetails(listOpps);
 
         // Retrieve the Primary Contacts for the Opportunities
-        Map<Id, List<Id>> primaryContactsToOpportunities = populatePrimaryContactToOpportunity(listOpps, oppAccountDetails);
+        Map<Id, List<Id>> primaryContactsToOpportunities = populatePrimaryContactToOpportunities(listOpps, oppAccountDetails);
+
+        // Retrieve the Account Ids for the Organizational Opportunities
+        Map<Id, List<Id>> accountsToOpportunities = populateAccountToOpportunities(listOpps, oppAccountDetails);
 
         //Get existing primary contact roles for the trigger opps. 
         for (OpportunityContactRole ocr : [SELECT OpportunityId, ContactId, Role, IsPrimary FROM OpportunityContactRole WHERE IsPrimary = true and OpportunityId IN :listOpps]) {
@@ -289,10 +292,18 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
             insert listPrimaryOCRForInsert;
         }
 
+        // Create Relationship Soft Credits accordingly
         if (!primaryContactsToOpportunities.isEmpty()) {
             List<sObject> relationshipOCRs
                 = OPP_AutomatedSoftCreditsService.createRelationshipOCRs(primaryContactsToOpportunities);
             dmlWrapper.objectsToInsert.addAll(relationshipOCRs);
+        }
+
+        // Create Affiliation Soft Credits accordingly
+        if (!accountsToOpportunities.isEmpty()) {
+            List<sObject> affiliationOCRs
+                = OPP_AutomatedSoftCreditsService.createAffiliationOCRs(accountsToOpportunities);
+            dmlWrapper.objectsToInsert.addAll(affiliationOCRs);
         }
     }
 
@@ -336,7 +347,10 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         Map<Id, Account> oppAccountDetails = populateAccountDetails(listOpps);
 
         // Retrieve the Primary Contacts for the Opportunities
-        Map<Id, List<Id>> primaryContactsToOpportunities = populatePrimaryContactToOpportunity(listOpps, oppAccountDetails);
+        Map<Id, List<Id>> primaryContactsToOpportunities = populatePrimaryContactToOpportunities(listOpps, oppAccountDetails);
+
+        // Retrieve the Account Ids for the Organizational Opportunities
+        Map<Id, List<Id>> accountsToOpportunities = populateAccountToOpportunities(listOpps, oppAccountDetails);
 
         //find changed opportunities and instantiate a map entry to hold OCRs
         for (integer i=0; i<listOpps.size(); i++) {
@@ -382,6 +396,13 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
                 List<sObject> relationshipOCRs
                     = OPP_AutomatedSoftCreditsService.createRelationshipOCRs(primaryContactsToOpportunities);
                 dmlWrapper.objectsToInsert.addAll(relationshipOCRs);
+            }
+
+            // Create Affiliation Soft Credits accordingly
+            if (!accountsToOpportunities.isEmpty()) {
+                List<sObject> affiliationOCRs
+                    = OPP_AutomatedSoftCreditsService.createAffiliationOCRs(accountsToOpportunities);
+                dmlWrapper.objectsToInsert.addAll(affiliationOCRs);
             }
         }
     }
@@ -602,7 +623,8 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
     * @param currentOpportunities The Opportunities in the 'new' trigger context variable.
     * @return Map<Id, Account> containing the AccountId to Account.
     **********************************************************************************************************/
-    public static  Map<Id, Account> populateAccountDetails (List<Opportunity> currentOpportunities) {
+    @testVisible
+    private static Map<Id, Account> populateAccountDetails (List<Opportunity> currentOpportunities) {
         Map<Id, Account> accountDetails = null;
         List<Id> accountIds = new List<Id>();
 
@@ -625,12 +647,13 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
 
 
     /*********************************************************************************************************
-    * @description Populates a Map of Primary Contact to Opportunity Id.
+    * @description Populates a Map of Primary Contact to Opportunity Ids.
     * @param currentOpportunities The Opportunities in the 'new' trigger context variable.
     * @param oppAccountDetails A Map containing the Opportunities' related Accounts.
     * @return Map<Id, List<Id>> contains associated Primary Contacts and Opportunity Ids.
     **********************************************************************************************************/
-    public static  Map<Id, List<Id>> populatePrimaryContactToOpportunity(List<Opportunity> currentOpportunities, Map<Id, Account> oppAccountDetails) {
+    @testVisible
+    private static Map<Id, List<Id>> populatePrimaryContactToOpportunities(List<Opportunity> currentOpportunities, Map<Id, Account> oppAccountDetails) {
         Map<Id, List<Id>> primaryContactToOpportunity = new Map<Id, List<Id>>();
 
         if (currentOpportunities.isEmpty()) {
@@ -651,6 +674,36 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         }
 
         return primaryContactToOpportunity;
+    }
+
+
+    /*********************************************************************************************************
+    * @description Populates a Map of Account Id to Opportunity Ids.
+    * @param currentOpportunities The Opportunities in the 'new' trigger context variable.
+    * @param oppAccountDetails A Map containing the Opportunities' related Accounts.
+    * @return Map<Id, Id> contains associated Primary Contacts and Opportunity Ids.
+    **********************************************************************************************************/
+    @testVisible
+    private static Map<Id, List<Id>> populateAccountToOpportunities(List<Opportunity> currentOpportunities, Map<Id, Account> oppAccountDetails) {
+        Map<Id, List<Id>> accountToOpportunity = new Map<Id, List<Id>>();
+
+        if (currentOpportunities.isEmpty()) {
+            return accountToOpportunity;
+        }
+
+        for (Opportunity eachOppty : currentOpportunities) {
+            if (eachOppty.AccountId != null
+                && !oppAccountDetails.get(eachOppty.AccountId).npe01__SYSTEMIsIndividual__c) {
+                if (accountToOpportunity.containsKey(eachOppty.AccountId)) {
+                    List<Id> opportunities = accountToOpportunity.get(eachOppty.AccountId);
+                    opportunities.add(eachOppty.Id);
+                } else {
+                    accountToOpportunity.put(eachOppty.AccountId, new List<Id>{ eachOppty.Id });
+                }
+            }
+        }
+
+        return accountToOpportunity;
     }
 
 

--- a/src/classes/OPP_OpportunityContactRoles_TEST.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TEST.cls
@@ -673,7 +673,7 @@ private class OPP_OpportunityContactRoles_TEST {
     *   The updated Opportunity's Primary Contact details are retrieved.
     * @return void
     *********************************************************************************************************/
-    static testMethod void testPopulatePrimaryContactToOpportunity() {
+    static testMethod void testPopulatePrimaryContactToOpportunities() {
         Map<Id, List<Id>> primaryContactToOpportunity = new Map<Id, List<Id>>();
         Map<Id, Account> accountDetails = new Map<Id, Account>();
 
@@ -689,7 +689,7 @@ private class OPP_OpportunityContactRoles_TEST {
 
         accountDetails = OPP_OpportunityContactRoles_TDTM.populateAccountDetails(testOpptys);
 
-        primaryContactToOpportunity = OPP_OpportunityContactRoles_TDTM.populatePrimaryContactToOpportunity(testOpptys, accountDetails);
+        primaryContactToOpportunity = OPP_OpportunityContactRoles_TDTM.populatePrimaryContactToOpportunities(testOpptys, accountDetails);
         Test.stopTest();
 
         System.assertEquals(5, primaryContactToOpportunity.size());
@@ -697,5 +697,41 @@ private class OPP_OpportunityContactRoles_TEST {
         System.assertEquals(testOpptys[3].Id, primaryContactToOpportunity.get(testContacts[3].Id)[0]);
     }
 
+
+    /*********************************************************************************************************
+    * @description Tests populating a Map of the Opportunity's associated Account Id to  Opportunity Ids.
+    * verify:
+    *   The Map was populated accordingly.
+    * @return void
+    *********************************************************************************************************/
+    static testMethod void testPopulateAccountToOpportunities() {
+        Map<Id, List<Id>> accountToOpportunity = new Map<Id, List<Id>>();
+        Map<Id, Account> accountDetails = new Map<Id, Account>();
+        List<Account> testAccounts = new List<Account>();
+
+        List<Contact> testContacts = UTIL_UnitTestData_TEST.CreateMultipleTestContacts(5);
+        insert testContacts;
+        testContacts = [SELECT Id, AccountId, FirstName, LastName FROM Contact];
+
+        List<Opportunity> testOpptys = UTIL_UnitTestData_TEST.OppsForContactWithAccountList(testContacts, null, UTIL_UnitTestData_TEST.getClosedWonStage(),
+                                                                                            System.today(), 100, null, null);
+
+        Test.startTest();
+        insert testOpptys;
+
+        accountDetails = OPP_OpportunityContactRoles_TDTM.populateAccountDetails(testOpptys);
+        for (Account eachAccount : accountDetails.values()) {
+            eachAccount.npe01__SYSTEMIsIndividual__c = false;
+            testAccounts.add(eachAccount);
+        }
+        update testAccounts;
+
+        accountToOpportunity = OPP_OpportunityContactRoles_TDTM.populateAccountToOpportunities(testOpptys, accountDetails);
+        Test.stopTest();
+
+        System.assertEquals(5, accountToOpportunity.size());
+        System.assertEquals(testOpptys[0].Id, accountToOpportunity.get(testContacts[0].AccountId)[0]);
+        System.assertEquals(testOpptys[3].Id, accountToOpportunity.get(testContacts[3].AccountId)[0]);
+    }
 
 }

--- a/src/objects/npe5__Affiliation__c.object
+++ b/src/objects/npe5__Affiliation__c.object
@@ -7,4 +7,30 @@
         <fields>npe5__Contact__c</fields>
         <label>NPSP Affiliation Compact Layout</label>
     </compactLayouts>
+    <fields>
+        <fullName>Related_Opportunity_Contact_Role__c</fullName>
+        <description>The Opportunity Contact Role created for the Contact in this Affiliation when you create an Opportunity for the Organization.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The Opportunity Contact Role created for the Contact in this Affiliation when you create an Opportunity for the Organization.</inlineHelpText>
+        <label>Related Opportunity Contact Role</label>
+        <picklist>
+            <picklistValues>
+                <fullName>Soft Credit</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>Solicitor</fullName>
+                <default>false</default>
+            </picklistValues>
+            <picklistValues>
+                <fullName>Matching Gift</fullName>
+                <default>false</default>
+            </picklistValues>
+            <sorted>false</sorted>
+        </picklist>
+        <required>false</required>
+        <trackFeedHistory>false</trackFeedHistory>
+        <trackTrending>false</trackTrending>
+        <type>Picklist</type>
+    </fields>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -886,6 +886,7 @@
         <members>npe03__Recurring_Donations_Settings__c.Recurring_Donation_Batch_Size__c</members>
         <members>npe4__Relationship__c.Related_Opportunity_Contact_Role__c</members>
         <members>npe4__Relationship_Settings__c.Enable_Custom_Field_Sync__c</members>
+        <members>npe5__Affiliation__c.Related_Opportunity_Contact_Role__c</members>
         <members>npo02__Household__c.Number_of_Household_Members__c</members>
         <members>npo02__Households_Settings__c.Matched_Donor_Role__c</members>
         <name>CustomField</name>


### PR DESCRIPTION
Implemented functionality that allows a data entry user to define which specific Affiliation records should receive OCRs when an Opportunity is created. Work Item #: W-009097.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
