### PR TITLE
Rollups: Lookdown Lookups

### DIFF
--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -443,6 +443,11 @@ public with sharing class CRLP_RollupUI_SVC {
                 String fieldType = getFieldType(objectName,dfr.name);
                 fieldObject.put('type', fieldType);
 
+                if (fieldType == 'REFERENCE') {
+                    fieldObject.put('referenceTo', dfr.referenceTo[0].getDescribe().name);
+                } else if (fieldType == 'ID') {
+                    fieldObject.put('referenceTo', objectName);
+                }
                 fieldObjectList.add(fieldObject);
             }
         }
@@ -491,7 +496,7 @@ public with sharing class CRLP_RollupUI_SVC {
     private static String getFieldType (String objectName, String field) {
         String fieldType = UTIL_Describe.getFieldType(objectName,field);
         // re-casting picklists and multipicklists as strings because strings and picklists are interchangeable for rollups
-        if(fieldType == 'PICKLIST' || fieldType == 'MULTIPICKLIST') {
+        if (fieldType == 'PICKLIST' || fieldType == 'MULTIPICKLIST') {
             fieldType = 'STRING';
         }
         return fieldType;
@@ -839,9 +844,9 @@ public with sharing class CRLP_RollupUI_SVC {
 
         for (Schema.DescribeFieldResult dfr : objectFields.values()) {
             //valid types are taken from the DisplayType Enum and only include values that make sense to roll up
-            String type = dfr.getType().Name();
+            String fieldType = getFieldType(objectName, dfr.name);
             Set<String> validTypeSet = new Set<String>{'CURRENCY', 'DATE', 'DATETIME', 'DOUBLE', 'INTEGER', 'MULTIPICKLIST', 'PICKLIST', 'REFERENCE', 'STRING', 'TEXTAREA'};
-            Boolean isValidType = validTypeSet.contains(type);
+            Boolean isValidType = validTypeSet.contains(fieldType);
 
             //check that summary field isn't being used on another rollup
             Boolean isRolledUp = referencedFieldSet.contains(dfr);
@@ -851,8 +856,12 @@ public with sharing class CRLP_RollupUI_SVC {
                 Map<String, String> fieldObject = new Map<String, String>();
                 fieldObject.put('name', dfr.name);
                 fieldObject.put('label', dfr.label);
-                String fieldType = getFieldType(objectName, dfr.name);
                 fieldObject.put('type', fieldType);
+
+                if (fieldType == 'REFERENCE') {
+                    fieldObject.put('referenceTo', dfr.referenceTo[0].getDescribe().name);
+                }
+
 
                 fieldObjectList.add(fieldObject);
             }


### PR DESCRIPTION
# Critical Changes

# Changes

- References (Lookups) and Record IDs both match to roll up into Reference (Lookup) fields

- Object must match between detail field and summary field to roll an ID/ref into a Reference.

# Issues Closed

# New Metadata

# Deleted Metadata
