### PR TITLE
Rollups: Prevent duplicate batches running

### DIFF
--- a/src/classes/CRLP_AccountSkew_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_BATCH.cls
@@ -62,7 +62,9 @@ public class CRLP_AccountSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_AccountSkew_BATCH')) {
+                Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
+            }
         }
     }
 }

--- a/src/classes/CRLP_AccountSkew_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_BATCH.cls
@@ -66,9 +66,7 @@ public class CRLP_AccountSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_AccountSkew_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_BATCH.cls
@@ -61,9 +61,14 @@ public class CRLP_AccountSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = 'CRLP_AccountSkew_BATCH';
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_AccountSkew_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_AccountSkew_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_BATCH.cls
@@ -66,7 +66,7 @@ public class CRLP_AccountSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_AccountSkew_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_BATCH.cls
@@ -61,7 +61,7 @@ public class CRLP_AccountSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        String className = 'CRLP_AccountSkew_BATCH';
+        String className = CRLP_AccountSkew_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);

--- a/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
@@ -61,10 +61,15 @@ public class CRLP_AccountSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = 'CRLP_AccountSkew_SoftCredit_BATCH';
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_AccountSkew_SoftCredit_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
@@ -67,9 +67,7 @@ public class CRLP_AccountSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
@@ -61,7 +61,7 @@ public class CRLP_AccountSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        String className = 'CRLP_AccountSkew_SoftCredit_BATCH';
+        String className = CRLP_AccountSkew_SoftCredit_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,

--- a/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
@@ -67,7 +67,7 @@ public class CRLP_AccountSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_AccountSkew_SoftCredit_BATCH.cls
@@ -62,8 +62,10 @@ public class CRLP_AccountSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
-                    CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_AccountSkew_SoftCredit_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
+                        CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_Account_BATCH.cls
+++ b/src/classes/CRLP_Account_BATCH.cls
@@ -66,7 +66,7 @@ public class CRLP_Account_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_Account_BATCH.cls
+++ b/src/classes/CRLP_Account_BATCH.cls
@@ -61,7 +61,7 @@ public class CRLP_Account_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJobs('CRLP_Account_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Account_BATCH')) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             }

