### PR TITLE
Rollups: Final rollup changes

### DIFF
--- a/src/classes/CRLP_Batch_Base_Skew.cls
+++ b/src/classes/CRLP_Batch_Base_Skew.cls
@@ -44,7 +44,7 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
      * this number of batch iterations. After that number, the record will be committed to the database.
      * Salesforce can easily put data significantly out of sequence -- hundreds or even thousands of batch iterations.
      */
-    private Integer MAX_BATCHES_TO_HOLD_BEFORE_COMMIT = 200;
+    private Integer MAX_BATCHES_TO_HOLD_BEFORE_COMMIT = 1500;
 
     /** @description The last Id of a set of records passed to this method. Passed back to the SkewDispatcher batch job */
     private Id lastIdProcessedForChunking;

--- a/src/classes/CRLP_DefaultConfigBuilder.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder.cls
@@ -62,12 +62,20 @@ public class CRLP_DefaultConfigBuilder {
     public static final String LastNDaysAllocString = (legacyAllocSettings.Rollup_N_Day_Value__c != null ?
         String.valueOf(legacyAllocSettings.Rollup_N_Day_Value__c.intValue()) : '365');
 
-        /** @description The RecordName for the default filter group of Closed Won Donations (Unique to Account rollups) */
-    public static String FilterGroup_Opps_Accounts = RecordNamePrefix + 'ClosedWon_Opps' +
+    /** @description The RecordName for the default filter group of Closed Won Donations (Unique to Account rollups) */
+    public static String FilterGroup_Opps_Accounts_HC = RecordNamePrefix + 'ClosedWon_Opps_HC' +
+            (isDifferentContactFilterGroupNeeded  ? '_Accounts' : '');
+
+    /** @description The RecordName for the default filter group of Closed Won Donations (Unique to Account rollups) */
+    public static String FilterGroup_Opps_Accounts_SC = RecordNamePrefix + 'ClosedWon_Opps_SC' +
             (isDifferentContactFilterGroupNeeded  ? '_Accounts' : '');
 
     /** @description The RecordName for the default filter group of Closed Won Donations (Unique to Contact rollups) */
-    public static String FilterGroup_Opps_Contacts = RecordNamePrefix + 'ClosedWon_Opps' +
+    public static String FilterGroup_Opps_Contacts_HC = RecordNamePrefix + 'ClosedWon_Opps_HC' +
+            (isDifferentContactFilterGroupNeeded ? '_Contacts' : '');
+
+    /** @description The RecordName for the default filter group of Closed Won Donations (Unique to Contact rollups) */
+    public static String FilterGroup_Opps_Contacts_SC = RecordNamePrefix + 'ClosedWon_Opps_SC' +
             (isDifferentContactFilterGroupNeeded ? '_Contacts' : '');
 
     /** @description The RecordName for the default filter group of Closed Won Membership */
@@ -111,41 +119,41 @@ public class CRLP_DefaultConfigBuilder {
 
             /* ======== Account Hard Credit ======== */
             'Account.npo02__AverageAmount__c' =>
-                    new List<String>{ opportunityObject, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Average', 'All_Time', '' },
+                    new List<String>{ opportunityObject, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Average', 'All_Time', '' },
             'Account.npo02__Best_Gift_Year__c' =>
-                    new List<String>{ opportunityObject, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Best_Year', 'All_Time', '' },
+                    new List<String>{ opportunityObject, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Best_Year', 'All_Time', '' },
             'Account.npo02__Best_Gift_Year_Total__c' =>
-                    new List<String>{ opportunityObject, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Best_Year_Total', 'All_Time', '' },
+                    new List<String>{ opportunityObject, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Best_Year_Total', 'All_Time', '' },
             'Account.npo02__FirstCloseDate__c' =>
-                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
+                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
             'Account.npo02__LargestAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
             'Account.npo02__LastCloseDate__c' =>
-                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
+                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
             'Account.npo02__LastOppAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
             'Account.npo02__NumberOfClosedOpps__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Count', '', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Count', '', '' },
             'Account.npo02__OppAmount2YearsAgo__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '2' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '2' },
             'Account.npo02__OppAmountLastNDays__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Sum', 'Days_Back', LastNDaysString },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Days_Back', LastNDaysString },
             'Account.npo02__OppAmountLastYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '1' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '1' },
             'Account.npo02__OppAmountThisYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '0' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '0' },
             'Account.npo02__OppsClosed2YearsAgo__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '2' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '2' },
             'Account.npo02__OppsClosedLastNDays__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Count', 'Days_Back', LastNDaysString },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Days_Back', LastNDaysString },
             'Account.npo02__OppsClosedLastYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '1' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '1' },
             'Account.npo02__OppsClosedThisYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '0' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '0' },
             'Account.npo02__SmallestAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Smallest', 'All_Time', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Smallest', 'All_Time', '' },
             'Account.npo02__TotalOppAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts, oppAmountFld, oppCloseDateFld, 'Sum', '', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Accounts_HC, oppAmountFld, oppCloseDateFld, 'Sum', '', '' },
 
             /* ======== Account Membership ======== */
             'Account.npo02__TotalMembershipOppAmount__c' =>
@@ -167,75 +175,75 @@ public class CRLP_DefaultConfigBuilder {
 
             /* ======== Contact Hard Credit ======== */
             'Contact.npo02__AverageAmount__c' =>
-                    new List<String>{ opportunityObject, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Average', 'All_Time', '' },
+                    new List<String>{ opportunityObject, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Average', 'All_Time', '' },
             'Contact.npo02__Best_Gift_Year__c' =>
-                    new List<String>{ opportunityObject, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Best_Year', 'All_Time', '' },
+                    new List<String>{ opportunityObject, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Best_Year', 'All_Time', '' },
             'Contact.npo02__Best_Gift_Year_Total__c' =>
-                    new List<String>{ opportunityObject, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Best_Year_Total', 'All_Time', '' },
+                    new List<String>{ opportunityObject, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Best_Year_Total', 'All_Time', '' },
             'Contact.npo02__FirstCloseDate__c' =>
-                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
+                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
             'Contact.npo02__LargestAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
             'Contact.npo02__LastCloseDate__c' =>
-                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
+                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
             'Contact.npo02__LastOppAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
             'Contact.npo02__NumberOfClosedOpps__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Count', '', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Count', '', '' },
             'Contact.npo02__OppAmount2YearsAgo__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '2' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '2' },
             'Contact.npo02__OppAmountLastNDays__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Sum', 'Days_Back', LastNDaysString },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Days_Back', LastNDaysString },
             'Contact.npo02__OppAmountLastYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '1' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '1' },
             'Contact.npo02__OppAmountThisYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '0' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '0' },
             'Contact.npo02__OppsClosed2YearsAgo__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '2' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '2' },
             'Contact.npo02__OppsClosedLastNDays__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Count', 'Days_Back', LastNDaysString },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Days_Back', LastNDaysString },
             'Contact.npo02__OppsClosedLastYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '1' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '1' },
             'Contact.npo02__OppsClosedThisYear__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '0' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '0' },
             'Contact.npo02__SmallestAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Smallest', 'All_Time', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Smallest', 'All_Time', '' },
             'Contact.npo02__TotalOppAmount__c' =>
-                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts, oppAmountFld, oppCloseDateFld, 'Sum', '', '' },
+                    new List<String>{ oppAmountFld, FilterGroup_Opps_Contacts_HC, oppAmountFld, oppCloseDateFld, 'Sum', '', '' },
 
             /* ======== Contact Soft Credit ======== */
             'Contact.First_Soft_Credit_Date__c' =>
-                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
+                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
             'Contact.Last_Soft_Credit_Date__c' =>
-                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
+                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
             'Contact.First_Soft_Credit_Amount__c' =>
-                    new List<String>{ pscAmountFld, FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
+                    new List<String>{ pscAmountFld, FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'First', 'All_Time', '' },
             'Contact.Largest_Soft_Credit_Amount__c' =>
-                    new List<String>{ pscAmountFld, FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
+                    new List<String>{ pscAmountFld, FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
             'Contact.Largest_Soft_Credit_Date__c' =>
-                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
+                    new List<String>{ oppCloseDateFld, FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Largest', 'All_Time', '' },
             'Contact.Last_Soft_Credit_Amount__c' =>
-                    new List<String>{ pscAmountFld, FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
+                    new List<String>{ pscAmountFld, FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Last', 'All_Time', '' },
             'Contact.npo02__Soft_Credit_Last_Year__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '1' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '1' },
             'Contact.npo02__Soft_Credit_This_Year__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '0' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '0' },
             'Contact.npo02__Soft_Credit_Total__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Sum', 'All_Time', '' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Sum', 'All_Time', '' },
             'Contact.npo02__Soft_Credit_Two_Years_Ago__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '2' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Sum', 'Years_Ago', '2' },
             'Contact.Number_of_Soft_Credits__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Count', 'All_Time', '' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Count', 'All_Time', '' },
             'Contact.Number_of_Soft_Credits_Last_N_Days__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Count', 'Days_Back', LastNDaysString },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Count', 'Days_Back', LastNDaysString },
             'Contact.Number_of_Soft_Credits_Last_Year__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '1' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '1' },
             'Contact.Number_of_Soft_Credits_This_Year__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '0' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '0' },
             'Contact.Number_of_Soft_Credits_Two_Years_Ago__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '2' },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Count', 'Years_Ago', '2' },
             'Contact.Soft_Credit_Last_N_Days__c' =>
-                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts, pscAmountFld, oppCloseDateFld, 'Sum', 'Days_Back', LastNDaysString },
+                    new List<String>{ 'Partial_Soft_Credit__c', FilterGroup_Opps_Contacts_SC, pscAmountFld, oppCloseDateFld, 'Sum', 'Days_Back', LastNDaysString },
 
             /* ======== Contact Membership ======== */
             'Contact.npo02__TotalMembershipOppAmount__c' =>

--- a/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
@@ -71,10 +71,11 @@ public class CRLP_DefaultConfigBuilder_SVC {
      * @return List<FilterGroup> defined Filter Group wrapper classes; each containing a List<FilterRule>
      */
     private static List<CRLP_RollupCMT.FilterGroup> buildDefaultFilterGroups() {
-        String acctOpp = 'Opportunities';  // Use this to differentiate Account from Contact filters if that is needed
-        String contOpp = 'Opportunities';  // Use this to differentiate Account from Contact filters if that is needed
-        String acctPmt = 'Payments';  // Use this to differentiate Account from Contact filters if that is needed
-        String contPmt = 'Payments';  // Use this to differentiate Account from Contact filters if that is needed
+        // Use these to differentiate Account from Contact filters if that is needed
+        String acctOpp = 'Opps';
+        String contOpp = 'Opps';
+        String acctPmt = 'Pmts';
+        String contPmt = 'Pmts';
         if (CRLP_DefaultConfigBuilder.isDifferentContactFilterGroupNeeded) {
             acctOpp = acctOpp + '-Acct';
             contOpp = contOpp + '-Cont';
@@ -86,113 +87,197 @@ public class CRLP_DefaultConfigBuilder_SVC {
         Boolean conRTExclusionsExist = (CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c != null);
         Boolean acctOppTypeExclusionsExist = (CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Types__c != null);
         Boolean conOppTypeExclusionsExist = (CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Types__c != null);
+
         // ==============================================================================================================
-        // Default "Donations: Close/Won Stage" filter group -- All Hard Credit, Soft Credit, and GAU Rollups
+        // Default "Donations: Close/Won Stage" filter group -- Hard Credit Rollups
         // ==============================================================================================================
 
-        CRLP_RollupCMT.FilterGroup groupClosedWonDonations = new CRLP_RollupCMT.FilterGroup(acctOpp +': Won' + (acctRTExclusionsExist ? ' excluding Rec Types' : ''));
-        groupClosedWonDonations.recordName = CRLP_DefaultConfigBuilder.FilterGroup_Opps_Accounts;
-        groupClosedWonDonations.description = 'Won Opportunities for both Hard and Soft Credit Rollups. ' +
-                'The Soft Credit Role Name rule is only applied when rolling up Soft Credits to Accounts' +
-                (CRLP_DefaultConfigBuilder.isDifferentContactFilterGroupNeeded ? '.' : ' or Contacts.') +
+        CRLP_RollupCMT.FilterGroup groupClosedWonDonationsHC = new CRLP_RollupCMT.FilterGroup(acctOpp +': Won (HC)' + (acctRTExclusionsExist ? ' Excl RecTypes' : ''));
+        groupClosedWonDonationsHC.recordName = CRLP_DefaultConfigBuilder.FilterGroup_Opps_Accounts_HC;
+        groupClosedWonDonationsHC.description = 'Won Opportunities for '+ (CRLP_DefaultConfigBuilder.isDifferentContactFilterGroupNeeded ? 'Account ' : '')+ 'Hard Credit Rollups.' +
                 (acctRTExclusionsExist ? ' Excludes Record Types as defined in legacy NPSP Rollup Settings.' : '');
-        groupClosedWonDonations.isDeleted = false;
+        groupClosedWonDonationsHC.isDeleted = false;
 
-        CRLP_RollupCMT.FilterRule ruleCloseWonStage = new CRLP_RollupCMT.FilterRule(groupClosedWonDonations.recordName, acctOpp +': Won Only');
-        ruleCloseWonStage.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStage.recordName;
-        ruleCloseWonStage.objectName = 'Opportunity';
-        ruleCloseWonStage.fieldName = 'IsWon';
-        ruleCloseWonStage.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
-        ruleCloseWonStage.value = 'true';
-        ruleCloseWonStage.isDeleted = false;
-        groupClosedWonDonations.rules.add(ruleCloseWonStage);
+        CRLP_RollupCMT.FilterRule ruleCloseWonStageHC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsHC.recordName, acctOpp +': Won Only (HC)');
+        ruleCloseWonStageHC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStageHC.recordName;
+        ruleCloseWonStageHC.objectName = 'Opportunity';
+        ruleCloseWonStageHC.fieldName = 'IsWon';
+        ruleCloseWonStageHC.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
+        ruleCloseWonStageHC.value = 'true';
+        ruleCloseWonStageHC.isDeleted = false;
+        groupClosedWonDonationsHC.rules.add(ruleCloseWonStageHC);
 
         if (acctRTExclusionsExist) {
-            CRLP_RollupCMT.FilterRule ruleRecordType = new CRLP_RollupCMT.FilterRule(groupClosedWonDonations.recordName, acctOpp + ': Excluded RT');
-            ruleRecordType.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleRecordType.recordName;
-            ruleRecordType.objectName = 'Opportunity';
-            ruleRecordType.fieldName = 'RecordTypeId';
-            ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
-            ruleRecordType.isDeleted = false;
-            groupClosedWonDonations.rules.add(ruleRecordType);
+            CRLP_RollupCMT.FilterRule ruleRecordTypeHC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsHC.recordName, acctOpp + ': Excl RT (HC)');
+            ruleRecordTypeHC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleRecordTypeHC.recordName;
+            ruleRecordTypeHC.objectName = 'Opportunity';
+            ruleRecordTypeHC.fieldName = 'RecordTypeId';
+            ruleRecordTypeHC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+            ruleRecordTypeHC.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
+            ruleRecordTypeHC.isDeleted = false;
+            groupClosedWonDonationsHC.rules.add(ruleRecordTypeHC);
         }
 
         if (acctOppTypeExclusionsExist) {
-            CRLP_RollupCMT.FilterRule ruleOppType = new CRLP_RollupCMT.FilterRule(groupClosedWonDonations.recordName, acctOpp +': Excluded Opp.Type');
-            ruleOppType.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleOppType.recordName;
-            ruleOppType.objectName = 'Opportunity';
-            ruleOppType.fieldName = 'Type';
-            ruleOppType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleOppType.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Types__c;
-            ruleOppType.isDeleted = false;
-            groupClosedWonDonations.rules.add(ruleOppType);
+            CRLP_RollupCMT.FilterRule ruleOppTypeHC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsHC.recordName, acctOpp +': Excl Opp.Type (HC)');
+            ruleOppTypeHC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleOppTypeHC.recordName;
+            ruleOppTypeHC.objectName = 'Opportunity';
+            ruleOppTypeHC.fieldName = 'Type';
+            ruleOppTypeHC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+            ruleOppTypeHC.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Types__c;
+            ruleOppTypeHC.isDeleted = false;
+            groupClosedWonDonationsHC.rules.add(ruleOppTypeHC);
+        }
+
+        // If there is a need to create another Filter Group for Contacts that is different than Accounts ...
+        CRLP_RollupCMT.FilterGroup groupClosedWonDonationsContactsHC;
+        if (CRLP_DefaultConfigBuilder.isDifferentContactFilterGroupNeeded) {
+            // ==============================================================================================================
+            // Default "Donations: Close/Won Stage" filter group -- Hard Credit Rollups CONTACTS ONLY
+            // ==============================================================================================================
+            groupClosedWonDonationsContactsHC = new CRLP_RollupCMT.FilterGroup(contOpp +': Won (HC)' + (conRTExclusionsExist ? ' Excl RecTypes' : ''));
+            groupClosedWonDonationsContactsHC.recordName = CRLP_DefaultConfigBuilder.FilterGroup_Opps_Contacts_HC;
+            groupClosedWonDonationsContactsHC.description = 'Won Opportunities for Contact Hard Credit Rollups.' +
+                    (conRTExclusionsExist ? ' Excludes Record Types as defined in legacy NPSP Rollup Settings.' : '');
+            groupClosedWonDonationsContactsHC.isDeleted = false;
+
+            CRLP_RollupCMT.FilterRule ruleCloseWonStage1HC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContactsHC.recordName, contOpp +': Won Only (HC)');
+            ruleCloseWonStage1HC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStage1HC.recordName;
+            ruleCloseWonStage1HC.objectName = 'Opportunity';
+            ruleCloseWonStage1HC.fieldName = 'IsWon';
+            ruleCloseWonStage1HC.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
+            ruleCloseWonStage1HC.value = 'true';
+            ruleCloseWonStage1HC.isDeleted = false;
+            groupClosedWonDonationsContactsHC.rules.add(ruleCloseWonStage1HC);
+
+            if (conRTExclusionsExist) {
+                CRLP_RollupCMT.FilterRule ruleRecordTypeConHC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContactsHC.recordName, contOpp +': Excl RT (HC)');
+                ruleRecordTypeConHC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleRecordTypeConHC.recordName;
+                ruleRecordTypeConHC.objectName = 'Opportunity';
+                ruleRecordTypeConHC.fieldName = 'RecordTypeId';
+                ruleRecordTypeConHC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+                ruleRecordTypeConHC.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
+                ruleRecordTypeConHC.isDeleted = false;
+                groupClosedWonDonationsContactsHC.rules.add(ruleRecordTypeConHC);
+            }
+
+            if (conOppTypeExclusionsExist) {
+                CRLP_RollupCMT.FilterRule ruleOppTypeConHC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContactsHC.recordName, contOpp +': Excl Opp.Type (HC)');
+                ruleOppTypeConHC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleOppTypeConHC.recordName;
+                ruleOppTypeConHC.objectName = 'Opportunity';
+                ruleOppTypeConHC.fieldName = 'Type';
+                ruleOppTypeConHC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+                ruleOppTypeConHC.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Types__c;
+                ruleOppTypeConHC.isDeleted = false;
+                groupClosedWonDonationsContactsHC.rules.add(ruleOppTypeConHC);
+            }
+
+        }
+
+        // ==============================================================================================================
+        // Default "Donations: Close/Won Stage" filter group -- Soft Credit Rollups
+        // ==============================================================================================================
+
+        CRLP_RollupCMT.FilterGroup groupClosedWonDonationsSC = new CRLP_RollupCMT.FilterGroup(acctOpp +': Won (SC)' + (acctRTExclusionsExist ? ' Excl RecTypes' : ''));
+        groupClosedWonDonationsSC.recordName = CRLP_DefaultConfigBuilder.FilterGroup_Opps_Accounts_SC;
+        groupClosedWonDonationsSC.description = 'Won Opportunities for '+ (CRLP_DefaultConfigBuilder.isDifferentContactFilterGroupNeeded ? 'Account ' : '')+ 'Soft Credit Rollups.' +
+                (acctRTExclusionsExist ? ' Excludes Record Types as defined in legacy NPSP Rollup Settings.' : '');
+        groupClosedWonDonationsSC.isDeleted = false;
+
+        CRLP_RollupCMT.FilterRule ruleCloseWonStageSC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsSC.recordName, acctOpp +': Won Only (SC)');
+        ruleCloseWonStageSC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStageSC.recordName;
+        ruleCloseWonStageSC.objectName = 'Opportunity';
+        ruleCloseWonStageSC.fieldName = 'IsWon';
+        ruleCloseWonStageSC.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
+        ruleCloseWonStageSC.value = 'true';
+        ruleCloseWonStageSC.isDeleted = false;
+        groupClosedWonDonationsSC.rules.add(ruleCloseWonStageSC);
+
+        if (acctRTExclusionsExist) {
+            CRLP_RollupCMT.FilterRule ruleRecordTypeSC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsSC.recordName, acctOpp + ': Excl RT (SC)');
+            ruleRecordTypeSC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleRecordTypeSC.recordName;
+            ruleRecordTypeSC.objectName = 'Opportunity';
+            ruleRecordTypeSC.fieldName = 'RecordTypeId';
+            ruleRecordTypeSC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+            ruleRecordTypeSC.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
+            ruleRecordTypeSC.isDeleted = false;
+            groupClosedWonDonationsSC.rules.add(ruleRecordTypeSC);
+        }
+
+        if (acctOppTypeExclusionsExist) {
+            CRLP_RollupCMT.FilterRule ruleOppTypeSC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsSC.recordName, acctOpp +': Excl Opp.Type (SC)');
+            ruleOppTypeSC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleOppTypeSC.recordName;
+            ruleOppTypeSC.objectName = 'Opportunity';
+            ruleOppTypeSC.fieldName = 'Type';
+            ruleOppTypeSC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+            ruleOppTypeSC.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Types__c;
+            ruleOppTypeSC.isDeleted = false;
+            groupClosedWonDonationsSC.rules.add(ruleOppTypeSC);
         }
 
         if (CRLP_DefaultConfigBuilder.legacySettings.npo02__Soft_Credit_Roles__c != null) {
-            CRLP_RollupCMT.FilterRule ruleSoftCreditRoles = new CRLP_RollupCMT.FilterRule(groupClosedWonDonations.recordName, acctOpp +': Soft Credit Roles ');
+            CRLP_RollupCMT.FilterRule ruleSoftCreditRoles = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsSC.recordName, acctOpp +': Soft Credit Roles ');
             ruleSoftCreditRoles.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleSoftCreditRoles.recordName;
             ruleSoftCreditRoles.objectName = SObjectType.Partial_Soft_Credit__c.getName();
             ruleSoftCreditRoles.fieldName = SObjectType.Partial_Soft_Credit__c.Fields.Role_Name__c.getName();
             ruleSoftCreditRoles.operationName = CMT_FilterRule.FilterOperation.IN_LIST.name();
             ruleSoftCreditRoles.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Soft_Credit_Roles__c;
             ruleSoftCreditRoles.isDeleted = false;
-            groupClosedWonDonations.rules.add(ruleSoftCreditRoles);
+            groupClosedWonDonationsSC.rules.add(ruleSoftCreditRoles);
         }
 
         // If there is a need to create another Filter Group for Contacts that is different than Accounts ...
-        CRLP_RollupCMT.FilterGroup groupClosedWonDonationsContacts;
+        CRLP_RollupCMT.FilterGroup groupClosedWonDonationsContactsSC;
         if (CRLP_DefaultConfigBuilder.isDifferentContactFilterGroupNeeded) {
             // ==============================================================================================================
-            // Default "Donations: Close/Won Stage" filter group -- All Hard Credit, Soft Credit, and GAU Rollups CONTACTS ONLY
+            // Default "Donations: Close/Won Stage" filter group -- Soft Credit Rollups CONTACTS ONLY
             // ==============================================================================================================
-            groupClosedWonDonationsContacts = new CRLP_RollupCMT.FilterGroup(contOpp +': Won' + (conRTExclusionsExist ? ' excluding Rec Types' : ''));
-            groupClosedWonDonationsContacts.recordName = CRLP_DefaultConfigBuilder.FilterGroup_Opps_Contacts;
-            groupClosedWonDonationsContacts.description = 'Won Opportunities for both Hard and Soft Credit Rollups. ' +
-                    'The Soft Credit Role Name rule is only applied when rolling up Soft Credits to Contacts.' +
+            groupClosedWonDonationsContactsSC = new CRLP_RollupCMT.FilterGroup(contOpp +': Won (SC)' + (conRTExclusionsExist ? ' Excl RecTypes' : ''));
+            groupClosedWonDonationsContactsSC.recordName = CRLP_DefaultConfigBuilder.FilterGroup_Opps_Contacts_SC;
+            groupClosedWonDonationsContactsSC.description = 'Won Opportunities for Contact Soft Credit Rollups.' +
                     (conRTExclusionsExist ? ' Excludes Record Types as defined in legacy NPSP Rollup Settings.' : '');
-            groupClosedWonDonationsContacts.isDeleted = false;
+            groupClosedWonDonationsContactsSC.isDeleted = false;
 
-            CRLP_RollupCMT.FilterRule ruleCloseWonStage1 = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContacts.recordName, contOpp +': Won Only');
-            ruleCloseWonStage1.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStage1.recordName;
-            ruleCloseWonStage1.objectName = 'Opportunity';
-            ruleCloseWonStage1.fieldName = 'IsWon';
-            ruleCloseWonStage1.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
-            ruleCloseWonStage1.value = 'true';
-            ruleCloseWonStage1.isDeleted = false;
-            groupClosedWonDonationsContacts.rules.add(ruleCloseWonStage1);
+            CRLP_RollupCMT.FilterRule ruleCloseWonStageConSC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContactsSC.recordName, contOpp +': Won Only (SC)');
+            ruleCloseWonStageConSC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStageConSC.recordName;
+            ruleCloseWonStageConSC.objectName = 'Opportunity';
+            ruleCloseWonStageConSC.fieldName = 'IsWon';
+            ruleCloseWonStageConSC.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
+            ruleCloseWonStageConSC.value = 'true';
+            ruleCloseWonStageConSC.isDeleted = false;
+            groupClosedWonDonationsContactsSC.rules.add(ruleCloseWonStageConSC);
 
             if (conRTExclusionsExist) {
-                CRLP_RollupCMT.FilterRule ruleRecordType = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContacts.recordName, contOpp +': Excluded RT');
-                ruleRecordType.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleRecordType.recordName;
-                ruleRecordType.objectName = 'Opportunity';
-                ruleRecordType.fieldName = 'RecordTypeId';
-                ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
-                ruleRecordType.isDeleted = false;
-                groupClosedWonDonationsContacts.rules.add(ruleRecordType);
+                CRLP_RollupCMT.FilterRule ruleRecordTypeConSC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContactsSC.recordName, contOpp +': Excluded RT (SC)');
+                ruleRecordTypeConSC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleRecordTypeConSC.recordName;
+                ruleRecordTypeConSC.objectName = 'Opportunity';
+                ruleRecordTypeConSC.fieldName = 'RecordTypeId';
+                ruleRecordTypeConSC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+                ruleRecordTypeConSC.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
+                ruleRecordTypeConSC.isDeleted = false;
+                groupClosedWonDonationsContactsSC.rules.add(ruleRecordTypeConSC);
             }
 
             if (conOppTypeExclusionsExist) {
-                CRLP_RollupCMT.FilterRule ruleOppType = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContacts.recordName, contOpp +': Excluded Opp.Type');
-                ruleOppType.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleOppType.recordName;
-                ruleOppType.objectName = 'Opportunity';
-                ruleOppType.fieldName = 'Type';
-                ruleOppType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleOppType.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Types__c;
-                ruleOppType.isDeleted = false;
-                groupClosedWonDonationsContacts.rules.add(ruleOppType);
+                CRLP_RollupCMT.FilterRule ruleOppTypeConSC = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContactsSC.recordName, contOpp +': Excluded Opp.Type (SC)');
+                ruleOppTypeConSC.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleOppTypeConSC.recordName;
+                ruleOppTypeConSC.objectName = 'Opportunity';
+                ruleOppTypeConSC.fieldName = 'Type';
+                ruleOppTypeConSC.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
+                ruleOppTypeConSC.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Types__c;
+                ruleOppTypeConSC.isDeleted = false;
+                groupClosedWonDonationsContactsSC.rules.add(ruleOppTypeConSC);
             }
 
             if (CRLP_DefaultConfigBuilder.legacySettings.npo02__Soft_Credit_Roles__c != null) {
-                CRLP_RollupCMT.FilterRule ruleSoftCreditRoles = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContacts.recordName, contOpp +': Soft Credit Roles');
-                ruleSoftCreditRoles.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleSoftCreditRoles.recordName;
-                ruleSoftCreditRoles.objectName = SObjectType.Partial_Soft_Credit__c.getName();
-                ruleSoftCreditRoles.fieldName = SObjectType.Partial_Soft_Credit__c.Fields.Role_Name__c.getName();
-                ruleSoftCreditRoles.operationName = CMT_FilterRule.FilterOperation.IN_LIST.name();
-                ruleSoftCreditRoles.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Soft_Credit_Roles__c;
-                ruleSoftCreditRoles.isDeleted = false;
-                groupClosedWonDonationsContacts.rules.add(ruleSoftCreditRoles);
+                CRLP_RollupCMT.FilterRule ruleSoftCreditRolesCon = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsContactsSC.recordName, contOpp +': Soft Credit Roles');
+                ruleSoftCreditRolesCon.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleSoftCreditRolesCon.recordName;
+                ruleSoftCreditRolesCon.objectName = SObjectType.Partial_Soft_Credit__c.getName();
+                ruleSoftCreditRolesCon.fieldName = SObjectType.Partial_Soft_Credit__c.Fields.Role_Name__c.getName();
+                ruleSoftCreditRolesCon.operationName = CMT_FilterRule.FilterOperation.IN_LIST.name();
+                ruleSoftCreditRolesCon.value = CRLP_DefaultConfigBuilder.legacySettings.npo02__Soft_Credit_Roles__c;
+                ruleSoftCreditRolesCon.isDeleted = false;
+                groupClosedWonDonationsContactsSC.rules.add(ruleSoftCreditRolesCon);
             }
         }
 
