### PR TITLE
CCI: Create default NPSP Settings when creating new scratch orgs

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -158,6 +158,17 @@ tasks:
                 - npsp__General_Accounting_Unit__c
                 - Campaign
 
+    npsp_default_settings:
+        description: Configure the default NPSP Settings including Membership RecordType
+        class_path: tasks.anon_apex.AnonymousApexFromFileTask
+        options:
+            path: scripts/configure_npsp_default_settings.cls
+            method: initializeNPSPSettings();
+
+    apex_anon:
+        description: Execute the specified apex anonymous script
+        class_path: tasks.anon_apex.AnonymousApexFromFileTask
+
 flows:
     config_dev:
         steps:
@@ -165,6 +176,8 @@ flows:
                 task: deploy_dev_config_delete
             4:
                 task: deploy_dev_config
+            5:
+                task: npsp_default_settings
 
     config_qa:
         steps:

--- a/scripts/configure_npsp_default_settings.cls
+++ b/scripts/configure_npsp_default_settings.cls
@@ -1,0 +1,43 @@
+/**
+* @description Configure all default NPSP Custom Settings by calling each of the "getOrg..." methods in the
+* CustomSettingsFacade. In addition, this retrieves the Opportunity.Membership record type Id and populates
+* that in the HouseholdSettings object.
+* @author Michael Smith
+* @date 2018-06-07
+*/
+public static void initializeNPSPSettings() {
+    // When calling this code in a managed context, the string %%%NAMESPACE%%% will be replaced with
+    // "NAMESPACE__" via a custom cci task defined in tasks/anon_apex.py as AnonymousApexFromFileTask().
+    // Similarly %%%NAMESPACED_RT%%% will be replaced by "NAMESPACE." for namespaced record type support
+
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgContactsSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgHouseholdsSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgRecurringDonationsSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgRelationshipSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgAffiliationsSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgHouseholdNamingSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgErrorSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgAddressVerificationSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgBDESettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgAllocationsSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgDataImportSettings();
+
+    Id rtId = [SELECT Id FROM RecordType WHERE SObjectType = 'Opportunity' AND DeveloperName = 'Membership' LIMIT 1].Id;
+
+    npo02__Households_Settings__c hs = %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgHouseholdsSettings();
+    hs.npo02__Membership_Record_Types__c = rtId;
+    upsert hs;
+
+    npe01__Contacts_And_Orgs_Settings__c cos = %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgContactsSettings();
+    cos.%%%NAMESPACE%%%Honoree_Opportunity_Contact_Role__c = 'Honoree Contact';
+    cos.%%%NAMESPACE%%%Notification_Recipient_Opp_Contact_Role__c = 'Notification Contact';
+    cos.%%%NAMESPACE%%%Payments_Auto_Close_Stage_Name__c = getClosedWonStage();
+    upsert cos;
+}
+
+private static String getClosedWonStage(){
+    OpportunityStage closedWonStage = [SELECT MasterLabel FROM OpportunityStage
+        WHERE IsActive = true AND IsWon = true LIMIT 1];
+    return closedWonStage.MasterLabel;
+}
+

--- a/scripts/deleteSettings
+++ b/scripts/deleteSettings
@@ -6,6 +6,8 @@
  * The first one is an object and the rest are custom settings.
  **/
 delete [select ID from Trigger_Handler__c];
+delete [select ID from Allocations_Settings__c];
+delete [select ID from Customizable_Rollup_Settings__c];
 delete [select ID from Addr_Verification_Settings__c];
 delete [select ID from npe5__Affiliations_Settings__c];
 delete [select ID from Batch_Data_Entry_Settings__c];

--- a/tasks/anon_apex.py
+++ b/tasks/anon_apex.py
@@ -1,0 +1,102 @@
+import os
+import string
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+from cumulusci.core.exceptions import ApexCompilationException
+from cumulusci.core.exceptions import ApexException
+from cumulusci.core.exceptions import SalesforceException
+from cumulusci.utils import findReplace
+
+
+class AnonymousApexFromFileTask(BaseSalesforceApiTask):
+    """ Executes anonymous apex from a file. """
+    task_options = {
+        'managed': {
+            'description': 'If True, will insert the actual namespace prefix.  Defaults to False or no namespace',
+            'required': False,
+        },
+        'namespaced': {
+            'description': 'If True, the tokens %%%NAMESPACED_RT%%% and %%%namespaced%%% will get replaced with the namespace prefix for Record Types.',
+            'required': False,
+        },
+        'path': {
+            'description': 'The path to an Apex file to run.',
+            'required': True,
+        },
+        'method': {
+            'description': 'Options apex method to execute within the class specified by PATH.',
+            'required': False,
+        }
+    }
+
+    def _init_options(self, kwargs):
+        super(AnonymousApexFromFileTask, self)._init_options(kwargs)
+
+        if 'managed' not in self.options:
+            self.options['managed'] = False
+
+        if 'namespaced' not in self.options:
+            self.options['namespaced'] = False
+
+    def _run_task(self):
+
+        managed = self.options['managed']
+        namespaced = self.options['namespaced']
+        path = self.options['path']
+        pwd = os.getcwd()
+
+        path = os.path.join(pwd, path)
+
+        if not os.path.isdir( os.path.dirname(path) ):
+            self.logger.warn('Path {} not found, skipping'.format(path))
+            return
+
+        self.logger.info('Getting Apex to run from {}'.format(
+            self.options['path'],
+        ))
+        with open(path, 'r') as apex_content:
+            apex = apex_content.read()
+
+        # Process namespace tokens
+        namespace = self.project_config.project__package__namespace
+        namespace_prefix = ''
+        record_type_prefix = ''
+
+        if managed or namespaced:
+            namespace_prefix = namespace + '__'
+
+        if namespaced:
+            record_type_prefix = namespace + '.'
+
+        apex = apex.replace('%%%NAMESPACE%%%',namespace_prefix);
+        apex = apex.replace('%%%NAMESPACED_ORG%%%',namespace_prefix);
+        apex = apex.replace('%%%NAMESPACED_RT%%%',record_type_prefix);
+
+        if apex and 'method' in self.options:
+            apex = apex + ' ' + self.options['method']
+
+        # self.logger.info(apex) # Too much to print out
+
+        self.logger.info('Executing Anonymous Apex')
+        result = self.tooling._call_salesforce(
+            method='GET',
+            url='{}executeAnonymous'.format(self.tooling.base_url),
+            params={'anonymousBody': apex },
+        )
+        if result.status_code != 200:
+            raise SalesforceGeneralError(url,
+                                         path,
+                                         result.status_code,
+                                         result.content)
+        # anon_results is an ExecuteAnonymous Result
+        # https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/sforce_api_calls_executeanonymous_result.htm
+
+        anon_results = result.json()
+        if not anon_results['compiled']:
+            raise ApexCompilationException(
+                anon_results['line'], anon_results['compileProblem'])
+
+        if not anon_results['success']:
+            raise ApexException(
+                anon_results['exceptionMessage'], anon_results['exceptionStackTrace'])
+
+        self.logger.info('Anonymous Apex Success')


### PR DESCRIPTION
Add support for executing a specified Apex Anonymous script. In addition, update the `config_dev` flow used to create scratch orgs to call a new `npsp_default_settings` task to insert the all default NPSP Custom Settings records. Add an additional generic task for `apex_anon` that will execute any specified apex anonymous script.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
