### PR TITLE
Fix missing NPSP Application in Lightning Experience

### DIFF
--- a/src/applications/Nonprofit_CRM.app
+++ b/src/applications/Nonprofit_CRM.app
@@ -15,4 +15,5 @@
     <tab>Contact_Merge</tab>
     <tab>NPSP_Settings</tab>
     <tab>NPSP_Resources</tab>
+    <formFactors>Large</formFactors>
 </CustomApplication>


### PR DESCRIPTION
v39 of the SalesforceAPI requires that any custom apps have `<formFactors>Large</formFactors>` to enable visibility in the Lightning Experience.

# Critical Changes

# Changes

# Issues Closed

Fixes #3208 

# New Metadata

# Deleted Metadata
