### PR TITLE
Rollup enablement page fix

### DIFF
--- a/src/classes/STG_PanelCustomizableRollup_CTRL.cls
+++ b/src/classes/STG_PanelCustomizableRollup_CTRL.cls
@@ -89,24 +89,18 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
     public virtual override PageReference saveSettings() {
 
         STG_SettingsManager_CTRL.idPanelCurrent = idPanel();
-        Customizable_Rollup_Settings__c crlpSettings = UTIL_CustomSettingsFacade.getCustomizableRollupSettings();
         Savepoint sp = Database.setSavepoint();
         isEditMode = false;
         try {
             if (STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c) {
-                String oldStatus = STG_Panel.stgService.stgCRLP.CMT_API_Status__c;
-                // Only start polling if it's their first time or the last deployment wasn't a success
-                if(String.isEmpty(oldStatus) || !oldStatus.contains('Succeeded')) {
-                    isPolling = true;
-                }
-                // This method includes committing Customizable_Rollups_Enabled__c as true if the deployment succeeds
+                isPolling = true;
                 jobId = CRLP_DefaultConfigBuilder_SVC.convertLegacyRollupsIntoCustomizableRollups();
                 if (Test.isRunningTest()) {
                     jobId = '123';
                 }
             } else {
                 // The deployment method takes care of setting the Enabled flag to true if it succeeds.
-                // In here, we only set it to false.
+                // In here, we only set it to false in the case on disabling CRLPs.
                 stgService.saveAll();
             }
             UTIL_MasterSchedulableHelper.setScheduledJobs();
@@ -115,6 +109,7 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
             ERR_Handler.processError(e, ERR_Handler_API.Context.STTG);
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, e.getMessage()));
             isPolling = false;
+            Customizable_Rollup_Settings__c crlpSettings = UTIL_CustomSettingsFacade.getCustomizableRollupSettings();
             crlpSettings.Customizable_Rollups_Enabled__c = !STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c;
         }
         return null;

--- a/src/classes/STG_PanelCustomizableRollup_CTRL.cls
+++ b/src/classes/STG_PanelCustomizableRollup_CTRL.cls
@@ -82,6 +82,23 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
     public String jobId { get; private set; }
 
     /*******************************************************************************************************
+    * @description the existing value of the CRLP enablement setting, cached upon entering edit mode
+    */
+    private Boolean cachedSetting;
+
+    /*******************************************************************************************************
+    * @description Overridden Action Method to put the current page into Edit mode and cache the existing setting
+    * @return null
+    */
+    public virtual override PageReference editSettings() {
+        STG_SettingsManager_CTRL.idPanelCurrent = idPanel();
+        // cache the status of CRLP settings upon entering edit mode so we can check for no change
+        cachedSetting = UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings().Customizable_Rollups_Enabled__c;
+        isEditMode = true;
+        return null;
+    }
+
+    /*******************************************************************************************************
     * @description Overridden Action Method to kick off CMDT deployment, save custom setting,
     * and reschedule Scheduled Jobs
     * @return void
@@ -89,28 +106,40 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
     public virtual override PageReference saveSettings() {
 
         STG_SettingsManager_CTRL.idPanelCurrent = idPanel();
-        Savepoint sp = Database.setSavepoint();
         isEditMode = false;
-        try {
-            if (STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c) {
-                isPolling = true;
-                jobId = CRLP_DefaultConfigBuilder_SVC.convertLegacyRollupsIntoCustomizableRollups();
-                if (Test.isRunningTest()) {
-                    jobId = '123';
+
+        Boolean settingHasChanged = (cachedSetting != STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c);
+
+        if (settingHasChanged) {
+            // we only proceed with deployment/save if they changed the checkbox.
+
+            // if they hit edit and then they immediately hit save,
+            // we do NOT want to reset their CRLP customizations (if both were true)
+            // or run extraneous code (if both were false) so in that case we do nothing.
+            // they have essentially hit cancel.
+
+            Savepoint sp = Database.setSavepoint();
+            try {
+                if (STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c) {
+                    isPolling = true;
+                    jobId = CRLP_DefaultConfigBuilder_SVC.convertLegacyRollupsIntoCustomizableRollups();
+                    if (Test.isRunningTest()) {
+                        jobId = '123';
+                    }
+                } else {
+                    // The deployment method takes care of setting the Enabled flag to true if it succeeds.
+                    // In here, we only set it to false in the case on disabling CRLPs.
+                    stgService.saveAll();
                 }
-            } else {
-                // The deployment method takes care of setting the Enabled flag to true if it succeeds.
-                // In here, we only set it to false in the case on disabling CRLPs.
-                stgService.saveAll();
+                UTIL_MasterSchedulableHelper.setScheduledJobs();
+            } catch (Exception e) {
+                Database.rollback(sp);
+                ERR_Handler.processError(e, ERR_Handler_API.Context.STTG);
+                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, e.getMessage()));
+                isPolling = false;
+                Customizable_Rollup_Settings__c crlpSettings = UTIL_CustomSettingsFacade.getCustomizableRollupSettings();
+                crlpSettings.Customizable_Rollups_Enabled__c = !STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c;
             }
-            UTIL_MasterSchedulableHelper.setScheduledJobs();
-        } catch (Exception e) {
-            Database.rollback(sp);
-            ERR_Handler.processError(e, ERR_Handler_API.Context.STTG);
-            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, e.getMessage()));
-            isPolling = false;
-            Customizable_Rollup_Settings__c crlpSettings = UTIL_CustomSettingsFacade.getCustomizableRollupSettings();
-            crlpSettings.Customizable_Rollups_Enabled__c = !STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c;
         }
         return null;
     }

--- a/src/classes/STG_PanelCustomizableRollup_CTRL.cls
+++ b/src/classes/STG_PanelCustomizableRollup_CTRL.cls
@@ -84,7 +84,7 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
     /*******************************************************************************************************
     * @description the existing value of the CRLP enablement setting, cached upon entering edit mode
     */
