### PR TITLE
Feature/rollups  filter rule space and null fix

### DIFF
--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroup.cmp
@@ -253,11 +253,13 @@
                                 <!--START CONSTANT INPUT OPTIONS-->
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'text')}">
                                     <!--todo: combine dynamic type with 214 release-->
-                                    <div class="slds-p-horizontal_small">
-                                        <c:CRLP_Tooltip helpText="{!v.labels.filterRuleValueHelp}" fieldLabel="{!v.labels.constant}"/>
+                                    <div class="slds-p-top_small">
+                                        <div class="slds-p-horizontal_small">
+                                            <c:CRLP_Tooltip helpText="{!v.labels.filterRuleValueHelp}" fieldLabel="{!v.labels.constant}"/>
+                                        </div>
+                                        <lightning:textarea aura:id="filterRuleField" class="slds-p-horizontal_small filterGroupField" value="{!v.activeFilterRule.value}"
+                                                            required="true" label="{!v.labels.constant}" maxlength="300" variant="label-hidden" />
                                     </div>
-                                    <lightning:textarea aura:id="filterRuleField" class="slds-p-horizontal_small filterGroupField" value="{!v.activeFilterRule.value}"
-                                                        required="true" label="{!v.labels.constant}" maxlength="300" variant="label-hidden" />
                                 </aura:if>
                                 <aura:if isTrue="{!equals(v.filterRuleFieldType, 'date')}">
                                     <lightning:input aura:id="filterRuleField" class="slds-p-around_small" value="{!v.activeFilterRule.value}"

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
@@ -344,10 +344,14 @@
             var newValueApiName = valueApiName.join(";");
             cmp.set("v.activeFilterRule.value", newValueApiName);
         } else if (filterRuleFieldType === "text" && valueApiName.indexOf(";") > 0 && valueApiName) {
-            var labelRe = /;[\n]+[ ]+|;[ ]+[\n]+|;/g;
-            updatedLabel = valueApiName.replace(labelRe, ";\n");
-            var nameRe = /\n| /g;
-            var newValueApiName = valueApiName.replace(nameRe, "");
+            var valueList = valueApiName.split(';');
+            var cleanList = valueList.map(function(value){
+               return value.replace('\n', '').trim();
+            });
+            updatedLabel = cleanList.join(";\n");
+            var newValueApiName = updatedLabel.replace(/\n/g, "");
+            cmp.set("v.activeFilterRule.value", newValueApiName);
+        } else if (filterRuleFieldType === "text" && valueApiName) {
             cmp.set("v.activeFilterRule.value", newValueApiName);
         }
 

--- a/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
+++ b/src/aura/CRLP_FilterGroup/CRLP_FilterGroupHelper.js
@@ -140,17 +140,16 @@
      * @param errors - list of errors from response
      */
     handleErrors: function(cmp, errors) {
-        var helper = this;
         var msg = "Unknown error";
         if (errors && errors[0] && errors[0].message) {
             msg = errors[0].message;
         }
         if (cmp.get("v.mode") === 'delete') {
-            helper.showToast(cmp, 'error', cmp.get("v.labels.filtersDeleteFail"), msg);
+            this.showToast(cmp, 'error', cmp.get("v.labels.filtersDeleteFail"), msg);
         } else {
-            helper.showToast(cmp, 'error', cmp.get("v.labels.filtersSaveFail"), msg);
+            this.showToast(cmp, 'error', cmp.get("v.labels.filtersSaveFail"), msg);
             cmp.set("v.mode", 'edit');
-            helper.onChangeMode(cmp, event, helper);
+            this.changeMode(cmp);
         }
     },
 

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -697,7 +697,7 @@ public with sharing class CRLP_RollupUI_SVC {
             // CMT data will generate a unique RecordName to use for the new record.
             CRLP_RollupCMT.FilterGroup filterGroupCMTObj = (CRLP_RollupCMT.FilterGroup) JSON.deserialize(filterGroupCMT, CRLP_RollupCMT.FilterGroup.class);
 
-            if (filterGroupCMTObj.isDeleted) {
+            if (filterGroupCMTObj.isDeleted == true) {
                 Map<Id, List<Rollup__mdt>> rollupsByFilterGroup = CRLP_Rollup_SEL.getRollupsByFilterGroup();
                 Integer countRollups = rollupsByFilterGroup.containsKey(filterGroupCMTObj.recordId) ? rollupsByFilterGroup.get(filterGroupCMTObj.recordId).size() : 0;
 


### PR DESCRIPTION
# Critical Changes

# Changes
- Fix to error handler in Filter Group cmp.
- Handle for null isDeleted in CRLP_RollupUI_SVC
- Small CSS fix for filter rule modal to allow for error space when the field is empty.
- Changed regex to map and fixed logic when queueing filter rules to In_List items are formatted correctly on the page and as a saved value.
# Issues Closed

# New Metadata

# Deleted Metadata
