### PR TITLE
NPSP Settings: Add Skew mode help text and fix issue with values over 1000 not displaying in Batch Size Settings

### DIFF
--- a/src/pages/STG_PanelSchedule.page
+++ b/src/pages/STG_PanelSchedule.page
@@ -90,6 +90,9 @@
                     <div class="slds-form-element__control">
                         <apex:outputField value="{!stgService.stgCRLP.Rollups_Skew_Dispatcher_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                         <apex:inputField value="{!stgService.stgCRLP.Rollups_Skew_Dispatcher_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxSkewDis" html-aria-describedby="{!$Component.tbxSkewDisHelp}" styleClass="slds-input" />
+                        <apex:outputPanel id="tbxSkewDisHelp" layout="block">
+                            <apex:outputText styleClass="slds-form-element__help" value="{!$ObjectType.Customizable_Rollup_Settings__c.fields.Rollups_Skew_Dispatcher_Batch_Size__c.inlineHelpText}"/>
+                        </apex:outputPanel>
                     </div>
                 </div>
             </div>

--- a/src/pages/STG_PanelSchedule.page
+++ b/src/pages/STG_PanelSchedule.page
@@ -14,42 +14,42 @@
                 <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Contact_Batch_Size__c.Label}" for="tbxConHard" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgCRLP.Rollups_Contact_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Contact_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxConHard" html-aria-describedby="{!$Component.tbxConHardHelp}" styleClass="slds-input" />
+                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Contact_Batch_Size__c}" rendered="{!isEditMode}" id="tbxConHard" html-aria-describedby="{!$Component.tbxConHardHelp}" styleClass="slds-input" />
                 </div>
             </div>
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_Batch_Size__c.Label}" for="tbxAccHard" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxAccHard" html-aria-describedby="{!$Component.tbxAccHardHelp}" styleClass="slds-input" />
+                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccHard" html-aria-describedby="{!$Component.tbxAccHardHelp}" styleClass="slds-input" />
                 </div>
             </div>
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Contact_Soft_Credit_Batch_Size__c.Label}" for="tbxConSoft" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgCRLP.Rollups_Contact_Soft_Credit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Contact_Soft_Credit_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxConSoft" html-aria-describedby="{!$Component.tbxConSoftHelp}" styleClass="slds-input" />
+                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Contact_Soft_Credit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxConSoft" html-aria-describedby="{!$Component.tbxConSoftHelp}" styleClass="slds-input" />
                 </div>
             </div>
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_Soft_Credit_Batch_Size__c.Label}" for="tbxAccSoft" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxAccSoft" html-aria-describedby="{!$Component.tbxAccSoftHelp}" styleClass="slds-input" />
+                    <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSoft" html-aria-describedby="{!$Component.tbxAccSoftHelp}" styleClass="slds-input" />
                 </div>
             </div>
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_GAU_Batch_Size__c.Label}" for="tbxGAU" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgCRLP.Rollups_GAU_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                    <apex:inputField value="{!stgService.stgCRLP.Rollups_GAU_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxGAU" html-aria-describedby="{!$Component.tbxGAUHelp}" styleClass="slds-input" />
+                    <apex:inputField value="{!stgService.stgCRLP.Rollups_GAU_Batch_Size__c}" rendered="{!isEditMode}" id="tbxGAU" html-aria-describedby="{!$Component.tbxGAUHelp}" styleClass="slds-input" />
                 </div>
             </div>
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npe03__Recurring_Donations_Settings__c.Fields.Recurring_Donation_Batch_Size__c.Label}" for="tbxRD" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgRD.Recurring_Donation_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                    <apex:inputField value="{!stgService.stgRD.Recurring_Donation_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxRD" html-aria-describedby="{!$Component.tbxRDHelp}" styleClass="slds-input" />
+                    <apex:inputField value="{!stgService.stgRD.Recurring_Donation_Batch_Size__c}" rendered="{!isEditMode}" id="tbxRD" html-aria-describedby="{!$Component.tbxRDHelp}" styleClass="slds-input" />
                 </div>
             </div>
 
@@ -65,7 +65,7 @@
                     <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Limit_on_Attached_Opps_for_Skew__c.Label}" for="tbxSkewLimit" styleClass="slds-form-element__label" />
                     <div class="slds-form-element__control">
                         <apex:outputField value="{!stgService.stgCRLP.Rollups_Limit_on_Attached_Opps_for_Skew__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Limit_on_Attached_Opps_for_Skew__c}" type="number" rendered="{!isEditMode}" id="tbxSkewLimit" html-aria-describedby="{!$Component.tbxSkewLimitHelp}" styleClass="slds-input" />
