### PR TITLE
Rollups: Enablement Fix for RecordTypes 

### DIFF
--- a/src/classes/CRLP_Batch_Base_Skew.cls
+++ b/src/classes/CRLP_Batch_Base_Skew.cls
@@ -44,7 +44,7 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
      * this number of batch iterations. After that number, the record will be committed to the database.
      * Salesforce can easily put data significantly out of sequence -- hundreds or even thousands of batch iterations.
      */
-    private Integer MAX_BATCHES_TO_HOLD_BEFORE_COMMIT = 200;
+    private Integer MAX_BATCHES_TO_HOLD_BEFORE_COMMIT = 1500;
 
     /** @description The last Id of a set of records passed to this method. Passed back to the SkewDispatcher batch job */
     private Id lastIdProcessedForChunking;

--- a/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
@@ -38,8 +38,8 @@
 */
 public class CRLP_DefaultConfigBuilder_SVC {
 
-    /** @description Use this Map of RecordTypes by Id to convert the legacy settings into a DeveloperName for the Filter Rule */
-    private static final Map<Id, RecordType> recordTypesById = new Map<Id, RecordType>(
+    /** @description Use this Map of Opp RecordTypes by Id to convert the legacy settings into a DeveloperName for the Filter Rule */
+    private static final Map<Id, RecordType> oppRecordTypesById = new Map<Id, RecordType>(
         [SELECT Id, RecordType.DeveloperName
             FROM RecordType
             WHERE SobjectType = 'Opportunity']);
@@ -113,7 +113,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordType.objectName = 'Opportunity';
             ruleRecordType.fieldName = 'RecordTypeId';
             ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c, 'Membership');
+            ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
             ruleRecordType.isDeleted = false;
             groupClosedWonDonations.rules.add(ruleRecordType);
         }
@@ -168,7 +168,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 ruleRecordType.objectName = 'Opportunity';
                 ruleRecordType.fieldName = 'RecordTypeId';
                 ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c, 'Membership');
+                ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
                 ruleRecordType.isDeleted = false;
                 groupClosedWonDonationsContacts.rules.add(ruleRecordType);
             }
@@ -219,7 +219,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordType.objectName = 'Opportunity';
             ruleRecordType.fieldName = 'RecordTypeId';
             ruleRecordType.operationName = CMT_FilterRule.FilterOperation.IN_LIST.name();
-            ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Membership_Record_Types__c, 'Membership');
+            ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Membership_Record_Types__c);
             ruleRecordType.isDeleted = false;
             groupMemberships.rules.add(ruleRecordType);
         }
@@ -250,7 +250,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordType.objectName = 'Opportunity';
             ruleRecordType.fieldName = 'RecordTypeId';
             ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacyAllocSettings.Excluded_Opp_RecTypes__c, null);
+            ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacyAllocSettings.Excluded_Opp_RecTypes__c);
             ruleRecordType.isDeleted = false;
             groupAllocations.rules.add(ruleRecordType);
         }
@@ -324,7 +324,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordTypePaid.objectName = 'Opportunity';
             ruleRecordTypePaid.fieldName = 'RecordTypeId';
             ruleRecordTypePaid.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordTypePaid.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c, 'Membership');
+            ruleRecordTypePaid.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
             ruleRecordTypePaid.isDeleted = false;
             groupPaymentsPaid.rules.add(ruleRecordTypePaid);
         }
@@ -367,7 +367,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 ruleRecordTypePaidCon.objectName = 'Opportunity';
                 ruleRecordTypePaidCon.fieldName = 'RecordTypeId';
                 ruleRecordTypePaidCon.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleRecordTypePaidCon.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c, 'Membership');
+                ruleRecordTypePaidCon.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
                 ruleRecordTypePaidCon.isDeleted = false;
                 groupPaymentsPaidContacts.rules.add(ruleRecordTypePaidCon);
             }
