### PR TITLE
Rollups: FeatureParameter fix

### DIFF
--- a/src/classes/CMT_MetadataAPI.cls
+++ b/src/classes/CMT_MetadataAPI.cls
@@ -162,6 +162,9 @@ public class CMT_MetadataAPI {
             if (!Test.isRunningTest()) {
                 upsert crlpSettings;
             }
+            if (isSuccess) {
+                UTIL_OrgTelemetry_SVC.submitFeatureTelemetryToLMO();
+            }
         }
     }
 }

--- a/src/classes/STG_PanelCustomizableRollup_CTRL.cls
+++ b/src/classes/STG_PanelCustomizableRollup_CTRL.cls
@@ -158,6 +158,7 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
                         // there are existing rollups. just save the setting and reschedule jobs, don't deploy.
                         stgService.saveAll();
                         UTIL_MasterSchedulableHelper.setScheduledJobs();
+                        UTIL_OrgTelemetry_SVC.submitFeatureTelemetryToLMO();
                     }
 
                 } else {
@@ -166,9 +167,9 @@ public with sharing class STG_PanelCustomizableRollup_CTRL extends STG_Panel {
                     stgService.saveAll();
                     // reset to legacy jobs
                     UTIL_MasterSchedulableHelper.setScheduledJobs();
+                    UTIL_OrgTelemetry_SVC.submitFeatureTelemetryToLMO();
                 }
             }
-            UTIL_OrgTelemetry_SVC.submitFeatureTelemetryToLMO();
 
         } catch (Exception e) {
             Database.rollback(sp);


### PR DESCRIPTION
Because CRLP enablement is asynchronous, can't make the call to the submitFeatureTelemetryToLMO() method until the end of the async deployment process.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
