### PR TITLE
Rollups: Add recalculate button to the Household & Contact page layouts

### DIFF
--- a/src/layouts/Account-Household Layout.layout
+++ b/src/layouts/Account-Household Layout.layout
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <customButtons>Manage_Household</customButtons>
+    <customButtons>Recalculate_Rollups</customButtons>
     <excludeButtons>DataDotComAccountInsights</excludeButtons>
     <excludeButtons>DataDotComCompanyHierarchy</excludeButtons>
     <excludeButtons>IncludeOffline</excludeButtons>

--- a/src/layouts/Contact-Contact Layout.layout
+++ b/src/layouts/Contact-Contact Layout.layout
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <customButtons>npe4__Relationships_Viewer</customButtons>
+    <customButtons>Recalculate_Rollups</customButtons>
     <excludeButtons>Clone</excludeButtons>
     <excludeButtons>DataDotComClean</excludeButtons>
     <excludeButtons>DisableCustomerPortal</excludeButtons>


### PR DESCRIPTION
# Critical Changes

# Changes

* The buttons have been there for a while, but where never added to these 2 layouts in the repository.
* The button was already added to the GAU layout in the repo
* The release notes and docs will need to note that existing customers must manually add the button to their Account, Contact and GAU layouts because layout changes are never pushed in a package upgrade.

# Issues Closed

# New Metadata

# Deleted Metadata
