### PR TITLE
disable CRLPs during data import if DI settings call for it

### DIFF
--- a/src/classes/BDI_DataImportService.cls
+++ b/src/classes/BDI_DataImportService.cls
@@ -752,7 +752,7 @@ global with sharing class BDI_DataImportService {
         if (!diSettings.Run_Opportunity_Rollups_while_Processing__c) {
             List<Trigger_Handler__c> handlers = TDTM_Config_API.getCachedRecords();
             for (Trigger_Handler__c th : handlers) {
-                if (th.Object__c == 'Opportunity' && th.Class__c == 'RLLP_OppRollup_TDTM') {
+                if (th.Object__c == 'Opportunity' && (th.Class__c == 'RLLP_OppRollup_TDTM' || th.Class__c == 'CRLP_Rollup_TDTM')) {
                     th.Active__c = false;
                 }
             }


### PR DESCRIPTION
# Critical Changes

# Changes
-When the BDI Setting "Run Opportunity Rollups while Processing" is false, CRLP Trigger Handler on Opportunity is marked inactive during the transaction.

# Issues Closed

# New Metadata

# Deleted Metadata