@@ -408,7 +408,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordTypeWrittenOff.objectName = 'Opportunity';
             ruleRecordTypeWrittenOff.fieldName = 'RecordTypeId';
             ruleRecordTypeWrittenOff.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordTypeWrittenOff.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c, 'Membership');
+            ruleRecordTypeWrittenOff.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
             ruleRecordTypeWrittenOff.isDeleted = false;
             groupPaymentsWrittenOff.rules.add(ruleRecordTypeWrittenOff);
         }
@@ -451,7 +451,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 ruleRecordTypeWrittenOffCon.objectName = 'Opportunity';
                 ruleRecordTypeWrittenOffCon.fieldName = 'RecordTypeId';
                 ruleRecordTypeWrittenOffCon.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleRecordTypeWrittenOffCon.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c, 'Membership');
+                ruleRecordTypeWrittenOffCon.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
                 ruleRecordTypeWrittenOffCon.isDeleted = false;
                 groupPaymentsWrittenOffContacts.rules.add(ruleRecordTypeWrittenOffCon);
             }
@@ -625,20 +625,17 @@ public class CRLP_DefaultConfigBuilder_SVC {
      * Record Type Developer Names. These are easier to 'read' (i.e., self-documenting) and more importantly it allows
      * for deploying a custom Filter Rule from a Sandbox to Production (where the Record Type Id might be different
      * if the RT was created in the Sandbox).
-     * @param excludedRtIds semi-colon separatedlist of Record Type Id's
-     * @param defRT If excludedRtIds is null, this record type developer name is always excluded (optional)
+     * @param rtIds semi-colon separatedlist of Record Type Id's
      * @return Semi-colon separated list of Record Type Developer Names
      */
-    private static String convertExcludedRecordTypeIdsToDevNames(String excludedRtIds, String defRT) {
+    private static String convertRecordTypeIdsToDevNames(String rtIds) {
         Set<String> rtDevNames = new Set<String>();
-        if (excludedRtIds != null) {
-            for (String rtId : excludedRtIds.split(';')) {
-                if (recordTypesById.containsKey(rtId)) {
-                    rtDevNames.add(recordTypesById.get(rtId).DeveloperName);
+        if (rtIds != null) {
+            for (String rtId : rtIds.split(';')) {
+                if (oppRecordTypesById.containsKey(rtId)) {
+                    rtDevNames.add(oppRecordTypesById.get(rtId).DeveloperName);
                 }
             }
-        } else if (defRT != null) {
-            rtDevNames.add(defRT);   // default to this if there are no current exclusions
         }
         return String.join(new List<String>(rtDevNames), ';');
     }

--- a/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
@@ -42,7 +42,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
     private static final Map<Id, RecordType> recordTypesById = new Map<Id, RecordType>(
         [SELECT Id, RecordType.DeveloperName
             FROM RecordType
-            WHERE SobjectType = 'Opportunity' AND IsActive = True]);
+            WHERE SobjectType = 'Opportunity']);
 
     /*************************************************************************************************************
      * @description Call each of the methods in this class to build the default Filter Groups and each of the four

--- a/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
@@ -635,8 +635,6 @@ public class CRLP_DefaultConfigBuilder_SVC {
             for (String rtId : excludedRtIds.split(';')) {
                 if (recordTypesById.containsKey(rtId)) {
                     rtDevNames.add(recordTypesById.get(rtId).DeveloperName);
-                } else {
-                    rtDevNames.add(rtId);
                 }
             }
         } else if (defRT != null) {


### PR DESCRIPTION
# Critical Changes

# Changes

* Fix the enablement process to not exclude Inactive RecordTypes during the conversion from legacy RecordType.Id to RecordType.DeveloperName when building CRLP filters
* Remove the default RecordType for building the CRLP filters. All values should always come directly from the custom settings object, even if the field in the custom settings is null
* In Skew Mode jobs, significantly increase the `MAX_BATCHES_TO_HOLD_BEFORE_COMMIT` value to avoid unnecessary commits to the parent object.

# Issues Closed

# New Metadata

# Deleted Metadata
