### PR TITLE
Rollups: changed labels to not reference active

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -600,8 +600,8 @@
         <categories>Settings</categories>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Help text for the active rollups tree</shortDescription>
-        <value>The list of active rollups that are using this filter group. As long as there are rollups listed here, you can't delete this filter group.</value>
+        <shortDescription>Help text for the rollups tree</shortDescription>
+        <value>The list of rollups that are using this filter group. As long as there are rollups listed here, you can't delete this filter group.</value>
     </labels>
     <labels>
         <fullName>CMT_DeleteConfirm</fullName>
@@ -986,7 +986,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Shows rollups using a specific filter group.</shortDescription>
-        <value>Active Rollups Using this Filter Group</value>
+        <value>Rollups Using this Filter Group</value>
     </labels>
     <labels>
         <fullName>CRLP_RollupNew</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes
- Label on list of Rollups referenced by a Filter Group no longer inaccurately specifies "Active"

# Issues Closed

# New Metadata

# Deleted Metadata
