### PR TITLE
Changing Manage PSC page to display all OCR Roles

### DIFF
--- a/src/classes/PSC_ManageSoftCredits_CTRL.cls
+++ b/src/classes/PSC_ManageSoftCredits_CTRL.cls
@@ -128,10 +128,15 @@ public with sharing class PSC_ManageSoftCredits_CTRL {
         
         Map<Id, SoftCredit> ocrs = new Map<Id, SoftCredit>();
         softCredits = new List<SoftCredit>();
-        set<String> softCreditRoles = new set<String>();
-        if (UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Soft_Credit_Roles__c != null)
-            softCreditRoles = new set<String>(UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Soft_Credit_Roles__c.split(';'));
-        
+        Set<String> softCreditRoles = new Set<String>();
+        if (UTIL_CustomSettingsFacade.getCustomizableRollupSettings().Customizable_Rollups_Enabled__c) {
+            for(Schema.PicklistEntry pe : Schema.sObjectType.OpportunityContactRole.fields.Role.getPicklistValues()) {
+                softCreditRoles.add(pe.getLabel());
+            }
+        } else if (UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Soft_Credit_Roles__c != null) {
+            softCreditRoles = new Set<String>(UTIL_CustomSettingsFacade.getHouseholdsSettings().npo02__Soft_Credit_Roles__c.split(';'));
+        }
+
         // get all OCR's for the Opp
         map<Id, OpportunityContactRole> mapIdToOCR = new map<Id, OpportunityContactRole>([SELECT Id, ContactId, Role, 
             IsPrimary, Opportunity.Amount FROM OpportunityContactRole WHERE OpportunityId = :opp.Id]);


### PR DESCRIPTION
... when customizable rollups are enabled, since the Soft Credit Roles setting is no longer maintained.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