--- a/src/classes/CRLP_Account_BATCH.cls
+++ b/src/classes/CRLP_Account_BATCH.cls
@@ -66,9 +66,7 @@ public class CRLP_Account_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_Account_BATCH.cls
+++ b/src/classes/CRLP_Account_BATCH.cls
@@ -61,8 +61,10 @@ public class CRLP_Account_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
-                    CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJobs('CRLP_Account_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
+                        CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_Account_BATCH.cls
+++ b/src/classes/CRLP_Account_BATCH.cls
@@ -60,10 +60,15 @@ public class CRLP_Account_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = CRLP_Account_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Account_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_Account_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Account_SoftCredit_BATCH.cls
@@ -60,7 +60,7 @@ public class CRLP_Account_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        String className = 'CRLP_Account_SoftCredit_BATCH';
+        String className = CRLP_Account_SoftCredit_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,

--- a/src/classes/CRLP_Account_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Account_SoftCredit_BATCH.cls
@@ -60,10 +60,15 @@ public class CRLP_Account_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = 'CRLP_Account_SoftCredit_BATCH';
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Account_SoftCredit_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_Account_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Account_SoftCredit_BATCH.cls
@@ -61,8 +61,10 @@ public class CRLP_Account_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
-                    CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Account_SoftCredit_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
+                        CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_Account_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Account_SoftCredit_BATCH.cls
@@ -66,7 +66,7 @@ public class CRLP_Account_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_Account_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Account_SoftCredit_BATCH.cls
@@ -66,9 +66,7 @@ public class CRLP_Account_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_Batch_Base.cls
+++ b/src/classes/CRLP_Batch_Base.cls
@@ -312,11 +312,19 @@ public abstract class CRLP_Batch_Base {
         return pscDetailRecords;
     }
 
-    public class BatchException extends Exception {}
+    /*******************************************************************************************************
+     * @description CRLP Batch Job custom exception
+     */
+    public class CRLPBatchException extends Exception {}
 
+    /*******************************************************************************************************
+     * @description Shared method to log an Error record when a CRLP Batch is skipped because
+     * the previous job hadn't yet completed
+     * @param className The name of the skipped batch class to be used in the error message
+     */
     public void logDuplicateBatchError(String className) {
 
-        BatchException ex = new BatchException();
+        CRLPBatchException ex = new CRLPBatchException();
         ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
         ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
 

--- a/src/classes/CRLP_Batch_Base.cls
+++ b/src/classes/CRLP_Batch_Base.cls
@@ -311,4 +311,7 @@ public abstract class CRLP_Batch_Base {
 
         return pscDetailRecords;
     }
+
+    public class BatchException extends Exception {}
+
 }

--- a/src/classes/CRLP_Batch_Base.cls
+++ b/src/classes/CRLP_Batch_Base.cls
@@ -314,4 +314,12 @@ public abstract class CRLP_Batch_Base {
 
     public class BatchException extends Exception {}
 
+    public void logDuplicateBatchError(String className) {
+
+        BatchException ex = new BatchException();
+        ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+        ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+
+    }
+
 }

--- a/src/classes/CRLP_ContactSkew_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_BATCH.cls
@@ -61,13 +61,13 @@ public class CRLP_ContactSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        String className = 'CRLP_ContactSkew_BATCH';
+        String className = CRLP_ContactSkew_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_ContactSkew_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_BATCH.cls
@@ -67,9 +67,7 @@ public class CRLP_ContactSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_ContactSkew_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_BATCH.cls
@@ -61,10 +61,15 @@ public class CRLP_ContactSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = 'CRLP_ContactSkew_BATCH';
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_ContactSkew_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_ContactSkew_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_BATCH.cls
@@ -62,8 +62,10 @@ public class CRLP_ContactSkew_BATCH extends CRLP_Batch_Base_Skew implements Data
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
-                    CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_ContactSkew_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
+                        CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
@@ -61,10 +61,15 @@ public class CRLP_ContactSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = 'CRLP_ContactSkew_SoftCredit_BATCH';
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_ContactSkew_SoftCredit_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
@@ -62,8 +62,10 @@ public class CRLP_ContactSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
-                    CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_ContactSkew_SoftCredit_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
+                        CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
@@ -67,7 +67,7 @@ public class CRLP_ContactSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
@@ -67,9 +67,7 @@ public class CRLP_ContactSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_ContactSkew_SoftCredit_BATCH.cls
@@ -61,7 +61,7 @@ public class CRLP_ContactSkew_SoftCredit_BATCH extends CRLP_Batch_Base_Skew impl
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        String className = 'CRLP_ContactSkew_SoftCredit_BATCH';
+        String className = CRLP_ContactSkew_SoftCredit_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,

--- a/src/classes/CRLP_Contact_BATCH.cls
+++ b/src/classes/CRLP_Contact_BATCH.cls
@@ -61,8 +61,10 @@ public class CRLP_Contact_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
-                    CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Contact_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
+                        CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_Contact_BATCH.cls
+++ b/src/classes/CRLP_Contact_BATCH.cls
@@ -66,7 +66,7 @@ public class CRLP_Contact_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_Contact_BATCH.cls
+++ b/src/classes/CRLP_Contact_BATCH.cls
@@ -66,9 +66,7 @@ public class CRLP_Contact_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_Contact_BATCH.cls
+++ b/src/classes/CRLP_Contact_BATCH.cls
@@ -60,10 +60,15 @@ public class CRLP_Contact_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = 'CRLP_Contact_BATCH';
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Contact_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_Contact_BATCH.cls
+++ b/src/classes/CRLP_Contact_BATCH.cls
@@ -60,7 +60,7 @@ public class CRLP_Contact_BATCH extends CRLP_Batch_Base_NonSkew implements Datab
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        String className = 'CRLP_Contact_BATCH';
+        String className = CRLP_Contact_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,

--- a/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
@@ -61,8 +61,10 @@ public class CRLP_Contact_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Contact_SoftCredit_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
                     CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
@@ -60,7 +60,7 @@ public class CRLP_Contact_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        String className = 'CRLP_Contact_SoftCredit_BATCH';
+        String className = CRLP_Contact_SoftCredit_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
             if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,

--- a/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
@@ -60,10 +60,15 @@ public class CRLP_Contact_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = 'CRLP_Contact_SoftCredit_BATCH';
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_Contact_SoftCredit_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
                     CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
@@ -66,9 +66,7 @@ public class CRLP_Contact_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
                     CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
+++ b/src/classes/CRLP_Contact_SoftCredit_BATCH.cls
@@ -66,7 +66,7 @@ public class CRLP_Contact_SoftCredit_BATCH extends CRLP_Batch_Base_NonSkew imple
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
                     CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_GAU_BATCH.cls
+++ b/src/classes/CRLP_GAU_BATCH.cls
@@ -62,8 +62,10 @@ public class CRLP_GAU_BATCH extends CRLP_Batch_Base_Skew implements Database.Bat
      */
     public void execute(SchedulableContext context) {
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.GAU,
-                    CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_GAU_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.GAU,
+                        CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            }
         }
     }
 }

