### PR TITLE
Rollups: Extend CRLP debugging tool for customer package deployment

### DIFF
--- a/src/classes/CRLP_Batch_Base_NonSkew.cls
+++ b/src/classes/CRLP_Batch_Base_NonSkew.cls
@@ -277,7 +277,20 @@ public abstract class CRLP_Batch_Base_NonSkew extends CRLP_Batch_Base {
         }
     }
 
-    public void finish(Database.BatchableContext bc) { }
+    public void finish(Database.BatchableContext bc) {
+        // In debug mode, write a summary of the job to the error log
+        if (CRLP_Debug_UTIL.isDebuggingEnabled) {
+            Error__c logEntry = new Error__c(
+                    Context_Type__c = ERR_Handler_API.Context.CRLP.name() + ': ' + this.jobType.name() + ' ' + this.jobMode.name(),
+                    Error_Type__c = 'DEBUG LOG',
+                    Full_Message__c = ('Total Batch Iterations: ' + this.batchIteration + '\n' +
+                            'Total DML Operations: ' + this.totalCommits + '\n' +
+                            'Total Records Updates: ' + this.totalRecordsModified + '\n' +
+                            'Rollups State:\n' + CRLP_Debug_UTIL.getCurrentRollupState()).left(32768)
+            );
+            insert logEntry;
+        }
+    }
 
     /**
      * @description Instantiate the ProcessingOptions class for Non-Skew Mode batch operations.

--- a/src/classes/CRLP_Batch_Base_Skew.cls
+++ b/src/classes/CRLP_Batch_Base_Skew.cls
@@ -390,6 +390,22 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
                     CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
         }
 
+        // In debug mode, write a summary of the job to the error log
+        if (CRLP_Debug_UTIL.isDebuggingEnabled) {
+            Error__c logEntry = new Error__c(
+                    Context_Type__c = ERR_Handler_API.Context.CRLP.name() + ': ' + this.jobType.name() + ' ' + this.jobMode.name(),
+                    Error_Type__c = 'DEBUG LOG',
+                    Full_Message__c = ('Total Batch Iterations: ' + this.batchIteration + '\n' +
+                            'Total DML Operations: ' + this.totalCommits + '\n' +
+                            'Total Records Updates: ' + this.totalRecordsModified + '\n' +
+                            'Parent Ids Commited in Finish: ' + (this.parentIdsNotCommittedWithBatch !=  null ?
+                                '(' + this.parentIdsNotCommittedWithBatch.size() + ')\n' +
+                                        JSON.serializePretty(this.parentIdsNotCommittedWithBatch) : 'none') + '\n' +
+                            'Rollups State:\n' + CRLP_Debug_UTIL.getCurrentRollupState()).left(32768)
+            );
+            insert logEntry;
+        }
+
     }
 
     /**

--- a/src/classes/CRLP_Debug_UTIL.cls
+++ b/src/classes/CRLP_Debug_UTIL.cls
@@ -1,29 +1,92 @@
+/*
+    Copyright (c) 2018, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
 /**
-* ====================================
-* TODO REMOVE THIS CLASS EVENTUALLY
-* ====================================
-* TEMPORARY STATIC VALUE AND METHODS TO HOLD CURRENT STATE TO USE FOR ROLLUP DEBUGGING
+* @author Salesforce.org
+* @date 2018
+* @group Customizable Rollups Debug Logger
+* @description TEMPORARY USE ONLY
 */
 public class CRLP_Debug_UTIL {
 
-    private static final Boolean isEnabled = false;
+    public static final Integer LEVEL_MIN = 1;
+    public static final Integer LEVEL_MAX = 2;
+
+    /*
+     * @description Rather than package the Customizable_Rollup_Settings__c.Debug_Level__c field, which will make it harder
+     * to remove at a later point, this requries that an admin (or sfdo staff) manually create the new custom settings field
+     * on this object as an unmanaged field. The code below attempts to check for the field and if it exists will use it
+     * to set the current debugging level. No field or a value of 0 or null means there CRLP Debugging is disabled.
+     * Level 0 = OFF
+     * Level 1 = MINIMAL
+     * Level 2 = DETAILED
+     */
+    public static Integer debuggingLevel {
+        get {
+            if (debuggingLevel == null) {
+                Customizable_Rollup_Settings__c crlpSettings = UTIL_CustomSettingsFacade.getCustomizableRollupSettings();
+                try {
+                    debuggingLevel = ((Double) crlpSettings.get('Debug_Level__c')).intValue();
+                } catch (Exception ex) {
+                    debuggingLevel = 0;
+                }
+            }
+            return debuggingLevel;
+        }
+    }
+
+    /**
+     * @description Meant to be used externally to determine when debugging is enabled
+     */
+    public static Boolean isDebuggingEnabled {
+        get {
+            return (debuggingLevel > 0);
+        }
+    }
+
     private static List<String> currentRollupState = new List<String>();
 
     public static void clearCurrentRollupState() {
-        if (isEnabled) {
+        if (isDebuggingEnabled) {
             currentRollupState.clear();
         }
     }
 
     public static void setCurrentRollupState(String state) {
-        if (isEnabled) {
+        if (isDebuggingEnabled) {
             UTIL_Debug.debug('===== setCurrentRollupState(' + state + ')\n');
             currentRollupState.add(state);
         }
     }
 
     public static void amendLastCurrentRollupState(String state) {
-        if (isEnabled) {
+        if (isDebuggingEnabled) {
             String lastStateVal = currentRollupState[currentRollupState.size() - 1];
             UTIL_Debug.debug('===== setCurrentRollupState(' + lastStateVal + ' ' + state + ')');
             currentRollupState[currentRollupState.size() - 1] = lastStateVal + ' ' + state;
@@ -31,7 +94,7 @@ public class CRLP_Debug_UTIL {
     }
 
     public static void setCurrentRollupState(String state, CRLP_Rollup rollup) {
-        if (isEnabled) {
+        if (isDebuggingEnabled) {
             String rollupData = '';
             for (CRLP_Rollup.Rollupmdt rcmt : rollup.rollupsMdt) {
                 rollupData += rcmt.summaryObject + '.' + rcmt.summaryField + '-' + rcmt.operation + ';';
@@ -42,7 +105,7 @@ public class CRLP_Debug_UTIL {
 
     public static String getCurrentRollupState() {
         String val = '';
-        if (isEnabled) {
+        if (isDebuggingEnabled) {
             for (Integer n = currentRollupState.size() - 1; n >= 0; n--) {
                 if (!currentRollupState[n].startsWith(' ')) {
                     val += '* ' + currentRollupState[n] + '\n';
@@ -55,7 +118,7 @@ public class CRLP_Debug_UTIL {
     }
 
     public static String getRollupCurrentValues(CRLP_Rollup r) {
-        return (!isEnabled ? '' :
+        return (debuggingLevel == 0 ? '' :
                 '\n* # of MDT records=' + r.rollupsMdt.size() +
                 '\n* resultFieldName=' + r.resultFieldName + '/' + r.resultFieldType +
                 '\n* timeBoundOperation=' + r.timeBoundOperation +
@@ -77,7 +140,7 @@ public class CRLP_Debug_UTIL {
 
     public static String getRollupState(List<CRLP_Rollup> rollups) {
         String theState = '';
-        if (isEnabled) {
+        if (isDebuggingEnabled) {
             for (CRLP_Rollup r : rollups) {
                 theState += getRollupCurrentValues(r) + '\n';
             }
@@ -91,14 +154,14 @@ public class CRLP_Debug_UTIL {
      * all records no matter how many records there are in the system.
      * @param summObjectType Summary Object Type
      */
-    public static void clearAllRollupFields(SObjectType summObjectType) {
+    /*public static void clearAllRollupFields(SObjectType summObjectType) {
         System.enqueueJob(new clearRollupFieldsASync(summObjectType, 0));
-    }
+    }*/
 
     /**
      * @description Queueable Implementation called by clearAllRollupFields()
      */
-    private class clearRollupFieldsASync implements System.Queueable {
+    /*private class clearRollupFieldsASync implements System.Queueable {
 
         private SObjectType objType;
         private Integer queryOffset;
@@ -124,5 +187,5 @@ public class CRLP_Debug_UTIL {
                 System.enqueueJob(new clearRollupFieldsASync(this.objType, records.size()));
             }
         }
-    }
+    }*/
 }

--- a/src/classes/CRLP_Debug_UTIL.cls-meta.xml
+++ b/src/classes/CRLP_Debug_UTIL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>41.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/CRLP_RollupProcessor_SVC.cls
+++ b/src/classes/CRLP_RollupProcessor_SVC.cls
@@ -116,7 +116,9 @@ public class CRLP_RollupProcessor_SVC {
                 recordsToUpdate.put(parentId, updatedRecord);
             }
 
-            CRLP_Debug_UTIL.clearCurrentRollupState();
+            if (listSizeSum > 1) {
+                CRLP_Debug_UTIL.clearCurrentRollupState();
+            }
             previousParentIdProcessed = parentId;
         }
 

--- a/src/classes/CRLP_RollupQueueable.cls
+++ b/src/classes/CRLP_RollupQueueable.cls
@@ -153,6 +153,19 @@ public class CRLP_RollupQueueable implements System.Queueable {
 
             // DML and capture any returned DML errors into a Map by Summary Record Id
             CRLP_RollupProcessor_SVC.updateChangedRecordsWithLogging(updatedRecords, options.rollupJobType);
+
+            // In debug mode, write a summary of the job to the error log
+            if (CRLP_Debug_UTIL.isDebuggingEnabled) {
+                Error__c logEntry = new Error__c(
+                        Context_Type__c = ERR_Handler_API.Context.CRLP.name() + ': ' + options.rollupJobType.name() + ' ' + options.mode.name(),
+                        Error_Type__c = 'DEBUG LOG',
+                        Full_Message__c = ('CRLP_RollupQueueable\n' +
+                                'detailRecords Count: ' + detailRecords.size() + '\n' +
+                                'updatedRecords Count: ' + (updatedRecords != null ? updatedRecords.size() : 0) + '\n' +
+                                'Rollups State:\n' + CRLP_Debug_UTIL.getCurrentRollupState()).left(32768)
+                );
+                insert logEntry;
+            }
         }
     }
 }

--- a/src/classes/CRLP_VRollupHandler.cls
+++ b/src/classes/CRLP_VRollupHandler.cls
@@ -149,11 +149,14 @@ public virtual class CRLP_VRollupHandler implements CRLP_Rollup_SVC.IRollupHandl
      */
     public SObject getPopulatedSObject() {
         this.record = CRLP_Rollup_SVC.createEmptyResultObject(this.objectId, this.rollups);
+        Boolean debugMode = CRLP_Debug_UTIL.debuggingLevel == CRLP_Debug_UTIL.LEVEL_MAX;
         for (CRLP_Rollup rollup : this.rollups) {
             Map<String,Object> results = rollup.getFinalValues();
             CRLP_Debug_UTIL.setCurrentRollupState(this.objectId + ': ' + CRLP_Debug_UTIL.getRollupCurrentValues(rollup));
             for (String fld : results.keySet()) {
-                //CRLP_Debug_UTIL.setCurrentRollupState('   ' + fld + ' = ' + results.get(fld));
+                if (debugMode) {
+                    CRLP_Debug_UTIL.setCurrentRollupState('   ' + fld + ' = ' + results.get(fld));
+                }
                 this.record.put(fld, results.get(fld));
             }
         }


### PR DESCRIPTION
# Critical Changes

# Changes

* Enable the `CRLP_Debug_UTIL` class to be included in the managed package
* Debugging is disabled until the admin adds a custom field for `Debug_Level__c` to the `Customizable_Rollups_Settings` custom settings object. This is done to avoid packaging a custom field for debugging.
* The initial intent is to remove the class shortly after the initial go live; leaving it there only to troubleshoot any unexpected rollup issues post go-live. However, it is possible this will be left in long term, in which case the debugging logic might be expanded.
* It is important to note that enabling debugging during the rollup has a pretty significant impact on performance.

# Issues Closed

# New Metadata

# Deleted Metadata