+                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Limit_on_Attached_Opps_for_Skew__c}" rendered="{!isEditMode}" id="tbxSkewLimit" html-aria-describedby="{!$Component.tbxSkewLimitHelp}" styleClass="slds-input" />
                         <apex:outputPanel id="tbxSkewLimitHelp" layout="block">
                             <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpRollupSkewLimit}"/>
                         </apex:outputPanel>
@@ -75,21 +75,21 @@
                     <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Contact_SkewMode_Batch_Size__c.Label}" for="tbxConSkew" styleClass="slds-form-element__label" />
                     <div class="slds-form-element__control">
                         <apex:outputField value="{!stgService.stgCRLP.Rollups_Contact_SkewMode_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Contact_SkewMode_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxConSkew" html-aria-describedby="{!$Component.tbxConSkewHelp}" styleClass="slds-input" />
+                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Contact_SkewMode_Batch_Size__c}" rendered="{!isEditMode}" id="tbxConSkew" html-aria-describedby="{!$Component.tbxConSkewHelp}" styleClass="slds-input" />
                     </div>
                 </div>
                 <div class="slds-form-element">
                     <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_SkewMode_Batch_Size__c.Label}" for="tbxAccSkew" styleClass="slds-form-element__label" />
                     <div class="slds-form-element__control">
                         <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_SkewMode_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_SkewMode_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxAccSkew" html-aria-describedby="{!$Component.tbxAccSkewHelp}" styleClass="slds-input" />
+                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_SkewMode_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSkew" html-aria-describedby="{!$Component.tbxAccSkewHelp}" styleClass="slds-input" />
                     </div>
                 </div>
                 <div class="slds-form-element">
                     <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Skew_Dispatcher_Batch_Size__c.Label}" for="tbxSkewDis" styleClass="slds-form-element__label" />
                     <div class="slds-form-element__control">
                         <apex:outputField value="{!stgService.stgCRLP.Rollups_Skew_Dispatcher_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Skew_Dispatcher_Batch_Size__c}" type="number" rendered="{!isEditMode}" id="tbxSkewDis" html-aria-describedby="{!$Component.tbxSkewDisHelp}" styleClass="slds-input" />
+                        <apex:inputField value="{!stgService.stgCRLP.Rollups_Skew_Dispatcher_Batch_Size__c}" rendered="{!isEditMode}" id="tbxSkewDis" html-aria-describedby="{!$Component.tbxSkewDisHelp}" styleClass="slds-input" />
                         <apex:outputPanel id="tbxSkewDisHelp" layout="block">
                             <apex:outputText styleClass="slds-form-element__help" value="{!$ObjectType.Customizable_Rollup_Settings__c.fields.Rollups_Skew_Dispatcher_Batch_Size__c.inlineHelpText}"/>
                         </apex:outputPanel>


### PR DESCRIPTION
- Added help text to Skew Mode batch field
- Removed type="number" on the input fields to allow 4 digit numbers in edit mode on the Batch Settings page, addressing W-025174

# Critical Changes

# Changes

# Issues Closed

Fixes #3225 

# New Metadata

# Deleted Metadata