--- a/src/classes/CRLP_GAU_BATCH.cls
+++ b/src/classes/CRLP_GAU_BATCH.cls
@@ -67,9 +67,7 @@ public class CRLP_GAU_BATCH extends CRLP_Batch_Base_Skew implements Database.Bat
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.GAU,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                BatchException ex = new BatchException();
-                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_GAU_BATCH.cls
+++ b/src/classes/CRLP_GAU_BATCH.cls
@@ -61,10 +61,15 @@ public class CRLP_GAU_BATCH extends CRLP_Batch_Base_Skew implements Database.Bat
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = CRLP_GAU_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_GAU_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.GAU,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
+            } else {
+                Exception ex;
+                ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }
         }
     }

--- a/src/classes/CRLP_GAU_BATCH.cls
+++ b/src/classes/CRLP_GAU_BATCH.cls
@@ -67,7 +67,7 @@ public class CRLP_GAU_BATCH extends CRLP_Batch_Base_Skew implements Database.Bat
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.GAU,
                         CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             } else {
-                Exception ex;
+                BatchException ex = new BatchException();
                 ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
             }

--- a/src/classes/CRLP_RDSkew_BATCH.cls
+++ b/src/classes/CRLP_RDSkew_BATCH.cls
@@ -61,9 +61,14 @@
          * @description Scheduler execute method to support scheduling this job directly from the UI
          */
         public void execute(SchedulableContext context) {
+            String className = CRLP_RDSkew_BATCH.class.getName();
             if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-                if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_RDSkew_BATCH')) {
+                if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                     Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.RecurringDonations), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
+                } else {
+                    Exception ex;
+                    ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
+                    ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
                 }
             }
         }

--- a/src/classes/CRLP_RDSkew_BATCH.cls
+++ b/src/classes/CRLP_RDSkew_BATCH.cls
@@ -61,6 +61,10 @@
          * @description Scheduler execute method to support scheduling this job directly from the UI
          */
         public void execute(SchedulableContext context) {
-            Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.RecurringDonations), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
+            if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
+                if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_RDSkew_BATCH')) {
+                    Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.RecurringDonations), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
+                }
+            }
         }
     }

--- a/src/classes/CRLP_RDSkew_BATCH.cls
+++ b/src/classes/CRLP_RDSkew_BATCH.cls
@@ -66,7 +66,7 @@
                 if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                     Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.RecurringDonations), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
                 } else {
-                    Exception ex;
+                    BatchException ex = new BatchException();
                     ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
                     ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
                 }

--- a/src/classes/CRLP_RDSkew_BATCH.cls
+++ b/src/classes/CRLP_RDSkew_BATCH.cls
@@ -66,9 +66,7 @@
                 if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                     Database.executeBatch(new CRLP_SkewDispatcher_BATCH(CRLP_RollupProcessingOptions.RollupType.RecurringDonations), CRLP_SkewDispatcher_BATCH.BATCH_SIZE);
                 } else {
-                    BatchException ex = new BatchException();
-                    ex.setMessage(String.format(Label.CRLP_BatchSkipped, new List<String>{className}));
-                    ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP);
+                    logDuplicateBatchError(className);
                 }
             }
         }

