### PR TITLE
CCI: Disable lex caching when creating new feature and dev scratch orgs

### DIFF
--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -8,6 +8,9 @@
       "DisableParallelApexTesting",
       "S1DesktopEnabled",
       "Translation"
+    ],
+    "disabled": [
+      "S1EncryptedStoragePref2"
     ]
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -8,6 +8,9 @@
       "DisableParallelApexTesting",
       "S1DesktopEnabled",
       "Translation"
+    ],
+    "disabled": [
+      "S1EncryptedStoragePref2"
     ]
   }
 }


### PR DESCRIPTION
* Add the `S1EncryptedStoragePref2` property as disabled to the json org file.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
