### PR TITLE
CRLP-related pagemessages in NPSP Settings

### DIFF
--- a/src/classes/STG_PanelCustomizableRollup_CTRL.cls
+++ b/src/classes/STG_PanelCustomizableRollup_CTRL.cls
@@ -82,21 +82,6 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
     public String jobId { get; private set; }
 
     /*******************************************************************************************************
-    * @description action method run on page load to check account model and admin status of running user
-    * and add pagemessages as needed
-    */
-    public void checkPermissions() {
-        // throw an error if the org isn't on HH account model
-        if (!isHHAccount) {
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, Label.stgCRLPHouseholdAccountError));
-        }
-        // throw an error if the user isn't an admin
-        if (!isAdmin) {
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, Label.stgCRLPNonAdminError));
-        }
-    }
-
-    /*******************************************************************************************************
     * @description Overridden Action Method to kick off CMDT deployment, save custom setting,
     * and reschedule Scheduled Jobs
     * @return void

--- a/src/classes/STG_PanelTDTM_CTRL.cls
+++ b/src/classes/STG_PanelTDTM_CTRL.cls
@@ -106,9 +106,6 @@ public with sharing class STG_PanelTDTM_CTRL extends STG_Panel {
     * @return PageReference The page that it redirects to. Same page user was in, in this case.
     */
     public PageReference addPageMessages() {
-        // Display standard warning message
-        ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Warning, Label.stgHelpTriggerHandlers));
-
         // Display message if any async classes
         boolean hasAsync = false;
         List<Trigger_Handler__c> listTHDefault = TDTM_DefaultConfig.getDefaultRecords();

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -924,7 +924,6 @@ public with sharing class STG_SettingsManager_TEST {
         System.assertEquals(false, ApexPages.hasMessages());
         System.assert(panel.isHHAccount);
         System.assert(panel.isAdmin);
-        panel.checkPermissions();
         System.assertEquals(false, ApexPages.hasMessages());
         STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c = true;
         panel.saveSettings();

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4847,6 +4847,29 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>You must be using the Household Account Model in order to use Customizable Rollups.</value>
     </labels>
     <labels>
+        <fullName>stgCRLPInfoOnUDRBody</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>stgCRLPInfoOnUDRBody</shortDescription>
+        <value>Customizable Rollups offer all the functionality of User Defined Rollups and so much more:&lt;br/&gt;
+            &lt;br/&gt;
+            ● Roll up Payments in addition to Opportunities&lt;br/&gt;
+            ● Use filters to easily exclude certain records or data&lt;br/&gt;
+            ● Roll up data for more than 2 years back&lt;br/&gt;
+            &lt;br/&gt;
+            Go to NPSP Settings | Donations | Customizable Rollups to enable Customizable Rollups and get started using them!
+        </value>
+    </labels>
+    <labels>
+        <fullName>stgCRLPInfoOnUDRHeading</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>stgCRLPInfoOnUDRHeading</shortDescription>
+        <value>Why not try Customizable Rollups instead?</value>
+    </labels>
+    <labels>
         <fullName>stgCRLPNonAdminError</fullName>
         <categories>Settings</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1615,6 +1615,8 @@
         <members>stgBtnRunBatch</members>
         <members>stgBtnSave</members>
         <members>stgCRLPHouseholdAccountError</members>
+        <members>stgCRLPInfoOnUDRBody</members>
+        <members>stgCRLPInfoOnUDRHeading</members>
         <members>stgCRLPNonAdminError</members>
         <members>stgCheckboxFalse</members>
         <members>stgCheckboxTrue</members>

--- a/src/pages/STG_PanelCustomizableRollup.page
+++ b/src/pages/STG_PanelCustomizableRollup.page
@@ -12,12 +12,11 @@
                     </p>
                 </div>
             </div>
-            <c:UTIL_PageMessages id="messages"/>
+            <c:UTIL_PageMessages allowClose="false" id="messages"/>
 
             <apex:outputPanel rendered="{! !isHHAccount }">
                 <div class="slds" id="page_messages">
                     <div role="alert" class="slds-notify slds-notify_toast slds-notify--toast slds-theme_error slds-theme--error">
-
                         <div class="notify__content">
                             <div class="slds-media">
                                 <div class="slds-media__figure">
@@ -39,11 +38,9 @@
                 </div>
             </apex:outputPanel>
 
-
             <apex:outputPanel rendered="{! !isAdmin }">
                 <div class="slds" id="page_messages">
                     <div role="alert" class="slds-notify slds-notify_toast slds-notify--toast slds-theme_error slds-theme--error">
-
                         <div class="notify__content">
                             <div class="slds-media">
                                 <div class="slds-media__figure">

--- a/src/pages/STG_PanelCustomizableRollup.page
+++ b/src/pages/STG_PanelCustomizableRollup.page
@@ -1,4 +1,4 @@
-<apex:page controller="STG_PanelCustomizableRollup_CTRL" action="{!checkPermissions}"  >
+<apex:page controller="STG_PanelCustomizableRollup_CTRL" >
 
     <apex:slds/>
     <div class="slds-scope">
@@ -12,7 +12,58 @@
                     </p>
                 </div>
             </div>
-            <c:UTIL_PageMessages allowClose="false" id="messages"/>
+            <c:UTIL_PageMessages id="messages"/>
+
+            <apex:outputPanel rendered="{! !isHHAccount }">
+                <div class="slds" id="page_messages">
+                    <div role="alert" class="slds-notify slds-notify_toast slds-notify--toast slds-theme_error slds-theme--error">
+
+                        <div class="notify__content">
+                            <div class="slds-media">
+                                <div class="slds-media__figure">
+                                    <apex:outputText>
+                                        <svg class="slds-icon" aria-hidden="true" viewBox="0 0 24 24">
+                                            <path d="M12 .9C5.9.9.9 5.9.9 12s5 11.1 11.1 11.1 11.1-5 11.1-11.1S18.1.9 12 .9zm0 19.4c-4.6 0-8.3-3.7-8.3-8.3S7.4 3.7 12 3.7s8.3 3.7 8.3 8.3-3.7 8.3-8.3 8.3zm4.8-9.7H7.2c-.4 0-.6.3-.7.6v1.6c.1.4.3.6.7.6h9.6c.4 0 .6-.3.7-.6v-1.6c-.1-.3-.3-.6-.7-.6z" />
+                                        </svg>
+                                    </apex:outputText>
+                                </div>
+                                <div class="slds-media__body">
+                                    <h2 class="slds-text-heading_small slds-text-heading--small">
+                                        <apex:outputText value="{!$Label.PageMessagesError}: " />
+                                        <apex:outputText value="{!$Label.stgCRLPHouseholdAccountError}"/>
+                                    </h2>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </apex:outputPanel>
+
+
+            <apex:outputPanel rendered="{! !isAdmin }">
+                <div class="slds" id="page_messages">
+                    <div role="alert" class="slds-notify slds-notify_toast slds-notify--toast slds-theme_error slds-theme--error">
+
+                        <div class="notify__content">
+                            <div class="slds-media">
+                                <div class="slds-media__figure">
+                                    <apex:outputText>
+                                        <svg class="slds-icon" aria-hidden="true" viewBox="0 0 24 24">
+                                            <path d="M12 .9C5.9.9.9 5.9.9 12s5 11.1 11.1 11.1 11.1-5 11.1-11.1S18.1.9 12 .9zm0 19.4c-4.6 0-8.3-3.7-8.3-8.3S7.4 3.7 12 3.7s8.3 3.7 8.3 8.3-3.7 8.3-8.3 8.3zm4.8-9.7H7.2c-.4 0-.6.3-.7.6v1.6c.1.4.3.6.7.6h9.6c.4 0 .6-.3.7-.6v-1.6c-.1-.3-.3-.6-.7-.6z" />
+                                        </svg>
+                                    </apex:outputText>
+                                </div>
+                                <div class="slds-media__body">
+                                    <h2 class="slds-text-heading_small slds-text-heading--small">
+                                        <apex:outputText value="{!$Label.PageMessagesError}: " />
+                                        <apex:outputText value="{!$Label.stgCRLPNonAdminError}"/>
+                                    </h2>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </apex:outputPanel>
 
             <div class="slds-card {!IF(isPolling,'','slds-hide')}">
                 <div class="slds-col slds-size--1-of-1 slds-m-around--medium">

--- a/src/pages/STG_PanelTDTM.page
+++ b/src/pages/STG_PanelTDTM.page
@@ -8,7 +8,7 @@
         <div class="slds-m-around--x-large">
             <c:STG_PageHeader sectionLabel="{!$Label.stgNavSystem}" pageLabel="{!$Label.stgNavTriggerConfig}" />
             <div class="slds-text-body--small slds-m-around--medium"><apex:outputText value="{!$Label.stgHelpTDTM}" /></div>
-            <c:UTIL_PageMessages />
+            <c:UTIL_PageMessages allowClose="false"/>
             <div class="slds-grid slds-grid--align-center slds-grid--vertical-align-center slds-m-around--large">
                 <apex:commandButton id="newTriggerHandler" value="{!$Label.stgBtnNewTH}" action="{!newTh}" status="statusLoad" rendered="{!isReadOnlyMode}" immediate="true" rerender="form" styleClass="slds-button slds-button--small slds-button--neutral" />
             </div>

--- a/src/pages/STG_PanelTDTM.page
+++ b/src/pages/STG_PanelTDTM.page
@@ -9,6 +9,29 @@
             <c:STG_PageHeader sectionLabel="{!$Label.stgNavSystem}" pageLabel="{!$Label.stgNavTriggerConfig}" />
             <div class="slds-text-body--small slds-m-around--medium"><apex:outputText value="{!$Label.stgHelpTDTM}" /></div>
             <c:UTIL_PageMessages allowClose="false"/>
+
+            <div class="slds" id="page_messages">
+                <div role="alert" class="slds-notify slds-notify_toast slds-notify--toast slds-theme_warning slds-theme--warning">
+                    <div class="notify__content">
+                        <div class="slds-media">
+                            <div class="slds-media__figure">
+                                <apex:outputText>
+                                    <svg class="slds-icon" aria-hidden="true" viewBox="0 0 24 24">
+                                        <path  d="M23.7 19.6L13.2 2.5c-.6-.9-1.8-.9-2.4 0L.3 19.6c-.7 1.1 0 2.6 1.1 2.6h21.2c1.1 0 1.8-1.5 1.1-2.6zM12 18.5c-.8 0-1.4-.6-1.4-1.4s.6-1.4 1.4-1.4 1.4.6 1.4 1.4-.6 1.4-1.4 1.4zm1.4-4.2c0 .3-.2.5-.5.5h-1.8c-.3 0-.5-.2-.5-.5v-6c0-.3.2-.5.5-.5h1.8c.3 0 .5.2.5.5v6z"/>
+                                    </svg>
+                                </apex:outputText>
+                            </div>
+                            <div class="slds-media__body">
+                                <h2 class="slds-text-heading_small slds-text-heading--small">
+                                    <apex:outputText value="{!$Label.PageMessagesWarning}: " />
+                                    <apex:outputText value="{!$Label.stgHelpTriggerHandlers}"/>
+                                </h2>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="slds-grid slds-grid--align-center slds-grid--vertical-align-center slds-m-around--large">
                 <apex:commandButton id="newTriggerHandler" value="{!$Label.stgBtnNewTH}" action="{!newTh}" status="statusLoad" rendered="{!isReadOnlyMode}" immediate="true" rerender="form" styleClass="slds-button slds-button--small slds-button--neutral" />
             </div>

--- a/src/pages/STG_PanelUserRollup.page
+++ b/src/pages/STG_PanelUserRollup.page
@@ -7,6 +7,29 @@
             </div>        
         </div>
         <c:UTIL_PageMessages />
+
+        <div class="slds" id="page_messages">
+            <div role="alert" class="slds-notify slds-notify_toast slds-notify--toast slds-theme_info slds-theme--info">
+                <div class="notify__content">
+                    <div class="slds-media">
+                        <div class="slds-media__figure">
+                            <apex:outputText>
+                                <svg class="slds-icon" aria-hidden="true" viewBox="0 0 24 24">
+                                    <path  d="M12 .9C5.9.9.9 5.9.9 12s5 11.1 11.1 11.1 11.1-5 11.1-11.1S18.1.9 12 .9zm0 5.6c.8 0 1.4.6 1.4 1.4s-.6 1.4-1.4 1.4-1.4-.6-1.4-1.4.6-1.4 1.4-1.4zm2.3 9.7c0 .2-.2.4-.5.4h-3.6c-.3 0-.5-.1-.5-.4v-.9c0-.3.2-.5.5-.5.2 0 .4-.2.4-.4v-1.9c0-.2-.2-.5-.4-.5-.3 0-.5-.1-.5-.4v-.9c0-.3.2-.5.5-.5h2.7c.3 0 .5.2.5.5v3.7c0 .2.2.4.4.4.3 0 .5.2.5.5v.9z"/>
+                                </svg>
+                            </apex:outputText>
+                        </div>
+                        <div class="slds-media__body">
+                            <h2 class="slds-text-heading_small slds-text-heading--small">
+                                <apex:outputText value="{!$Label.stgCRLPInfoOnUDRHeading}" escape="true"/>
+                            </h2>
+                            <apex:outputText styleClass="slds-m-top_medium slds-m-top--medium" value="{!$Label.stgCRLPInfoOnUDRBody}" escape="false"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="slds-grid slds-grid--align-center slds-grid--vertical-align-center slds-m-around--large">
             <apex:commandButton id="newUDR" value="{!$Label.stgBtnNewUDR}" action="{!startBuild}" status="statusLoad" rendered="{!isReadOnlyMode}" immediate="true" rerender="form" styleClass="slds-button slds-button--small slds-button--neutral" />
         </div>


### PR DESCRIPTION
# Critical Changes

# Changes
- Added info message to UDR page to suggest they look at CRLPs instead
- Re-implemented CRLP Enablement page messages to not use apex:pagemessages
- Fixed TDTM pagemessage to not display close X, which was incorrectly reloading all of NPSP Settings.

# Issues Closed

# New Metadata

# Deleted Metadata