--- a/src/classes/CRLP_RD_BATCH.cls
+++ b/src/classes/CRLP_RD_BATCH.cls
@@ -60,10 +60,13 @@ public class CRLP_RD_BATCH extends CRLP_Batch_Base_NonSkew implements Database.B
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
+        String className = CRLP_RD_BATCH.class.getName();
         if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
-            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_RD_BATCH')) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob(className)) {
                 CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.RecurringDonations,
                         CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            } else {
+                logDuplicateBatchError(className);
             }
         }
     }

--- a/src/classes/CRLP_RD_BATCH.cls
+++ b/src/classes/CRLP_RD_BATCH.cls
@@ -60,7 +60,11 @@ public class CRLP_RD_BATCH extends CRLP_Batch_Base_NonSkew implements Database.B
      * @description Scheduler execute method to support scheduling this job directly from the UI
      */
     public void execute(SchedulableContext context) {
-        CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.RecurringDonations,
-                CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+        if (CRLP_Rollup_SVC.isCustomizableRollupEngineEnabled) {
+            if (!UTIL_MasterSchedulableHelper.hasRunningJob('CRLP_RD_BATCH')) {
+                CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.RecurringDonations,
+                        CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode);
+            }
+        }
     }
 }

--- a/src/classes/UTIL_MasterSchedulableHelper.cls
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls
@@ -185,4 +185,22 @@ public without sharing class UTIL_MasterSchedulableHelper {
             ERR_Handler.processError(ex, ERR_Handler_API.Context.STTG);
         }
     }