-    private Boolean cachedSetting;
+    private Boolean isCRLPenabledPrevious;
 
     /*******************************************************************************************************
     * @description Overridden Action Method to put the current page into Edit mode and cache the existing setting
@@ -93,7 +93,7 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
     public virtual override PageReference editSettings() {
         STG_SettingsManager_CTRL.idPanelCurrent = idPanel();
         // cache the status of CRLP settings upon entering edit mode so we can check for no change
-        cachedSetting = UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings().Customizable_Rollups_Enabled__c;
+        isCRLPenabledPrevious = UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings().Customizable_Rollups_Enabled__c;
         isEditMode = true;
         return null;
     }
@@ -108,14 +108,14 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
         STG_SettingsManager_CTRL.idPanelCurrent = idPanel();
         isEditMode = false;
 
-        Boolean settingHasChanged = (cachedSetting != STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c);
+        Boolean settingHasChanged = (isCRLPenabledPrevious != STG_Panel.stgService.stgCRLP.Customizable_Rollups_Enabled__c);
 
         if (settingHasChanged) {
             // we only proceed with deployment/save if they changed the checkbox.
 
-            // if they hit edit and then they immediately hit save,
-            // we do NOT want to reset their CRLP customizations (if both were true)
-            // or run extraneous code (if both were false) so in that case we do nothing.
+            // if they hit edit and then they hit save without changing the setting checkbox,
+            // we do NOT want to reset their CRLP customizations (if the box was/is true)
+            // or run extraneous code (if the box was/is false) so in that case we do nothing.
             // they have essentially hit cancel.
 
             Savepoint sp = Database.setSavepoint();
@@ -130,8 +130,9 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
                     // The deployment method takes care of setting the Enabled flag to true if it succeeds.
                     // In here, we only set it to false in the case on disabling CRLPs.
                     stgService.saveAll();
+                    // reset to legacy jobs
+                    UTIL_MasterSchedulableHelper.setScheduledJobs();
                 }
-                UTIL_MasterSchedulableHelper.setScheduledJobs();
             } catch (Exception e) {
                 Database.rollback(sp);
                 ERR_Handler.processError(e, ERR_Handler_API.Context.STTG);
@@ -165,6 +166,8 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
         if(!String.isEmpty(newStatus) && newStatus.contains(jobId)){
             isPolling = false;
             if (newStatus.contains('Succeeded')) {
+                // reset to CRLP jobs
+                UTIL_MasterSchedulableHelper.setScheduledJobs();
                 return null;
             } else {
                 crlpSettings.Customizable_Rollups_Enabled__c = false;

--- a/src/pages/STG_PanelAllocations.page
+++ b/src/pages/STG_PanelAllocations.page
@@ -23,44 +23,46 @@
             <apex:commandButton id="editAllo" value="{!$Label.stgBtnEdit}" status="statusLoad" action="{!editSettings}" rendered="{!isReadOnlyMode}" immediate="true" rerender="form" styleClass="slds-button slds-button--small slds-button--neutral" />
         </div>
         <c:UTIL_PageMessages />
-        <div class="slds-section-title--divider" >{!$Label.stgLabelAllocationsRollupSettings}</div>
-        <div class="slds-form--horizontal">
-            <div class="slds-form-element">
-                <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Excluded_Opp_RecTypes__c.Label}" for="idDBMS" styleClass="slds-form-element__label" />
-                <div class="slds-form-element__control">
-                    <c:STG_DataBoundMultiSelect settingObject="{!stgService.stgAllo}" fieldname="Excluded_Opp_RecTypes__c" listSO="{!listSOOppRecTypesIds}" strValuesOverride="{!strExcludedOppRecTypesReadOnly}" inEditMode="{!isEditMode}" />
-                    <apex:outputPanel id="idDBMSHelp" layout="block">
-                        <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpRollupExcludeAlloOppRecType}" />
-                    </apex:outputPanel>
+        <div style="{!IF(!stgService.stgCRLP.Customizable_Rollups_Enabled__c, 'display:block', 'display:none')}">
+            <div class="slds-section-title--divider" >{!$Label.stgLabelAllocationsRollupSettings}</div>
+            <div class="slds-form--horizontal">
+                <div class="slds-form-element">
+                    <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Excluded_Opp_RecTypes__c.Label}" for="idDBMS" styleClass="slds-form-element__label" />
+                    <div class="slds-form-element__control">
+                        <c:STG_DataBoundMultiSelect settingObject="{!stgService.stgAllo}" fieldname="Excluded_Opp_RecTypes__c" listSO="{!listSOOppRecTypesIds}" strValuesOverride="{!strExcludedOppRecTypesReadOnly}" inEditMode="{!isEditMode}" />
+                        <apex:outputPanel id="idDBMSHelp" layout="block">
+                            <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpRollupExcludeAlloOppRecType}" />
+                        </apex:outputPanel>
+                    </div>
                 </div>
-            </div>
-            <div class="slds-form-element">
-                <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Excluded_Opp_Types__c.Label}" for="idDBMS" styleClass="slds-form-element__label" />
-                <div class="slds-form-element__control">
-                    <c:STG_DataBoundMultiSelect settingObject="{!stgService.stgAllo}" fieldname="Excluded_Opp_Types__c" listSO="{!listSOOppTypes}" inEditMode="{!isEditMode}" />
-                    <apex:outputPanel layout="block">
-                        <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpRollupExcludeAlloOppType}" />
-                    </apex:outputPanel>
+                <div class="slds-form-element">
+                    <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Excluded_Opp_Types__c.Label}" for="idDBMS" styleClass="slds-form-element__label" />
+                    <div class="slds-form-element__control">
+                        <c:STG_DataBoundMultiSelect settingObject="{!stgService.stgAllo}" fieldname="Excluded_Opp_Types__c" listSO="{!listSOOppTypes}" inEditMode="{!isEditMode}" />
+                        <apex:outputPanel layout="block">
+                            <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpRollupExcludeAlloOppType}" />
+                        </apex:outputPanel>
+                    </div>
                 </div>
-            </div>
-            <div class="slds-form-element">
-                <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Rollup_N_Day_Value__c.Label}" for="tbxRNDV" styleClass="slds-form-element__label" />
-                <div class="slds-form-element__control">
-                    <apex:outputField value="{!stgService.stgAllo.Rollup_N_Day_Value__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                    <apex:inputfield value="{!stgService.stgAllo.Rollup_N_Day_Value__c}" type="number" rendered="{!isEditMode}" id="tbxRNDV" html-aria-describedby="{!$Component.tbxRNDVHelp}" styleClass="slds-input" />
-                    <apex:outputPanel id="tbxRNDVHelp" layout="block">
-                        <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpAlloNDayValue}" />
-                    </apex:outputPanel>
+                <div class="slds-form-element">
+                    <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Rollup_N_Day_Value__c.Label}" for="tbxRNDV" styleClass="slds-form-element__label" />
+                    <div class="slds-form-element__control">
+                        <apex:outputField value="{!stgService.stgAllo.Rollup_N_Day_Value__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                        <apex:inputfield value="{!stgService.stgAllo.Rollup_N_Day_Value__c}" type="number" rendered="{!isEditMode}" id="tbxRNDV" html-aria-describedby="{!$Component.tbxRNDVHelp}" styleClass="slds-input" />
+                        <apex:outputPanel id="tbxRNDVHelp" layout="block">
+                            <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpAlloNDayValue}" />
+                        </apex:outputPanel>
+                    </div>
                 </div>
-            </div>
-            <div class="slds-form-element">
-                <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Use_Fiscal_Year_for_Rollups__c.Label}" for="cbxUFYFR" styleClass="slds-form-element__label" />
-                <div class="slds-form-element__control">
-                    <apex:inputCheckbox value="{!stgService.stgAllo.Use_Fiscal_Year_for_Rollups__c}" rendered="{!isEditMode}" id="cbxUFYFR" html-aria-describedby="{!$Component.cbxUFYFRHelp}" styleClass="slds-checkbox" />
-                    <apex:inputCheckbox value="{!stgService.stgAllo.Use_Fiscal_Year_for_Rollups__c}" rendered="{!isReadOnlyMode}" disabled="true" id="cbxUFYFRO" html-aria-describedby="{!$Component.cbxUFYFRHelp}" styleClass="slds-checkbox" />
-                    <apex:outputPanel id="cbxUFYFRHelp" layout="block">
-                        <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpAlloFiscalYearRollups}" />
-                    </apex:outputPanel>
+                <div class="slds-form-element">
+                    <apex:outputLabel value="{!$ObjectType.Allocations_Settings__c.Fields.Use_Fiscal_Year_for_Rollups__c.Label}" for="cbxUFYFR" styleClass="slds-form-element__label" />
+                    <div class="slds-form-element__control">
+                        <apex:inputCheckbox value="{!stgService.stgAllo.Use_Fiscal_Year_for_Rollups__c}" rendered="{!isEditMode}" id="cbxUFYFR" html-aria-describedby="{!$Component.cbxUFYFRHelp}" styleClass="slds-checkbox" />
+                        <apex:inputCheckbox value="{!stgService.stgAllo.Use_Fiscal_Year_for_Rollups__c}" rendered="{!isReadOnlyMode}" disabled="true" id="cbxUFYFRO" html-aria-describedby="{!$Component.cbxUFYFRHelp}" styleClass="slds-checkbox" />
+                        <apex:outputPanel id="cbxUFYFRHelp" layout="block">
+                            <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpAlloFiscalYearRollups}" />
+                        </apex:outputPanel>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/pages/STG_PanelCustomizableRollup.page
+++ b/src/pages/STG_PanelCustomizableRollup.page
@@ -80,7 +80,7 @@
             <div class="{!IF(isHHAccount, '', 'slds-hide')}">
 
                 <div class="slds-grid slds-grid_align-center slds-grid_vertical-align-center slds-p-around_large {!IF(isAdmin, '', 'slds-hide')}">
-                    <apex:commandButton id="editOppRollups" value="{!$Label.stgBtnEdit}" status="statusLoad" action="{!editSettings}" immediate="true" rendered="{!isReadOnlyMode && !isPolling}" rerender="form" styleClass="slds-button slds-button--small slds-button--neutral" />
+                    <apex:commandButton id="editCRLPs" value="{!$Label.stgBtnEdit}" status="statusLoad" action="{!editSettings}" immediate="true" rendered="{!isReadOnlyMode && !isPolling}" rerender="form" styleClass="slds-button slds-button--small slds-button--neutral" />
                 </div>
 
                 <div class="slds-form--horizontal slds-m-around--large">
@@ -97,9 +97,9 @@
                 </div>
 
                 <div class="slds-grid slds-grid_align-center slds-grid_vertical-align-center slds-p-around_large">
-                    <apex:commandButton id="saveOppRollups" value="{!$Label.stgBtnSave}" status="statusLoad" action="{!saveSettings}" immediate="false" rendered="{!isEditMode}" rerender="form, status, idPanelSchedule, idPanelConRole, idPanelMembership, UDRsTreeItem, donorStatsTreeItem" styleClass="slds-button slds-button_small slds-button_brand" />
-                    <apex:commandButton id="cancelOppRollups" value="{!$Label.stgBtnCancel}" status="statusLoad" action="{!cancelEdit}" immediate="true" rendered="{!isEditMode}" rerender="form" styleClass="slds-button slds-button_small slds-button_neutral" />
-                    <apex:commandButton id="navigate" value="{!$Label.stgCRLPGoToSetup}" action="{!navigate}" rendered="{!stgService.stgCRLP.Customizable_Rollups_Enabled__c && !isEditMode && !isPolling}" styleClass="slds-button slds-button--small slds-button--neutral" />
+                    <apex:commandButton id="saveCRLPs" value="{!$Label.stgBtnSave}" status="statusLoad" action="{!saveSettings}" immediate="false" rendered="{!isEditMode}" rerender="form, status, idPanelSchedule, idPanelConRole, idPanelMembership, UDRsTreeItem, donorStatsTreeItem" styleClass="slds-button slds-button_small slds-button_brand" />
+                    <apex:commandButton id="cancelCRLPs" value="{!$Label.stgBtnCancel}" status="statusLoad" action="{!cancelEdit}" immediate="true" rendered="{!isEditMode}" rerender="form" styleClass="slds-button slds-button_small slds-button_neutral" />
+                    <apex:commandButton id="navigateCRLPs" value="{!$Label.stgCRLPGoToSetup}" action="{!navigate}" rendered="{!stgService.stgCRLP.Customizable_Rollups_Enabled__c && !isEditMode && !isPolling}" styleClass="slds-button slds-button--small slds-button--neutral" />
                 </div>
 
             </div>

--- a/src/pages/STG_PanelCustomizableRollup.page
+++ b/src/pages/STG_PanelCustomizableRollup.page
@@ -97,7 +97,7 @@
                 </div>
 
                 <div class="slds-grid slds-grid_align-center slds-grid_vertical-align-center slds-p-around_large">
-                    <apex:commandButton id="saveCRLPs" value="{!$Label.stgBtnSave}" status="statusLoad" action="{!saveSettings}" immediate="false" rendered="{!isEditMode}" rerender="form, status, idPanelSchedule, idPanelConRole, idPanelMembership, UDRsTreeItem, donorStatsTreeItem" styleClass="slds-button slds-button_small slds-button_brand" />
+                    <apex:commandButton id="saveCRLPs" value="{!$Label.stgBtnSave}" status="statusLoad" action="{!saveSettings}" immediate="false" rendered="{!isEditMode}" rerender="form, status, idPanelSchedule, idPanelConRole, idPanelMembership, idPanelAllocations, UDRsTreeItem, donorStatsTreeItem" styleClass="slds-button slds-button_small slds-button_brand" />
                     <apex:commandButton id="cancelCRLPs" value="{!$Label.stgBtnCancel}" status="statusLoad" action="{!cancelEdit}" immediate="true" rendered="{!isEditMode}" rerender="form" styleClass="slds-button slds-button_small slds-button_neutral" />
                     <apex:commandButton id="navigateCRLPs" value="{!$Label.stgCRLPGoToSetup}" action="{!navigate}" rendered="{!stgService.stgCRLP.Customizable_Rollups_Enabled__c && !isEditMode && !isPolling}" styleClass="slds-button slds-button--small slds-button--neutral" />
                 </div>

--- a/src/pages/STG_SettingsManager.page
+++ b/src/pages/STG_SettingsManager.page
@@ -59,12 +59,14 @@
         node = document.getElementById(idPanelCurrent + 'Nav');
         if (node != null) node.classList.add('slds-is-selected');
 
-        var headerNode = node.parentElement.previousElementSibling;
-        headerNode.classList.remove('collapsed');
-        siblings = node.parentNode.childNodes;
-        for (var i = 0, ii = siblings.length; i < ii; i++) {
-            if(siblings[i].nodeName !== '#text') {
-                siblings[i].style.display = 'block';
+        if (node != null) {
+            var headerNode = node.parentElement.previousElementSibling;
+            headerNode.classList.remove('collapsed');
+            siblings = node.parentNode.childNodes;
+            for (var i = 0, ii = siblings.length; i < ii; i++) {
+                if(siblings[i].nodeName !== '#text') {
+                    siblings[i].style.display = 'block';
+                }
             }
         }
 

--- a/src/pages/STG_SettingsManager.page
+++ b/src/pages/STG_SettingsManager.page
@@ -282,7 +282,7 @@
                 </div>
 
                 <div class="panel noborder" id="idPanelAllocations" style="display:none" >
-                    <apex:include pageName="STG_PanelAllocations" />
+                    <apex:include pageName="STG_PanelAllocations" id="idPanelAllocations"/>
                 </div>
 
                 <div class="panel noborder" id="idPanelOppRollup" style="display:none" >


### PR DESCRIPTION
# Critical Changes

# Changes

- Hides GAU Rollup settings when CRLPs are enabled.
- Does NOT re-deploy CRLP defaults upon edit/save if value stays true.

# Issues Closed

# New Metadata

# Deleted Metadata
