### PR TITLE
Rollups: Cache individual filter rule results to improve performance

### DIFF
--- a/src/classes/CMT_FilterRule.cls
+++ b/src/classes/CMT_FilterRule.cls
@@ -146,6 +146,14 @@ public class CMT_FilterRule {
     }
 
     /**
+     * @description Returns a "unique" string that can be used to retrieve a cached version of this result
+     * object+field+operation+constant
+     */
+    public String getCacheKeyPrefix() {
+        return (this.objectName + '.' + this.field + '.' + this.operation.name() + '.' + this.constant).toLowerCase();
+    }
+
+    /**
      * @description Evaluate the passed SObject record against the current FilterRule instance
      * @param record to evaluate
      * @return True if the record matches and will be included in the roll-up, false otherwise

--- a/src/classes/CMT_FilterRuleEvaluation_SVC.cls
+++ b/src/classes/CMT_FilterRuleEvaluation_SVC.cls
@@ -52,6 +52,9 @@ public class CMT_FilterRuleEvaluation_SVC {
     @TestVisible
     private static Map<String, Boolean> cachedFilterEvalResults = new Map<String, Boolean>();
 
+    /* @description When working with the filterRule Cache, if the recordId is null make up a value to use to make each record unique */
+    private static Integer nullIdRowCounter = 1;
+
     /**
      * @description Allow the cache of filter group eval results to be cleared externally, such as when the
      * detail record changes.
@@ -77,7 +80,8 @@ public class CMT_FilterRuleEvaluation_SVC {
         // Build a unique key of a concatenation of the Id's of all the detail rows.
         String cacheKey = filterGroupId + '.';
         for (SObject record : detailRows) {
-            cacheKey += record.Id;
+            String recordId = (record.Id == null ? (nullIdRowCounter++).format() : record.Id);
+            cacheKey += recordId;
         }
         // If this set of detail rows has already been evaluated for this filter group, return the cached result
         if (cachedFilterEvalResults.containsKey(cacheKey)) {
@@ -97,11 +101,23 @@ public class CMT_FilterRuleEvaluation_SVC {
         List<CMT_FilterRule> rulesToEvaluate = mapOfFilterRulesByGroupId.get(filterGroupId);
 
         for (SObject record : detailRows) {
+            String recordId = (record.Id == null ? (nullIdRowCounter++).format() : record.Id);
             SObjectType objType = record.getSObjectType();
             for (CMT_FilterRule rule : rulesToEvaluate) {
                 if (objType == rule.getObjectType()) {
-                    if (!rule.isIncluded(record)) {
+                    // Not only caching the entire FilterGroup result, we're also caching the
+                    // individual filter rule result to help with performance.
+                    String ruleCacheKey = recordId + '.' + rule.getCacheKeyPrefix();
+                    Boolean isIncluded;
+                    if (cachedFilterEvalResults.containsKey(ruleCacheKey)) {
+                        isIncluded = cachedFilterEvalResults.get(ruleCacheKey);
+                    } else {
+                        isIncluded = rule.isIncluded(record);
+                        cachedFilterEvalResults.put(ruleCacheKey, isIncluded);
+                    }
+                    if (!isIncluded) {
                         // No reason to continue if any one rule for any one record fails the evaluation
+                        cachedFilterEvalResults.put(cacheKey, false);
                         return false;
                     }
                 }


### PR DESCRIPTION
# Critical Changes

Re-instate Filter Rule caching to improve performance. This was implemented and removed prior to rebuilding the Skew mode processing logic to use a dispatcher class. The original concern was that the cache (i.e. static var) contributed to the heap storage usage issue that plagued Skew mode. Now that the dispatcher is used to process data in smaller chunks, this isn't an issue. As a result, add this cache back in so that the filter rule eval service only evaluates a single rule type for a record one time. For example, multiple filter groups may have a single rule for IsWon=True. The Cache would store the result of that evaluation with a key of `Recordid.Opportunity.IsWon.Equals.True` into the cache map. A subsequent evaluation of the same type of rule for the same record could simply pull the result from the cache rather than attempt to evaluate the rule again.

I validated performance against this a few times in the XL org. The jobs did run about 10 minutes faster (~5%). It's not a significant increase, but it's not negligible either.

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