@@ -235,14 +320,14 @@ public class CRLP_DefaultConfigBuilder_SVC {
         groupAllocations.recordName = CRLP_DefaultConfigBuilder.FilterGroup_Allocations;
         groupAllocations.isDeleted = false;
 
-        CRLP_RollupCMT.FilterRule ruleCloseWonStage3 = new CRLP_RollupCMT.FilterRule(groupAllocations.recordName, 'Allocations: Won Only');
-        ruleCloseWonStage3.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStage3.recordName;
-        ruleCloseWonStage3.objectName = 'Opportunity';
-        ruleCloseWonStage3.fieldName = 'IsWon';
-        ruleCloseWonStage3.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
-        ruleCloseWonStage3.value = 'true';
-        ruleCloseWonStage3.isDeleted = false;
-        groupAllocations.rules.add(ruleCloseWonStage3);
+        CRLP_RollupCMT.FilterRule ruleCloseWonStageAllo = new CRLP_RollupCMT.FilterRule(groupAllocations.recordName, 'Allocations: Won Only');
+        ruleCloseWonStageAllo.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStageAllo.recordName;
+        ruleCloseWonStageAllo.objectName = 'Opportunity';
+        ruleCloseWonStageAllo.fieldName = 'IsWon';
+        ruleCloseWonStageAllo.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
+        ruleCloseWonStageAllo.value = 'true';
+        ruleCloseWonStageAllo.isDeleted = false;
+        groupAllocations.rules.add(ruleCloseWonStageAllo);
 
         if (alloRTExclusionsExist) {
             CRLP_RollupCMT.FilterRule ruleRecordType = new CRLP_RollupCMT.FilterRule(groupAllocations.recordName, 'Allocations: Excluded Record Types');
@@ -269,12 +354,12 @@ public class CRLP_DefaultConfigBuilder_SVC {
         // ==============================================================================================================
         // Default "Opportunities: Open" filter group -- Recurring Donations Rollups
         // ==============================================================================================================
-        CRLP_RollupCMT.FilterGroup groupOpenDonations = new CRLP_RollupCMT.FilterGroup('Opportunities: Open');
+        CRLP_RollupCMT.FilterGroup groupOpenDonations = new CRLP_RollupCMT.FilterGroup('Opps: Open');
         groupOpenDonations.recordName = CRLP_DefaultConfigBuilder.FilterGroup_OpenOpps;
         groupOpenDonations.description = 'All open Opportunities';
         groupOpenDonations.isDeleted = false;
 
-        CRLP_RollupCMT.FilterRule ruleOpenStage = new CRLP_RollupCMT.FilterRule(groupOpenDonations.recordName, 'Opportunities: Not Closed Only');
+        CRLP_RollupCMT.FilterRule ruleOpenStage = new CRLP_RollupCMT.FilterRule(groupOpenDonations.recordName, 'Opps: Not Closed Only');
         ruleOpenStage.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleOpenStage.recordName;
         ruleOpenStage.objectName = 'Opportunity';
         ruleOpenStage.fieldName = 'isClosed';
@@ -286,24 +371,24 @@ public class CRLP_DefaultConfigBuilder_SVC {
         // ==============================================================================================================
         // Default "Donations: Close/Won Stage WITHOUT RT Exclusions" filter group -- Recurring Donations Rollups
         // ==============================================================================================================
-        CRLP_RollupCMT.FilterGroup groupClosedWonDonationsNoRTExclusions = new CRLP_RollupCMT.FilterGroup('Opportunities: Won (Recurring Donations)');
+        CRLP_RollupCMT.FilterGroup groupClosedWonDonationsNoRTExclusions = new CRLP_RollupCMT.FilterGroup('Opps: Won (Recurring Donations)');
         groupClosedWonDonationsNoRTExclusions.recordName = CRLP_DefaultConfigBuilder.FilterGroup_ClosedWonOpps_NoRTExclusions;
         groupClosedWonDonationsNoRTExclusions.description = 'Won Opportunities used for Recurring Donations Rollups.';
         groupClosedWonDonationsNoRTExclusions.isDeleted = false;
 
-        CRLP_RollupCMT.FilterRule ruleCloseWonStage4 = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsNoRTExclusions.recordName, 'Opportunities: Won Only (RD)');
-        ruleCloseWonStage4.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStage4.recordName;
-        ruleCloseWonStage4.objectName = 'Opportunity';
-        ruleCloseWonStage4.fieldName = 'IsWon';
-        ruleCloseWonStage4.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
-        ruleCloseWonStage4.value = 'true';
-        ruleCloseWonStage4.isDeleted = false;
-        groupClosedWonDonationsNoRTExclusions.rules.add(ruleCloseWonStage4);
+        CRLP_RollupCMT.FilterRule ruleCloseWonStageRD = new CRLP_RollupCMT.FilterRule(groupClosedWonDonationsNoRTExclusions.recordName, 'Opps: Won Only (RD)');
+        ruleCloseWonStageRD.recordName = CRLP_DefaultConfigBuilder.RecordNamePrefix + ruleCloseWonStageRD.recordName;
+        ruleCloseWonStageRD.objectName = 'Opportunity';
+        ruleCloseWonStageRD.fieldName = 'IsWon';
+        ruleCloseWonStageRD.operationName = CMT_FilterRule.FilterOperation.EQUALS.name();
+        ruleCloseWonStageRD.value = 'true';
+        ruleCloseWonStageRD.isDeleted = false;
+        groupClosedWonDonationsNoRTExclusions.rules.add(ruleCloseWonStageRD);
 
         // ==============================================================================================================
         // Default "Payments: Paid" filter group
         // ==============================================================================================================
-        CRLP_RollupCMT.FilterGroup groupPaymentsPaid = new CRLP_RollupCMT.FilterGroup(acctPmt + ': Paid' + ( acctRTExclusionsExist ? ' excl Rec Types' : ''));
+        CRLP_RollupCMT.FilterGroup groupPaymentsPaid = new CRLP_RollupCMT.FilterGroup(acctPmt + ': Paid' + ( acctRTExclusionsExist ? ' Excl Rec Types' : ''));
         groupPaymentsPaid.recordName = CRLP_DefaultConfigBuilder.FilterGroup_PaymentsPaid;
         groupPaymentsPaid.description = 'All paid Payments.'+
                 (acctRTExclusionsExist ? ' Excludes Record Types as defined in legacy NPSP Rollup Settings.' : '');
@@ -346,7 +431,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             // ==============================================================================================================
             // Default "Payments: Paid" filter group CONTACTS ONLY
             // ==============================================================================================================
-            groupPaymentsPaidContacts = new CRLP_RollupCMT.FilterGroup(contPmt + ': Paid' + ( conRTExclusionsExist ? ' excl Rec Types' : ''));
+            groupPaymentsPaidContacts = new CRLP_RollupCMT.FilterGroup(contPmt + ': Paid' + ( conRTExclusionsExist ? ' Excl Rec Types' : ''));
             groupPaymentsPaidContacts.recordName = CRLP_DefaultConfigBuilder.FilterGroup_PaymentsPaid_Contacts;
             groupPaymentsPaidContacts.description = 'All paid Payments.'+
                     (conRTExclusionsExist ? ' Excludes Record Types as defined in legacy NPSP Rollup Settings.' : '');
@@ -388,7 +473,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
         // ==============================================================================================================
         // Default "Payments: Written Off" filter group
         // ==============================================================================================================
-        CRLP_RollupCMT.FilterGroup groupPaymentsWrittenOff = new CRLP_RollupCMT.FilterGroup(acctPmt + ': WrittenOff' + ( acctRTExclusionsExist ? ' excl Rec Types' : ''));
+        CRLP_RollupCMT.FilterGroup groupPaymentsWrittenOff = new CRLP_RollupCMT.FilterGroup(acctPmt + ': WrittenOff' + ( acctRTExclusionsExist ? ' Excl Rec Types' : ''));
         groupPaymentsWrittenOff.recordName = CRLP_DefaultConfigBuilder.FilterGroup_PaymentsWrittenOff;
         groupPaymentsWrittenOff.description = 'All written off Payments.';
         groupPaymentsWrittenOff.isDeleted = false;
@@ -430,7 +515,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             // ==============================================================================================================
             // Default "Payments: Written Off" filter group CONTACTS ONLY
             // ==============================================================================================================
-            groupPaymentsWrittenOffContacts = new CRLP_RollupCMT.FilterGroup(contPmt + ': WrittenOff' + ( conRTExclusionsExist ? ' excl Rec Types' : ''));
+            groupPaymentsWrittenOffContacts = new CRLP_RollupCMT.FilterGroup(contPmt + ': WrittenOff' + ( conRTExclusionsExist ? ' Excl Rec Types' : ''));
             groupPaymentsWrittenOffContacts.recordName = CRLP_DefaultConfigBuilder.FilterGroup_PaymentsWrittenOff_Contacts;
             groupPaymentsWrittenOffContacts.description = 'All written off Payments.'+
                     (conRTExclusionsExist ? ' Excludes Record Types as defined in legacy NPSP Rollup Settings.' : '');
@@ -474,7 +559,8 @@ public class CRLP_DefaultConfigBuilder_SVC {
         // ==============================================================================================================
 
         List<CRLP_RollupCMT.FilterGroup> groups = new List<CRLP_RollupCMT.FilterGroup>{
-                groupClosedWonDonations,
+                groupClosedWonDonationsHC,
+                groupClosedWonDonationsSC,
                 groupMemberships,
                 groupAllocations,
                 groupOpenDonations,
@@ -482,8 +568,11 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 groupPaymentsPaid,
                 groupPaymentsWrittenOff
         };
-        if (groupClosedWonDonationsContacts != null) {
-            groups.add(groupClosedWonDonationsContacts);
+        if (groupClosedWonDonationsContactsHC != null) {
+            groups.add(groupClosedWonDonationsContactsHC);
+        }
+        if (groupClosedWonDonationsContactsSC != null) {
+            groups.add(groupClosedWonDonationsContactsSC);
         }
         if (groupPaymentsPaidContacts != null) {
             groups.add(groupPaymentsPaidContacts);
@@ -600,8 +689,8 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 // rollup.recordName = 'UDR_' + rollup.recordName;
                 rollup.description = 'User Defined Roll-up';
                 rollup.filterGroupRecordName = (udr.npo02__Object_Name__c == 'Account'
-                        ? CRLP_DefaultConfigBuilder.FilterGroup_Opps_Accounts
-                        : CRLP_DefaultConfigBuilder.FilterGroup_Opps_Contacts);
+                        ? CRLP_DefaultConfigBuilder.FilterGroup_Opps_Accounts_HC
+                        : CRLP_DefaultConfigBuilder.FilterGroup_Opps_Contacts_HC);
                 rollup.summaryObject = applyNameSpaceToObjectField(udr.npo02__Object_Name__c);
                 rollup.summaryField = applyNameSpaceToObjectField(udr.npo02__Target_Field__c);
                 rollup.detailObject = 'Opportunity';

--- a/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
@@ -555,10 +555,15 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 rollup.intValue = Integer.valueOf(rollupDetails[6]);
             }
 
-            // If the legacy 'Enable Soft Credit Rollups' field is false, set all the soft credit rollup
-            // definitions to inactive.
             if (CRLP_DefaultConfigBuilder.legacySettings.npo02__Enable_Soft_Credit_Rollups__c == false &&
                     rollupDetails[2] == CRLP_DefaultConfigBuilder.pscAmountFld) {
+                // If the legacy 'Enable Soft Credit Rollups' field is false,
+                // set all the soft credit rollup definitions to inactive.
+                rollup.isActive = false;
+            } else if (CRLP_DefaultConfigBuilder.legacySettings.npo02__Membership_Record_Types__c == null &&
+                    rollupDetails[1] == CRLP_DefaultConfigBuilder.FilterGroup_Membership) {
+                // If the legacy Membership Record Type setting is null,
+                // set all the membership rollup definitions to inactive.
                 rollup.isActive = false;
             } else {
                 rollup.isActive = true;

--- a/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
@@ -695,10 +695,19 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 rollup.summaryField = applyNameSpaceToObjectField(udr.npo02__Target_Field__c);
                 rollup.detailObject = 'Opportunity';
                 rollup.detailField = udr.npo02__Source_Field__c;
+
+                String udrSourceFieldType = UTIL_Describe.getFieldType('Opportunity', udr.npo02__Source_Field__c.toLowerCase());
+                Boolean sourceFieldIsAmount = (udrSourceFieldType == 'CURRENCY'
+                                                || udrSourceFieldType == 'INTEGER'
+                                                || udrSourceFieldType == 'PERCENT'
+                                                || udrSourceFieldType == 'DOUBLE');
+                Boolean sourceFieldIsDate = (udrSourceFieldType == 'DATE'
+                                                || udrSourceFieldType == 'DATETIME');
+
                 rollup.amountObject = 'Opportunity';
-                rollup.amountField = 'Amount';
+                rollup.amountField = (sourceFieldIsAmount ? udr.npo02__Source_Field__c : 'Amount');
                 rollup.dateObject = 'Opportunity';
-                rollup.dateField = 'CloseDate';
+                rollup.dateField = (sourceFieldIsDate ? udr.npo02__Source_Field__c : 'CloseDate');
                 rollup.operation = convertUDROperationMap.get(udr.npo02__Field_Action__c);
                 rollup.useFiscalYear = CRLP_DefaultConfigBuilder.legacySettings.npo02__Use_Fiscal_Year_for_Rollups__c;
                 rollup.isActive = true;

--- a/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_SVC.cls
@@ -38,11 +38,11 @@
 */
 public class CRLP_DefaultConfigBuilder_SVC {
 
-    /** @description Use this Map of RecordTypes by Id to convert the legacy settings into a DeveloperName for the Filter Rule */
-    private static final Map<Id, RecordType> recordTypesById = new Map<Id, RecordType>(
+    /** @description Use this Map of Opp RecordTypes by Id to convert the legacy settings into a DeveloperName for the Filter Rule */
+    private static final Map<Id, RecordType> oppRecordTypesById = new Map<Id, RecordType>(
         [SELECT Id, RecordType.DeveloperName
             FROM RecordType
-            WHERE SobjectType = 'Opportunity' AND IsActive = True]);
+            WHERE SobjectType = 'Opportunity']);
 
     /*************************************************************************************************************
      * @description Call each of the methods in this class to build the default Filter Groups and each of the four
@@ -113,7 +113,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordType.objectName = 'Opportunity';
             ruleRecordType.fieldName = 'RecordTypeId';
             ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c, 'Membership');
+            ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
             ruleRecordType.isDeleted = false;
             groupClosedWonDonations.rules.add(ruleRecordType);
         }
@@ -168,7 +168,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 ruleRecordType.objectName = 'Opportunity';
                 ruleRecordType.fieldName = 'RecordTypeId';
                 ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c, 'Membership');
+                ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
                 ruleRecordType.isDeleted = false;
                 groupClosedWonDonationsContacts.rules.add(ruleRecordType);
             }
@@ -219,7 +219,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordType.objectName = 'Opportunity';
             ruleRecordType.fieldName = 'RecordTypeId';
             ruleRecordType.operationName = CMT_FilterRule.FilterOperation.IN_LIST.name();
-            ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Membership_Record_Types__c, 'Membership');
+            ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Membership_Record_Types__c);
             ruleRecordType.isDeleted = false;
             groupMemberships.rules.add(ruleRecordType);
         }
@@ -250,7 +250,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordType.objectName = 'Opportunity';
             ruleRecordType.fieldName = 'RecordTypeId';
             ruleRecordType.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordType.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacyAllocSettings.Excluded_Opp_RecTypes__c, null);
+            ruleRecordType.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacyAllocSettings.Excluded_Opp_RecTypes__c);
             ruleRecordType.isDeleted = false;
             groupAllocations.rules.add(ruleRecordType);
         }
@@ -324,7 +324,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordTypePaid.objectName = 'Opportunity';
             ruleRecordTypePaid.fieldName = 'RecordTypeId';
             ruleRecordTypePaid.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordTypePaid.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c, 'Membership');
+            ruleRecordTypePaid.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
             ruleRecordTypePaid.isDeleted = false;
             groupPaymentsPaid.rules.add(ruleRecordTypePaid);
         }
@@ -367,7 +367,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 ruleRecordTypePaidCon.objectName = 'Opportunity';
                 ruleRecordTypePaidCon.fieldName = 'RecordTypeId';
                 ruleRecordTypePaidCon.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleRecordTypePaidCon.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c, 'Membership');
+                ruleRecordTypePaidCon.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
                 ruleRecordTypePaidCon.isDeleted = false;
                 groupPaymentsPaidContacts.rules.add(ruleRecordTypePaidCon);
             }
@@ -408,7 +408,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
             ruleRecordTypeWrittenOff.objectName = 'Opportunity';
             ruleRecordTypeWrittenOff.fieldName = 'RecordTypeId';
             ruleRecordTypeWrittenOff.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-            ruleRecordTypeWrittenOff.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c, 'Membership');
+            ruleRecordTypeWrittenOff.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Account_Opp_Rectypes__c);
             ruleRecordTypeWrittenOff.isDeleted = false;
             groupPaymentsWrittenOff.rules.add(ruleRecordTypeWrittenOff);
         }
@@ -451,7 +451,7 @@ public class CRLP_DefaultConfigBuilder_SVC {
                 ruleRecordTypeWrittenOffCon.objectName = 'Opportunity';
                 ruleRecordTypeWrittenOffCon.fieldName = 'RecordTypeId';
                 ruleRecordTypeWrittenOffCon.operationName = CMT_FilterRule.FilterOperation.NOT_IN_LIST.name();
-                ruleRecordTypeWrittenOffCon.value = convertExcludedRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c, 'Membership');
+                ruleRecordTypeWrittenOffCon.value = convertRecordTypeIdsToDevNames(CRLP_DefaultConfigBuilder.legacySettings.npo02__Excluded_Contact_Opp_Rectypes__c);
                 ruleRecordTypeWrittenOffCon.isDeleted = false;
                 groupPaymentsWrittenOffContacts.rules.add(ruleRecordTypeWrittenOffCon);
             }
@@ -625,22 +625,17 @@ public class CRLP_DefaultConfigBuilder_SVC {
      * Record Type Developer Names. These are easier to 'read' (i.e., self-documenting) and more importantly it allows
      * for deploying a custom Filter Rule from a Sandbox to Production (where the Record Type Id might be different
      * if the RT was created in the Sandbox).
-     * @param excludedRtIds semi-colon separatedlist of Record Type Id's
-     * @param defRT If excludedRtIds is null, this record type developer name is always excluded (optional)
+     * @param rtIds semi-colon separatedlist of Record Type Id's
      * @return Semi-colon separated list of Record Type Developer Names
      */
-    private static String convertExcludedRecordTypeIdsToDevNames(String excludedRtIds, String defRT) {
+    private static String convertRecordTypeIdsToDevNames(String rtIds) {
         Set<String> rtDevNames = new Set<String>();
-        if (excludedRtIds != null) {
-            for (String rtId : excludedRtIds.split(';')) {
-                if (recordTypesById.containsKey(rtId)) {
-                    rtDevNames.add(recordTypesById.get(rtId).DeveloperName);
-                } else {
-                    rtDevNames.add(rtId);
+        if (rtIds != null) {
+            for (String rtId : rtIds.split(';')) {
+                if (oppRecordTypesById.containsKey(rtId)) {
+                    rtDevNames.add(oppRecordTypesById.get(rtId).DeveloperName);
                 }
             }
-        } else if (defRT != null) {
-            rtDevNames.add(defRT);   // default to this if there are no current exclusions
         }
         return String.join(new List<String>(rtDevNames), ';');
     }

--- a/src/classes/CRLP_DefaultConfigBuilder_TEST.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_TEST.cls
@@ -100,7 +100,7 @@ private class CRLP_DefaultConfigBuilder_TEST {
             }
         }
 
-        System.assertEquals(8, fgCount, 'There should be 7 filter groups');
+        System.assertEquals(8, fgCount, 'There should be 8 filter groups');
         System.assertEquals(CRLP_DefaultConfigBuilder.rollupDetailsBySummaryField.size(), rlpCount, 'There should be 87 rollups');
     }
 
@@ -146,7 +146,7 @@ private class CRLP_DefaultConfigBuilder_TEST {
         }
 
 
-        System.assertEquals(12, fgCount, 'There should be 10 filter groups');
+        System.assertEquals(12, fgCount, 'There should be 12 filter groups');
         System.assertEquals(CRLP_DefaultConfigBuilder.rollupDetailsBySummaryField.size(), rlpCount, 'There should be 87 rollups');
     }
 }

--- a/src/classes/CRLP_DefaultConfigBuilder_TEST.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder_TEST.cls
@@ -100,7 +100,7 @@ private class CRLP_DefaultConfigBuilder_TEST {
             }
         }
 
-        System.assertEquals(7, fgCount, 'There should be 7 filter groups');
+        System.assertEquals(8, fgCount, 'There should be 7 filter groups');
         System.assertEquals(CRLP_DefaultConfigBuilder.rollupDetailsBySummaryField.size(), rlpCount, 'There should be 87 rollups');
     }
 
@@ -146,7 +146,7 @@ private class CRLP_DefaultConfigBuilder_TEST {
         }
 
 
-        System.assertEquals(10, fgCount, 'There should be 10 filter groups');
+        System.assertEquals(12, fgCount, 'There should be 10 filter groups');
         System.assertEquals(CRLP_DefaultConfigBuilder.rollupDetailsBySummaryField.size(), rlpCount, 'There should be 87 rollups');
     }
 }

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -154,6 +154,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
         UTIL_CustomSettingsFacade.getOrgBDESettings();
         UTIL_CustomSettingsFacade.getOrgAllocationsSettings();
         UTIL_CustomSettingsFacade.getOrgDataImportSettings();
+        UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
 
         UTIL_Debug.debug('****NPSP-to-Cumulus Map: ' + JSON.serializePretty(npspToCumulusMap));
  

--- a/src/pages/CRLP_RollupSetup.page
+++ b/src/pages/CRLP_RollupSetup.page
@@ -34,7 +34,6 @@
   @group-content ../../ApexDocContent/Rollups2.htm
   @description Wrapper page for the Rollups UI Lightning Container.
 -->
-
 <apex:page standardStylesheets="false" applyBodyTag="false" id="CRLP_Setup" showHeader="true" sideBar="false"
            controller="CRLP_RollupSetup_CTRL" docType="html-5.0">
 
@@ -42,27 +41,20 @@
     <apex:includeLightning/>
 
     <div class="slds-scope">
-
         <div id="gridWrapperCmp">
         </div>
-
     </div>
 
     <script>
         var ns = '{!namespacePrefix}';
-        var nsPrefix;
-        if (ns === '') {
-            nsPrefix = '';
+        if (!ns || ns === '') {
             ns = 'c';
-        } else {
-            nsPrefix = ns + '__';
         }
-
         $Lightning.use(ns + ":CRLP_RollupApp", function() {
             $Lightning.createComponent(ns + ":CRLP_RollupsContainer",
-                    {},
-                    "gridWrapperCmp",
-                    function() { }
+                {},
+                "gridWrapperCmp",
+                function() { }
             );
         });
     </script>


### PR DESCRIPTION
* Create the Customizable_Rollup_Settings record during package install. Otherwise found that the next time this was referenced was by the scheduled batch jobs at night, all of which attempted to insert the default record at the same time causing an error.
* Fix the enablement process to not exclude Inactive RecordTypes during the conversion from legacy RecordType.Id to RecordType.DeveloperName when building CRLP filters
* Remove the default RecordType for building the CRLP filters. All values should always come directly from the custom settings object, even if the field in the custom settings is null
* In Skew Mode jobs, significantly increase the MAX_BATCHES_TO_HOLD_BEFORE_COMMIT value to avoid unnecessary commits to the parent object.
* Create separate Filter Groups for HardCredit and SoftCredit rather than use the same group for both types of rollups (even though that is technically supported)

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
