### PR TITLE
Rollups: restrict RD target fields

### DIFF
--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -844,6 +844,7 @@ public with sharing class CRLP_RollupUI_SVC {
         List<Map<String, String>> fieldObjectList = new List<Map<String, String>>();
 
         Map<String, Schema.DescribeFieldResult> objectFields = UTIL_Describe.getAllFieldsDescribe(objectName);
+        // TODO: consider putting this into a map instead of a set
         Set<String> excludedFields = new Set<String>{'ConnectionReceivedId', 'ConnectionSentId', 'IsDeleted', 'IsSplit', 'Fiscal', 'FiscalQuarter', 'FiscalYear', 'SyncedQuoteID'};
 
         for (Schema.DescribeFieldResult dfr : objectFields.values()) {
@@ -883,12 +884,12 @@ public with sharing class CRLP_RollupUI_SVC {
             String fieldType = UTIL_Describe.getFieldType(objectName, dfr.name.toLowerCase());
             Boolean isValidType = validTypeSet.contains(fieldType);
 
-            //check that summary field isn't being used on another rollup
+            //check that target field isn't being used on another rollup
             Boolean isRolledUp = referencedFieldSet.contains(dfr);
 
-            if ((dfr.isUpdateable() && dfr.isCustom() && isValidType && !isRolledUp && !dfr.name.toLowerCase().contains('__system')
-                    && !dfr.name.contains('Latitude__s') && !dfr.name.contains('Longitude__s')
-                    && !fieldIsBanned(objectName,dfr.name))
+            if (( isValidType
+                    && !isRolledUp
+                     && isTargetFieldAllowed(objectName,dfr))
                     || selectedField.equals(dfr.name)) {
                 Map<String, String> fieldObject = new Map<String, String>();
                 fieldObject.put('name', dfr.name);
@@ -908,13 +909,20 @@ public with sharing class CRLP_RollupUI_SVC {
     }
 
     /*******************************************************************************************************
-    * @description Finds writable, custom, unused target fields of specific types to provide field lists for Rollup definitions.
-    *              Includes an exception for a set summary field on the rollup detail.
-    * @param objectName the name of the object to look up
-    * @param selectedField the name of a summary field already in use
-    * @return List<Map<String, String>> an object with field api names, labels and data type.
+    * @description Checks that a given field is allowed as a target field
+    * @param objectName the name of the object
+    * @param dfr the DescribeFieldResult of the field
+    * @return Boolean
     */
-    private static Boolean fieldIsBanned(String objectName, String fieldName) {
+    public static Boolean isTargetFieldAllowed(String objectName, Schema.DescribeFieldResult dfr) {
+
+        if(!dfr.isUpdateable()
+                || !dfr.isCustom()
+                || dfr.name.toLowerCase().contains('__system')
+                || dfr.name.contains('Latitude__s')
+                || dfr.name.contains('Longitude__s')) {
+            return false;
+        }
 
         Map<String,Set<String>> bannedFieldsByObject = new Map<String,Set<String>>();
 
@@ -935,7 +943,11 @@ public with sharing class CRLP_RollupUI_SVC {
 
         // add more objects here as needed with their banned fields
 
-        return bannedFieldsByObject.containsKey(objectName) && bannedFieldsByObject.get(objectName).contains(fieldName);
+        if (bannedFieldsByObject.containsKey(objectName) && bannedFieldsByObject.get(objectName).contains(dfr.name)) {
+            return false;
+        }
+
+        return true;
 
     }
 

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -888,7 +888,7 @@ public with sharing class CRLP_RollupUI_SVC {
 
             if ((dfr.isUpdateable() && dfr.isCustom() && isValidType && !isRolledUp && !dfr.name.toLowerCase().contains('__system')
                     && !dfr.name.contains('Latitude__s') && !dfr.name.contains('Longitude__s')
-                    && !(objectName == 'npe03__Recurring_Donation__c' && dfr.name.contains('npe03__')))
+                    && !fieldIsBanned(objectName,dfr.name))
                     || selectedField.equals(dfr.name)) {
                 Map<String, String> fieldObject = new Map<String, String>();
                 fieldObject.put('name', dfr.name);
@@ -905,6 +905,38 @@ public with sharing class CRLP_RollupUI_SVC {
         }
 
         return fieldObjectList;
+    }
+
+    /*******************************************************************************************************
+    * @description Finds writable, custom, unused target fields of specific types to provide field lists for Rollup definitions.
+    *              Includes an exception for a set summary field on the rollup detail.
+    * @param objectName the name of the object to look up
+    * @param selectedField the name of a summary field already in use
+    * @return List<Map<String, String>> an object with field api names, labels and data type.
+    */
+    private static Boolean fieldIsBanned(String objectName, String fieldName) {
+
+        Map<String,Set<String>> bannedFieldsByObject = new Map<String,Set<String>>();
+
+        // BAN ALL NPSP FIELDS ON RD EXCEPT THE FOUR CORE ROLLUP FIELDS
+        bannedFieldsByObject.put('npe03__Recurring_Donation__c',new Set<String>{'npe03__Amount__c'
+                ,'npe03__Recurring_Donation_Campaign__c'
+                ,'npe03__Contact__c'
+                ,'npe03__Date_Established__c'
+                ,'npe03__Donor_Name__c'
+                ,'npe03__Installment_Amount__c'
+                ,'npe03__Installment_Period__c'
+                ,'npe03__Installments__c'
+                ,'npe03__Open_Ended_Status__c'
+                ,'npe03__Organization__c'
+                ,'npe03__Schedule_Type__c'
+                ,'npe03__Total__c'
+                ,'Always_Use_Last_Day_Of_Month__c'});
+
+        // add more objects here as needed with their banned fields
+
+        return bannedFieldsByObject.containsKey(objectName) && bannedFieldsByObject.get(objectName).contains(fieldName);
+
     }
 
     public class RollupException extends Exception {}

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -887,7 +887,8 @@ public with sharing class CRLP_RollupUI_SVC {
             Boolean isRolledUp = referencedFieldSet.contains(dfr);
 
             if ((dfr.isUpdateable() && dfr.isCustom() && isValidType && !isRolledUp && !dfr.name.toLowerCase().contains('__system')
-                    && !dfr.name.contains('Latitude__s') && !dfr.name.contains('Longitude__s'))
+                    && !dfr.name.contains('Latitude__s') && !dfr.name.contains('Longitude__s')
+                    && !(objectName == 'npe03__Recurring_Donation__c' && dfr.name.contains('npe03__')))
                     || selectedField.equals(dfr.name)) {
                 Map<String, String> fieldObject = new Map<String, String>();
                 fieldObject.put('name', dfr.name);

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -844,7 +844,6 @@ public with sharing class CRLP_RollupUI_SVC {
         List<Map<String, String>> fieldObjectList = new List<Map<String, String>>();
 
         Map<String, Schema.DescribeFieldResult> objectFields = UTIL_Describe.getAllFieldsDescribe(objectName);
-        // TODO: consider putting this into a map instead of a set
         Set<String> excludedFields = new Set<String>{'ConnectionReceivedId', 'ConnectionSentId', 'IsDeleted', 'IsSplit', 'Fiscal', 'FiscalQuarter', 'FiscalYear', 'SyncedQuoteID'};
 
         for (Schema.DescribeFieldResult dfr : objectFields.values()) {
@@ -939,7 +938,7 @@ public with sharing class CRLP_RollupUI_SVC {
                 ,'npe03__Organization__c'
                 ,'npe03__Schedule_Type__c'
                 ,'npe03__Total__c'
-                ,'Always_Use_Last_Day_Of_Month__c'});
+                ,UTIL_Namespace.StrAllNSPrefix('Always_Use_Last_Day_Of_Month__c')});
 
         // add more objects here as needed with their banned fields
 

--- a/src/classes/CRLP_Rollup_SEL.cls
+++ b/src/classes/CRLP_Rollup_SEL.cls
@@ -45,8 +45,7 @@ public class CRLP_Rollup_SEL {
     public static List<Rollup__mdt> cachedRollups {
         get {
             if (cachedRollups == null) {
-                cachedRollups = new List<Rollup__mdt>();
-                List<Rollup__mdt> stagedRollups = [
+                cachedRollups = [
                         SELECT Id, DeveloperName, MasterLabel, Active__c, Use_Fiscal_Year__c, Filter_Group__r.DeveloperName,
                                 Description__c, Filter_Group__c, Filter_Group__r.MasterLabel, Operation__c, Integer__c,
                                 Time_Bound_Operation_Type__c
@@ -63,15 +62,6 @@ public class CRLP_Rollup_SEL {
                         WHERE Is_Deleted__c = false
                         ORDER BY Summary_Object__c, MasterLabel
                 ];
-
-                // Never return Rollups with banned Target Fields
-                // You can't create them in the CRLP UI, but they may have snuck in via native CMDT UI
-                for (Rollup__mdt rollup : stagedRollups) {
-                    if (CRLP_RollupUI_SVC.isTargetFieldAllowed(rollup.Summary_Object__r.QualifiedApiName,
-                            UTIL_Describe.getFieldDescribe(rollup.Summary_Object__r.QualifiedApiName, rollup.Summary_Field__r.QualifiedApiName))) {
-                        cachedRollups.add(rollup);
-                    }
-                }
 
             }
             return cachedRollups;

--- a/src/classes/CRLP_Rollup_SEL.cls
+++ b/src/classes/CRLP_Rollup_SEL.cls
@@ -45,7 +45,8 @@ public class CRLP_Rollup_SEL {
     public static List<Rollup__mdt> cachedRollups {
         get {
             if (cachedRollups == null) {
-                cachedRollups = [
+                cachedRollups = new List<Rollup__mdt>();
+                List<Rollup__mdt> stagedRollups = [
                         SELECT Id, DeveloperName, MasterLabel, Active__c, Use_Fiscal_Year__c, Filter_Group__r.DeveloperName,
                                 Description__c, Filter_Group__c, Filter_Group__r.MasterLabel, Operation__c, Integer__c,
                                 Time_Bound_Operation_Type__c
@@ -62,6 +63,16 @@ public class CRLP_Rollup_SEL {
                         WHERE Is_Deleted__c = false
                         ORDER BY Summary_Object__c, MasterLabel
                 ];
+
+                // Never return Rollups with banned Target Fields
+                // You can't create them in the CRLP UI, but they may have snuck in via native CMDT UI
+                for (Rollup__mdt rollup : stagedRollups) {
+                    if (CRLP_RollupUI_SVC.isTargetFieldAllowed(rollup.Summary_Object__r.QualifiedApiName,
+                            UTIL_Describe.getFieldDescribe(rollup.Summary_Object__r.QualifiedApiName, rollup.Summary_Field__r.QualifiedApiName))) {
+                        cachedRollups.add(rollup);
+                    }
+                }
+
             }
             return cachedRollups;
         }


### PR DESCRIPTION
# Critical Changes

# Changes
- Restrict target fields available from Recurring Donations to a user's own custom fields.
- Ignore Rollup__mdt records with banned target fields from the main rollup selector query

# Issues Closed

# New Metadata

# Deleted Metadata
