### PR TITLE
Rollups recalculate Recurring Donations Button

### DIFF
--- a/src/classes/CRLP_RecalculateBTN_CTRL.cls
+++ b/src/classes/CRLP_RecalculateBTN_CTRL.cls
@@ -85,6 +85,8 @@ public with sharing class CRLP_RecalculateBTN_CTRL {
                 jobType = CRLP_RollupProcessingOptions.RollupType.ContactHardCredit;
             } else if (this.objType == General_Accounting_Unit__c.SObjectType) {
                 jobType = CRLP_RollupProcessingOptions.RollupType.GAU;
+            } else if (this.objType == npe03__Recurring_Donation__c.SObjectType) {
+                jobType = CRLP_RollupProcessingOptions.RollupType.RecurringDonations;
             }
 
             // Is skew mode needed?
@@ -126,7 +128,10 @@ public with sharing class CRLP_RecalculateBTN_CTRL {
             } else if (this.objType == General_Accounting_Unit__c.SObjectType) {
                 ALLO_Rollup_SCHED rollup = new ALLO_Rollup_SCHED(recordId);
                 rollup.runRollups();
+            } else if (this.objType == npe03__Recurring_Donation__c.SObjectType) {
+                RD_RecurringDonations.updateRecurringDonationOnOppChangeFuture(new Set<Id>{ recordId });
             }
+
         }
         return null;
     }

