### PR TITLE
Rollups: Fixed back to settings link breaking in namespaced org

### DIFF
--- a/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainer.cmp
+++ b/src/aura/CRLP_RollupsContainer/CRLP_RollupsContainer.cmp
@@ -101,7 +101,7 @@
         <!--BEGIN BREADCRUMB-->
         <div class="slds-p-horizontal_large slds-p-top_large">
             <lightning:breadcrumbs>
-                <lightning:breadcrumb label="{!v.labels.returnNPSP}" href="/apex/STG_SettingsManager"/>
+                <lightning:breadcrumb label="{!v.labels.returnNPSP}" href="{!v.labels.urlNamespacePrefix}"/>
                 <aura:if isTrue="{!v.isCRLPEnabled}">
                     <aura:if isTrue="{! and(!v.isRollupsGrid, or(v.lastActiveRecordId == null, v.lastActiveRecordId == 'null'))}">
                         <lightning:breadcrumb label="{!v.labels.rollupSummaryTitle}"

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -513,7 +513,7 @@ public with sharing class CRLP_RollupUI_SVC {
     */
     public static Map<String, String> getAppLabels() {
 
-        PageReference settingsPage = new PageReference('/apex/STG_SettingsManager');
+        PageReference settingsPage = Page.STG_SettingsManager;
 
             Map<String, String> labels = new Map<String,String>
             {

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -513,6 +513,8 @@ public with sharing class CRLP_RollupUI_SVC {
     */
     public static Map<String, String> getAppLabels() {
 
+        PageReference settingsPage = new PageReference('/apex/STG_SettingsManager');
+
             Map<String, String> labels = new Map<String,String>
             {
                 'action' => Label.stgLabelActionColumn,
@@ -648,6 +650,7 @@ public with sharing class CRLP_RollupUI_SVC {
                 'summaryObject' => Schema.Rollup__mdt.Summary_Object__c.getDescribe().getLabel(),
                 'timeBoundOperationType' => Schema.Rollup__mdt.Time_Bound_Operation_Type__c.getDescribe().getLabel(),
                 'useFiscalYear' => Schema.Rollup__mdt.Use_Fiscal_Year__c.getDescribe().getLabel(),
+                'urlNamespacePrefix' => settingsPage.getUrl(),
                 'view' => Label.stgLabelView,
                 'warning' => Label.PageMessagesWarning
             };


### PR DESCRIPTION
# Critical Changes

# Changes
- Fixed issue with the back button not containing the namespace by moving the URL into the SVC class.
# Issues Closed
- Fixes #3195 
# New Metadata

# Deleted Metadata
