### PR TITLE
Rollups: Fixes for Inactive Rollup and a Rollup no assigned FilterGroup

### DIFF
--- a/src/classes/CRLP_Query_SEL.cls
+++ b/src/classes/CRLP_Query_SEL.cls
@@ -297,13 +297,19 @@
         }
 
         // Get a list of the applied FilterGroupId's
+        Boolean hasRollupWithNoFilter = false;
         Set<Id> filterGroupIds = new Set<Id>();
         for (Rollup__mdt r : rollups) {
+            if (r.Filter_Group__c == null) {
+                hasRollupWithNoFilter = true;
+                break;
+            }
             filterGroupIds.add(r.Filter_Group__c);
         }
 
-        // If there are not rollups or no filter groups, just exit out
-        if (filterGroupIds.size() == 0) {
+        // If there are no rollups, no filter groups, or at least one rollup that is not using a filter group
+        // just exit out because there is no common filter that can be built for this set.
+        if (hasRollupWithNoFilter || filterGroupIds.size() == 0) {
             return '';
         }
 

--- a/src/classes/CRLP_Rollup_SEL.cls
+++ b/src/classes/CRLP_Rollup_SEL.cls
@@ -299,7 +299,9 @@ public class CRLP_Rollup_SEL {
             // Rollup Type Job AND the Type Filter if there is one.
             for (Rollup__mdt r : rlps) {
                 Boolean includeRollupDefinition=false;
-                if (rollupType == CRLP_RollupProcessingOptions.RollupType.AccountHardCredit ||
+                if (r.Is_Deleted__c == true || r.Active__c == false) {
+                    // ignore deleted or inactive rollups
+                } else if (rollupType == CRLP_RollupProcessingOptions.RollupType.AccountHardCredit ||
                         rollupType == CRLP_RollupProcessingOptions.RollupType.ContactHardCredit) {
                     includeRollupDefinition = ((r.Detail_Object__r.QualifiedApiName == oppObjectName || r.Detail_Object__r.QualifiedApiName == pmtObjectName)
                             && r.Amount_Object__r.QualifiedApiName != pscObjectName);


### PR DESCRIPTION
# Critical Changes

# Changes

* If the Rollup__mdt.Active__c field is false, exclude the rollup from the list of Rollups to process by any of the rollup jobs. This is needed because InActive records are actually queried so they're available for the UI.
* Ignore null filter group Id when building a common where clause to use. In addition, if there is a rollup that has no filter group don't bother attempting to build a common where clause because all records need to be considered.

# Issues Closed

# New Metadata

# Deleted Metadata