--- a/src/classes/CRLP_RecalculateBTN_TEST.cls
+++ b/src/classes/CRLP_RecalculateBTN_TEST.cls
@@ -48,6 +48,17 @@ private class CRLP_RecalculateBTN_TEST {
 
         General_Accounting_Unit__c gau = new General_Accounting_Unit__c(Name = 'UNITTEST');
         insert gau;
+
+        npe03__Recurring_Donation__c rd = new npe03__Recurring_Donation__c();
+        rd.Name = 'test';
+        rd.npe03__Installments__c = 2;
+        rd.npe03__Contact__c = c.Id;
+        rd.npe03__Amount__c = 1;
+        rd.npe03__Installment_Period__c = system.label.npe03.RecurringDonationInstallmentPeriodYearly;
+        rd.npe03__Date_Established__c = date.newinstance(1970,6,12);
+        rd.npe03__Schedule_Type__c = system.label.npe03.RecurringDonationMultiplyValue;
+        rd.npe03__Open_Ended_Status__c = 'None'; 
+        insert rd;
     }
 
     /**
@@ -97,6 +108,19 @@ private class CRLP_RecalculateBTN_TEST {
         
         General_Accounting_Unit__c gau = [SELECT Id FROM General_Accounting_Unit__c LIMIT 1];
 
+        npe03__Recurring_Donation__c rd = [SELECT npe03__Paid_Amount__c, (SELECT StageName FROM npe03__Donations__r) FROM npe03__Recurring_Donation__c LIMIT 1];
+        rd.npe03__Paid_Amount__c = null;
+        rd.npe03__Donations__r[0].StageName = UTIL_UnitTestData_TEST.getClosedWonStage();
+
+        TDTM_TriggerHandler.disableTDTM = true;
+        update rd.npe03__Donations__r[0];
+        update rd;
+        TDTM_TriggerHandler.disableTDTM = false;
+
+        // Confirm that the initial value of the next payment is null.
+        rd = [SELECT npe03__Paid_Amount__c FROM npe03__Recurring_Donation__c LIMIT 1];
+        System.assert(rd.npe03__Paid_Amount__c == null);
+
         Test.startTest();
 
         CRLP_RecalculateBTN_CTRL ctlr = new CRLP_RecalculateBTN_CTRL(new ApexPages.StandardController(c));
@@ -107,13 +131,22 @@ private class CRLP_RecalculateBTN_TEST {
         System.assertEquals(false, ctlr.hasError, 'The controller constructor should have not generated an error');
         ctlr.buttonClick();
 
+        ctlr = new CRLP_RecalculateBTN_CTRL(new ApexPages.StandardController(rd));
+        System.assertEquals(false, ctlr.hasError, 'The controller constructor should have not generated an error');
+        ctlr.buttonClick();
+
         Test.stopTest();
 
-        // Confirm that the legacy rollup logic resets the value of the Total Gift and
-        // Soft Credit to 0;
+        // Confirm that the legacy rollup logic updates the value of the Total Gift and
+        // Soft Credit to a value different than the original value (100);
         c = [SELECT npo02__TotalOppAmount__c, npo02__Soft_Credit_Total__c FROM Contact LIMIT 1];
-        System.assert(c.npo02__TotalOppAmount__c == 0);
-        System.assert(c.npo02__Soft_Credit_Total__c == 0);
+        System.assert(c.npo02__TotalOppAmount__c != 100);
+        System.assert(c.npo02__Soft_Credit_Total__c != 100);
+
+        // Confirm that the legacy rollup logic updates the value of the RD rollup field Paid Amount.
+        // to a value different than the original value (null).
+        rd = [SELECT npe03__Paid_Amount__c FROM npe03__Recurring_Donation__c LIMIT 1];
+        System.assert(rd.npe03__Paid_Amount__c != null);
     }
 
     /**
@@ -138,6 +171,7 @@ private class CRLP_RecalculateBTN_TEST {
         Contact c = [SELECT Id, FirstName, LastName, AccountId, Account.Id FROM Contact LIMIT 1];
         Account a = c.Account;
         General_Accounting_Unit__c gau = [SELECT Id FROM General_Accounting_Unit__c LIMIT 1];
+        npe03__Recurring_Donation__c rd = [SELECT Id FROM npe03__Recurring_Donation__c LIMIT 1];
 
         System.assertEquals(0, [SELECT Count() FROM AsyncApexJob WHERE ApexClass.Name LIKE 'CRLP%'],
                 'Zero jobs should be currently scheduled');
@@ -174,7 +208,12 @@ private class CRLP_RecalculateBTN_TEST {
         ctlr.buttonClick();
         expectedJobCount++;
 
-        // validate that both the standard and the partial soft credit jobs were submitted
+        ctlr = new CRLP_RecalculateBTN_CTRL(new ApexPages.StandardController(rd));
+        System.assertEquals(false, ctlr.hasError, 'The controller constructor should have not generated an error');
+        ctlr.buttonClick();
+        expectedJobCount++;
+
+        // validate that the jobs were submitted
         System.assertEquals(expectedJobCount, [SELECT Count() FROM AsyncApexJob WHERE ApexClass.Name LIKE 'CRLP%'],
                 expectedJobCount + ' jobs should been queued');
 

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -17,4 +17,16 @@
         <trackTrending>false</trackTrending>
         <type>Checkbox</type>
     </fields>
+    <webLinks>
+        <fullName>Recalculate_Rollups</fullName>
+        <availability>online</availability>
+        <description>Recalculate Rollups</description>
+        <displayType>button</displayType>
+        <height>600</height>
+        <linkType>page</linkType>
+        <masterLabel>Recalculate Rollups</masterLabel>
+        <openType>sidebar</openType>
+        <page>CRLP_RollupRD_BTN</page>
+        <protected>false</protected>
+    </webLinks>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -450,6 +450,7 @@
         <members>CON_DeleteContactOverride</members>
         <members>CRLP_RollupAccount_BTN</members>
         <members>CRLP_RollupContact_BTN</members>
+        <members>CRLP_RollupRD_BTN</members>
         <members>CRLP_RollupSetup</members>
         <members>EP_ManageEPTemplate</members>
         <members>HH_CampaignDedupeBTN</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -2437,6 +2437,7 @@
         <members>Opportunity.Manage_Soft_Credits</members>
         <members>Opportunity.Refresh_Name</members>
         <members>Partial_Soft_Credit__c.Manage_Soft_Credits</members>
+        <members>npe03__Recurring_Donation__c.Recalculate_Rollups</members>
         <name>WebLink</name>
     </types>
     <types>

--- a/src/pages/CRLP_RollupRD_BTN.page
+++ b/src/pages/CRLP_RollupRD_BTN.page
@@ -1,0 +1,15 @@
+<apex:page standardController="npe03__Recurring_Donation__c" extensions="CRLP_RecalculateBTN_CTRL" action="{!buttonClick}" >
+    <apex:slds />
+    <div class="slds-scope">
+        <apex:form id="pgHeader">
+            <c:UTIL_PageHeader showBreadcrumb="false" parentEntityLabel="{! $ObjectType.npe03__Recurring_Donation__c.Label }"
+                               parentRecordName="{!$ObjectType.npe03__Recurring_Donation__c.Name }"
+                               parentRecordAction="/{!npe03__Recurring_Donation__c.Id}" header="Recalculate Roll-Ups"
+                               showSaveBtn="false" showCancelBtn="true"
+                               cancelLabel="Return" cancelAction="/{!npe03__Recurring_Donation__c.Id}"
+                               rendered="{!hasError == true}" />
+        </apex:form>
+        <c:UTIL_PageMessages />
+    </div>
+    <c:UTIL_NavigateBack recordId="{!npe03__Recurring_Donation__c.Id}" redirect="true" rendered="{!hasError == false}"/>
+</apex:page>

--- a/src/pages/CRLP_RollupRD_BTN.page-meta.xml
+++ b/src/pages/CRLP_RollupRD_BTN.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>CRLP_RollupRD_BTN</label>
+</ApexPage>


### PR DESCRIPTION
# Critical Changes

# Changes

- A new Recalculate Rollups button is available for the Recurring Donations page layout. The button recalculates all rollups for Recurring Donations using either the legacy Rollups engine or the new Customizable Rollups (if enabled). You will need to manually add the button to the appropriate Page Layouts to ensure that it is visible to users.

# Issues Closed

# New Metadata
CRLP_RollupRD_BTN.page

# Deleted Metadata
