### PR TITLE
Fix NPE exception when for a blank Account on an Opp in One-To-One Model

### DIFF
--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -375,22 +375,29 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         // Retrieve the Account Ids for the Organizational Opportunities
         Map<Id, List<Id>> accountsToOpportunities = populateAccountToOpportunities(listOpps, oppAccountDetails);
 
-        //find changed opportunities and instantiate a map entry to hold OCRs
-        for (integer i=0; i<listOpps.size(); i++) {
-            if (listOpps[i].Primary_Contact__c != listOldOpps[i].Primary_Contact__c ||
-                ((listOpps[i].AccountId != listOldOpps[i].AccountId)
-                    && (!oppAccountDetails.get(listOpps[i].AccountId).npe01__SYSTEMIsIndividual__c || !oppAccountDetails.containsKey(listOldOpps[i].Id))) ||
-                needsManageOCR(listOpps[i], listOldOpps[i], FIELD_NAME_HONOREE_CONTACT) ||
-                needsManageOCR(listOpps[i], listOldOpps[i], FIELD_NAME_NOTIFICATION_RECIPIENT_CONTACT)) {
+        // find changed opportunities and instantiate a map entry to hold OCRs
+        for (Integer i=0; i<listOpps.size(); i++) {
+            Opportunity newOpp = listOpps[i];
+            Opportunity oldOpp = listOldOpps[i];
 
-                mapOppIdMapConIdOCR.put(listOpps[i].Id, new Map<Id, OpportunityContactRole>());
+            Boolean isIndividualAccount = (newOpp.AccountId != null && oppAccountDetails.containsKey(newOpp.AccountId))
+                    ? oppAccountDetails.get(newOpp.AccountId).npe01__SYSTEMIsIndividual__c
+                    : null;
+
+            if (newOpp.Primary_Contact__c != oldOpp.Primary_Contact__c ||
+                    ((newOpp.AccountId != oldOpp.AccountId) && (isIndividualAccount == false ||
+                        !oppAccountDetails.containsKey(oldOpp.Id))) ||
+                        needsManageOCR(newOpp, oldOpp, FIELD_NAME_HONOREE_CONTACT) ||
+                        needsManageOCR(newOpp, oldOpp, FIELD_NAME_NOTIFICATION_RECIPIENT_CONTACT)) {
+
+                mapOppIdMapConIdOCR.put(newOpp.Id, new Map<Id, OpportunityContactRole>());
             }
 
-            if (listOpps[i].Primary_Contact__c != listOldOpps[i].Primary_Contact__c ||
-                ((listOpps[i].AccountId != listOldOpps[i].AccountId)
-                    && (!oppAccountDetails.get(listOpps[i].AccountId).npe01__SYSTEMIsIndividual__c || !oppAccountDetails.containsKey(listOldOpps[i].Id)))) {
+            if (newOpp.Primary_Contact__c != oldOpp.Primary_Contact__c ||
+                    ((newOpp.AccountId != oldOpp.AccountId) && (isIndividualAccount == false ||
+                        !oppAccountDetails.containsKey(oldOpp.Id)))) {
 
-                primaryContactAccountChangeOpptys.add(listOpps[i]);
+                primaryContactAccountChangeOpptys.add(newOpp);
             }
         }
 
@@ -401,11 +408,11 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
                 mapOppIdMapConIdOCR.get(ocr.OpportunityId).put(ocr.ContactId, ocr);
             }
 
-            for (integer i=0; i<listOpps.size(); i++) {
+            for (Integer i=0; i<listOpps.size(); i++) {
                 Opportunity newOpp = listOpps[i];
                 Opportunity oldOpp = listOldOpps[i];
 
-                Boolean isIndividualAccount = (oppAccountDetails.containsKey(newOpp.AccountId))
+                Boolean isIndividualAccount = (newOpp.AccountId != null && oppAccountDetails.containsKey(newOpp.AccountId))
                                             ? oppAccountDetails.get(newOpp.AccountId).npe01__SYSTEMIsIndividual__c
                                             : null;
 

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -248,9 +248,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
             //cloned opportunity is necessary in order to modify the Primary Contact lookup and update the record in the trigger set
             Opportunity clonedOpp = opp.clone(true,true,false,true);
 
-            Boolean isIndividualAccount = (oppAccountDetails.containsKey(opp.AccountId))
-                                            ? oppAccountDetails.get(opp.AccountId).npe01__SYSTEMIsIndividual__c
-                                            : null;
+            Boolean isIndividualAccount = isIndividualAccount(oppAccountDetails, opp.AccountId);
 
             //process opportunities that already have a primary OCR
             if (mapOppIdPrimaryOCR.containsKey(opp.id)) {
@@ -380,9 +378,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
             Opportunity newOpp = listOpps[i];
             Opportunity oldOpp = listOldOpps[i];
 
-            Boolean isIndividualAccount = (newOpp.AccountId != null && oppAccountDetails.containsKey(newOpp.AccountId))
-                    ? oppAccountDetails.get(newOpp.AccountId).npe01__SYSTEMIsIndividual__c
-                    : null;
+            Boolean isIndividualAccount = isIndividualAccount(oppAccountDetails, newOpp.AccountId);
 
             if (newOpp.Primary_Contact__c != oldOpp.Primary_Contact__c ||
                     ((newOpp.AccountId != oldOpp.AccountId) && (isIndividualAccount == false ||
@@ -412,9 +408,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
                 Opportunity newOpp = listOpps[i];
                 Opportunity oldOpp = listOldOpps[i];
 
-                Boolean isIndividualAccount = (newOpp.AccountId != null && oppAccountDetails.containsKey(newOpp.AccountId))
-                                            ? oppAccountDetails.get(newOpp.AccountId).npe01__SYSTEMIsIndividual__c
-                                            : null;
+                Boolean isIndividualAccount = isIndividualAccount(oppAccountDetails, newOpp.AccountId);
 
                 //first, manage primary contact role if the primary contact has changed
                 if (needsManageOCR(newOpp, oldOpp, FIELD_NAME_PRIMARY_CONTACT)) {
@@ -738,7 +732,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         }
 
         for (Opportunity eachOppty : currentOpportunities) {
-            if (eachOppty.Primary_Contact__c != null
+            if (eachOppty.Primary_Contact__c != null && eachOppty.AccountId != null
                 && oppAccountDetails.get(eachOppty.AccountId) != null
                 && !OPP_AutomatedSoftCreditsService.isOrganizationalAccount(oppAccountDetails.get(eachOppty.AccountId).npe01__SYSTEMIsIndividual__c)) {
                 if (primaryContactToOpportunities.containsKey(eachOppty.Primary_Contact__c)) {
@@ -878,5 +872,13 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         }
     }
 
-
+    /**
+     * @description Returns the value Account.npe01__SYSTEMIsIndividual__c or null if the AccountId is null
+     * @param accountMap Map of Accounts by Id
+     * @param accountId AccountId
+     * @return True or null
+     */
+    private static Boolean isIndividualAccount(Map<Id, Account> accountMap, Id accountId) {
+        return (accountId != null && accountMap.containsKey(accountId) ? accountMap.get(accountId).npe01__SYSTEMIsIndividual__c  : null);
+    }
 }

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -378,21 +378,19 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
             Opportunity newOpp = listOpps[i];
             Opportunity oldOpp = listOldOpps[i];
 
-            Boolean isIndividualAccount = isIndividualAccount(oppAccountDetails, newOpp.AccountId);
-
+            // 06/26/2018
+            // Updating this to run whenever the AccountId is changed regardless of whether the new or old
+            // Account is a Household or Organization
             if (newOpp.Primary_Contact__c != oldOpp.Primary_Contact__c ||
-                    ((newOpp.AccountId != oldOpp.AccountId) && (isIndividualAccount == false ||
-                        !oppAccountDetails.containsKey(oldOpp.Id))) ||
-                        needsManageOCR(newOpp, oldOpp, FIELD_NAME_HONOREE_CONTACT) ||
-                        needsManageOCR(newOpp, oldOpp, FIELD_NAME_NOTIFICATION_RECIPIENT_CONTACT)) {
+                    newOpp.AccountId != oldOpp.AccountId ||
+                    needsManageOCR(newOpp, oldOpp, FIELD_NAME_HONOREE_CONTACT) ||
+                    needsManageOCR(newOpp, oldOpp, FIELD_NAME_NOTIFICATION_RECIPIENT_CONTACT)) {
 
                 mapOppIdMapConIdOCR.put(newOpp.Id, new Map<Id, OpportunityContactRole>());
             }
 
             if (newOpp.Primary_Contact__c != oldOpp.Primary_Contact__c ||
-                    ((newOpp.AccountId != oldOpp.AccountId) && (isIndividualAccount == false ||
-                        !oppAccountDetails.containsKey(oldOpp.Id)))) {
-
+                    newOpp.AccountId != oldOpp.AccountId) {
                 primaryContactAccountChangeOpptys.add(newOpp);
             }
         }

--- a/src/classes/OPP_OpportunityContactRoles_TEST.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TEST.cls
@@ -288,7 +288,7 @@ private class OPP_OpportunityContactRoles_TEST {
         System.assertEquals(OPPORTUNITY_CONTACT_ROLE_DONOR, result[0].Role);
         System.assertEquals(true, result[0].isPrimary);
     }
-    
+
     /*******************************************************************************************************
     * @description Tests contact role creation for 1:1 model, using contact attribution.
     */
@@ -879,5 +879,67 @@ private class OPP_OpportunityContactRoles_TEST {
         Test.stopTest();
     }
 
+    /*******************************************************************************************************
+    * @description Validates that changing the Opp.AccountId to a null value or to a different Account does not
+    * cause an error and that the related OCR's are valid
+    */
+    static testMethod void testOppAccountIdChanges() {
+        //skip the test if Advancement is installed
+        if(ADV_PackageInfo_SVC.useAdv()) return;
+
+        Account orgAcct = new Account(Name = 'OrgTest567890', npe01__SYSTEMIsIndividual__c = false);
+        insert orgAcct;
+
+        npe01__Contacts_and_Orgs_Settings__c testSettings = UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_and_Orgs_Settings__c(
+                        npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR,
+                        npe01__Opportunity_Contact_Role_Default_role__c = OPPORTUNITY_CONTACT_ROLE_DONOR,
+                        Honoree_Opportunity_Contact_Role__c = OPPORTUNITY_CONTACT_ROLE_HONOREE,
+                        Notification_Recipient_Opp_Contact_Role__c = OPPORTUNITY_CONTACT_ROLE_NOTIFICATION_RECIPIENT
+                )
+        );
+
+        npo02__Households_Settings__c householdSettingsForTests = UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(
+                new npo02__Households_Settings__c (
+                        npo02__Household_Rules__c = HH_Households.NO_HOUSEHOLDS_PROCESSOR,
+                        npo02__Household_Contact_Roles_On__c = true,
+                        npo02__Household_Member_Contact_Role__c='Household Member'
+                )
+        );
+
+        Contact con = UTIL_UnitTestData_TEST.getContact();
+        insert con;
+
+        Contact c = [SELECT AccountId FROM Contact WHERE Id = :con.id LIMIT 1];
+
+        Opportunity opp1 = new Opportunity(
+                Name = 'Apex Test Opp 3',
+                Primary_Contact__c = c.Id,
+                CloseDate = date.today(),
+                StageName = UTIL_UnitTestData_TEST.getClosedWonStage()
+        );
+        insert opp1;
+
+        opp1 = [SELECT Id, AccountId FROM Opportunity WHERE Id = :opp1.Id LIMIT 1];
+        System.assertNotEquals(null, opp1.AccountId);
+
+        Test.startTest();
+        opp1.AccountId = null;
+        update opp1;
+        OpportunityContactRole[] result = [SELECT OpportunityId, Opportunity.AccountId, ContactId, isPrimary, Role FROM OpportunityContactRole WHERE OpportunityId = :opp1.Id];
+        //should be a contact role
+        System.assertEquals(1, result.size());
+        System.assertEquals(OPPORTUNITY_CONTACT_ROLE_DONOR, result[0].Role);
+        System.assertEquals(true, result[0].isPrimary);
+
+        opp1.AccountId = orgAcct.Id;
+        update opp1;
+        result = [SELECT OpportunityId, Opportunity.AccountId, ContactId, isPrimary, Role FROM OpportunityContactRole WHERE OpportunityId = :opp1.Id];
+        //should be a contact role
+        System.assertEquals(1, result.size());
+        System.assertEquals(OPPORTUNITY_CONTACT_ROLE_DONOR, result[0].Role);
+        System.assertEquals(true, result[0].isPrimary);
+        System.assertNotEquals(null, result[0].Opportunity.AccountId);
+    }
 
 }


### PR DESCRIPTION
To prevent an NPE exception, check for a null `AccountId` value before using that in a get() against the `oppAccountDetails` map. Primarily updated the first loop to match the second loop in its structure and pattern, which made it easier to apply the check for a null AccountId.

# Critical Changes

# Changes

# Issues Closed

Fixes #3353 

# New Metadata

# Deleted Metadata