+
+    /*******************************************************************************************************
+    * @description Checks for presently running jobs of a particular method
+    * @param methodName The name of the method to check for running jobs on
+    * @return Boolean
+    */
+    public Boolean hasRunningJobs(String methodName) {
+        List<AsyncApexJob> runningJobs = [SELECT Id, MethodName
+            FROM AsyncApexJob
+            WHERE MethodName = :methodName
+            AND Status NOT IN ('Aborted','Completed','Failed')
+            LIMIT 1];
+        if (runningJobs.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 }

--- a/src/classes/UTIL_MasterSchedulableHelper.cls
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls
@@ -192,12 +192,12 @@ public without sharing class UTIL_MasterSchedulableHelper {
     * @return Boolean
     */
     public static Boolean hasRunningJob(String className) {
-        List<AsyncApexJob> runningJobs = [SELECT Id, ApexClass.Name
+        Integer jobCount = [SELECT COUNT()
             FROM AsyncApexJob
             WHERE ApexClass.Name = :className
             AND Status NOT IN ('Queued','Aborted','Completed','Failed')
             LIMIT 1];
-        if (runningJobs.isEmpty()) {
+        if (jobCount == 0) {
             return false;
         } else {
             return true;

--- a/src/classes/UTIL_MasterSchedulableHelper.cls
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls
@@ -193,10 +193,13 @@ public without sharing class UTIL_MasterSchedulableHelper {
     */
     public static Boolean hasRunningJob(String className) {
         className = (className.contains('__') ? className.split('__')[1] : className);
+        // If any quick single-record rollup jobs have recently been launched, don't let these block the full re-run
+        Datetime tenMinutesAgo = DateTime.Now().addMinutes(-10);
         Integer jobCount = [SELECT COUNT()
             FROM AsyncApexJob
             WHERE ApexClass.Name = :className
             AND Status NOT IN ('Queued','Aborted','Completed','Failed')
+            AND CreatedDate < :tenMinutesAgo
             LIMIT 1];
         if (jobCount == 0) {
             return false;

--- a/src/classes/UTIL_MasterSchedulableHelper.cls
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls
@@ -191,11 +191,11 @@ public without sharing class UTIL_MasterSchedulableHelper {
     * @param methodName The name of the method to check for running jobs on
     * @return Boolean
     */
-    public Boolean hasRunningJobs(String methodName) {
-        List<AsyncApexJob> runningJobs = [SELECT Id, MethodName
+    public static Boolean hasRunningJob(String className) {
+        List<AsyncApexJob> runningJobs = [SELECT Id, ApexClass.Name
             FROM AsyncApexJob
-            WHERE MethodName = :methodName
-            AND Status NOT IN ('Aborted','Completed','Failed')
+            WHERE ApexClass.Name = :className
+            AND Status NOT IN ('Queued','Aborted','Completed','Failed')
             LIMIT 1];
         if (runningJobs.isEmpty()) {
             return false;

--- a/src/classes/UTIL_MasterSchedulableHelper.cls
+++ b/src/classes/UTIL_MasterSchedulableHelper.cls
@@ -192,6 +192,7 @@ public without sharing class UTIL_MasterSchedulableHelper {
     * @return Boolean
     */
     public static Boolean hasRunningJob(String className) {
+        className = (className.contains('__') ? className.split('__')[1] : className);
         Integer jobCount = [SELECT COUNT()
             FROM AsyncApexJob
             WHERE ApexClass.Name = :className

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -729,7 +729,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Error logged when a scheduled batch is skipped b/c yesterday&apos;s still running.</shortDescription>
-        <value>Today&apos;s scheduled {0} batch job was skipped because a previous {0} job was still running. The next batch job will run as scheduled. No action is required; this error is for information purposes only.</value>
+        <value>Today&apos;&apos;s scheduled {0} batch job was skipped because a previous {0} job was still running. The next batch job will run as scheduled. No action is required; this error is for information purposes only.</value>
     </labels>
     <labels>
         <fullName>CRLP_CreateRollupIntroHelpText</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -728,8 +728,8 @@
         <categories>Settings</categories>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Error logged when a scheduled batch is skipped b/c yesterday's still running.</shortDescription>
-        <value>Today's scheduled {0} batch job was skipped because a previous {0} job was still running. The next scheduled batch will still run. No action is required; this Error is for information purposes only.</value>
+        <shortDescription>Error logged when a scheduled batch is skipped b/c yesterday&apos;s still running.</shortDescription>
+        <value>Today&apos;s scheduled {0} batch job was skipped because a previous {0} job was still running. The next batch job will run as scheduled. No action is required; this error is for information purposes only.</value>
     </labels>
     <labels>
         <fullName>CRLP_CreateRollupIntroHelpText</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -724,6 +724,14 @@
         <value>These fields determine what information is being summarized and provide the normal defaults for Donations. You can edit them as needed.</value>
     </labels>
     <labels>
+        <fullName>CRLP_BatchSkipped</fullName>
+        <categories>Settings</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Error logged when a scheduled batch is skipped b/c yesterday's still running.</shortDescription>
+        <value>Today's scheduled {0} batch job was skipped because a previous {0} job was still running. The next scheduled batch will still run. No action is required; this Error is for information purposes only.</value>
+    </labels>
+    <labels>
         <fullName>CRLP_CreateRollupIntroHelpText</fullName>
         <categories>Settings</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1107,6 +1107,7 @@
         <members>CRLP_AdvancedCustomizationHeader</members>
         <members>CRLP_AdvancedCustomizationText</members>
         <members>CRLP_AvailableRollupType</members>
+        <members>CRLP_BatchSkipped</members>
         <members>CRLP_CreateRollupActiveHelpText</members>
         <members>CRLP_CreateRollupAmountFieldHelpText</members>
         <members>CRLP_CreateRollupDateFieldHelpText</members>
@@ -1130,8 +1131,8 @@
         <members>CRLP_DeleteSuccess</members>
         <members>CRLP_DeleteTimeout</members>
         <members>CRLP_DisabledMessage</members>
-        <members>CRLP_DuplicateTargetField</members>
         <members>CRLP_DisabledTitle</members>
+        <members>CRLP_DuplicateTargetField</members>
         <members>CRLP_HardCredit</members>
         <members>CRLP_NoAvailableDetailFieldsMessage</members>
         <members>CRLP_NoAvailableTargetFieldsMessage</members>


### PR DESCRIPTION
# Critical Changes

# Changes

- Before a batch kicks off, it checks to see if there are other instances of itself still in process, and only proceeds if it finds none.
- If a job is skipped because the previous day's job is still running, an Error is logged with an explanatory message.

# Issues Closed

# New Metadata

# Deleted Metadata
