### PR TITLE
Rollups: Create CRLP settings record during package upgrade

### DIFF
--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -154,6 +154,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
         UTIL_CustomSettingsFacade.getOrgBDESettings();
         UTIL_CustomSettingsFacade.getOrgAllocationsSettings();
         UTIL_CustomSettingsFacade.getOrgDataImportSettings();
+        UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
 
         UTIL_Debug.debug('****NPSP-to-Cumulus Map: ' + JSON.serializePretty(npspToCumulusMap));
  


### PR DESCRIPTION
Otherwise found that the next time this was referenced was by the scheduled batch jobs at night, all of which attempted to insert the default record at the same time causing an error.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
