### PR TITLE
Rollups: Fix Error in Account HC rollup when Membership Rollups are disabled

### DIFF
--- a/src/classes/CRLP_Batch_Base_NonSkew.cls
+++ b/src/classes/CRLP_Batch_Base_NonSkew.cls
@@ -96,11 +96,9 @@ public abstract class CRLP_Batch_Base_NonSkew extends CRLP_Batch_Base {
             String query = CRLP_Query_SEL.buildObjectQueryForRollup(this.summaryObjectType);
 
             // Fields in the fieldsToCheckForNonZero[] list must always be in the Contact query
-            if (this.summaryObjectType == Contact.SObjectType) {
-                for (String f : fieldsToCheckForNonZero) {
-                    if (!query.containsIgnoreCase(f)) {
-                        query = query.split(' FROM ')[0] + ', ' + f + ' FROM ' + query.split(' FROM ')[1];
-                    }
+            for (String f : fieldsToCheckForNonZero) {
+                if (!query.containsIgnoreCase(f)) {
+                    query = query.split(' FROM ')[0] + ', ' + f + ' FROM ' + query.split(' FROM ')[1];
                 }
             }
 


### PR DESCRIPTION
Ensure that the list of specific fields to be checked for a value are always added to the appropriate query regardless of the type of rollup job.

# Critical Changes

# Changes

# Issues Closed

Fixes #3217

# New Metadata

# Deleted Metadata
