### PR TITLE
Adding a global run method to TDTM_Config_API

### DIFF
--- a/ApexDocContent/TDTM.htm
+++ b/ApexDocContent/TDTM.htm
@@ -15,6 +15,7 @@
         <li>TDTM_TriggerActionHelper - class that contains helper methods for the TDTM Trigger Handler logic.</li>
         <li>TDTM_TriggerHandler - class called from each of the triggers (only one per object) that follow the TDTM design. 
         It's in charge of figuring out which of the classes that do the actual work need to be called, and calling them.</li>
+        <li>TDTM_Config_API - global API class that exposes the TDTM configuration, including the run method.</li>
     </ul>
     </body>
 </html>

--- a/src/classes/TDTM_Config_API.cls
+++ b/src/classes/TDTM_Config_API.cls
@@ -66,6 +66,26 @@ global class TDTM_Config_API {
         return TDTM_ObjectDataGateway.listTH;
     }
 
+    /*******************************************************************************************************
+    * @description Method to be called from each of the triggers (only one per object) that follow the TDTM 
+    * design. Figures out which classes need to be called, and calls them.
+    * @param isBefore Are we in a before trigger context.
+    * @param isAfter Are we in an after trigger context.
+    * @param isInsert Did the trigger run in response to an insert operation.
+    * @param isUpdate Did the trigger run in response to an update operation.
+    * @param isDelete Did the trigger run in response to a delete operation.
+    * @param isUnDelete Did the trigger run in response to an undelete operation.
+    * @param newList The records that were passed to the trigger as trigger.new.
+    * @param oldList The records that were passed to the trigger as trigger.old.
+    * @param describeObj The type of SObject the class runs for.
+    * @return void
+    */
+    global static void run(Boolean isBefore, Boolean isAfter, Boolean isInsert, Boolean isUpdate,
+    Boolean isDelete, Boolean isUnDelete, List<SObject> newList, List<SObject> oldList, 
+    Schema.DescribeSObjectResult describeObj) {
+        TDTM_TriggerHandler.run(isBefore, isAfter, isInsert, isUpdate, isDelete, isUnDelete, newList, oldList, describeObj, new TDTM_ObjectDataGateway());
+    }
+
     /**
      * @description Method to disable all NPSP roll-up triggers for the current code execution context.
      */

--- a/src/classes/TDTM_TriggerHandler.cls
+++ b/src/classes/TDTM_TriggerHandler.cls
@@ -59,7 +59,7 @@ public class TDTM_TriggerHandler {
     * @param dao The class that is going to retrieve all the TDTM records.
     * @return void
     */
-    public void run(Boolean isBefore, Boolean isAfter, Boolean isInsert, Boolean isUpdate,
+    public static void run(Boolean isBefore, Boolean isAfter, Boolean isInsert, Boolean isUpdate,
     Boolean isDelete, Boolean isUnDelete, List<Sobject> newList, List<Sobject> oldList, 
     Schema.DescribeSobjectResult describeObj, TDTM_iTableDataGateway dao) {
     	if (disableTDTM) {
@@ -153,7 +153,7 @@ public class TDTM_TriggerHandler {
         }
     }
 
-    private TDTM_Runnable.DmlWrapper runClass(SObject classToRunRecord, List<Sobject> newList, List<Sobject> oldList, 
+    private static TDTM_Runnable.DmlWrapper runClass(SObject classToRunRecord, List<Sobject> newList, List<Sobject> oldList, 
     TDTM_Runnable.Action thisAction, Schema.DescribeSobjectResult describeObj) {
     	        
         if(classToRunRecord != null) {
@@ -194,7 +194,7 @@ public class TDTM_TriggerHandler {
         return null;
     }
     
-    private void runAsync(TDTM_Runnable classToRun, String classToRunName, List<Sobject> newList, 
+    private static void runAsync(TDTM_Runnable classToRun, String classToRunName, List<Sobject> newList, 
     List<Sobject> oldList, TDTM_Runnable.Action thisAction, Schema.DescribeSobjectResult describeObj) {
        set<Id> setNewId;
        if(newlist != null) {

--- a/src/triggers/TDTM_Account.trigger
+++ b/src/triggers/TDTM_Account.trigger
@@ -29,9 +29,7 @@
 */ 
 trigger TDTM_Account on Account (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
-
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Account, 
-        new TDTM_ObjectDataGateway());
+  
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Account);
 }

--- a/src/triggers/TDTM_Address.trigger
+++ b/src/triggers/TDTM_Address.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Address on Address__c (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Address__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Address__c);
 }

--- a/src/triggers/TDTM_Affiliation.trigger
+++ b/src/triggers/TDTM_Affiliation.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Affiliation on npe5__Affiliation__c (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe5__Affiliation__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe5__Affiliation__c);
 }

--- a/src/triggers/TDTM_Allocation.trigger
+++ b/src/triggers/TDTM_Allocation.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Allocation on Allocation__c (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Allocation__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Allocation__c);
 }

--- a/src/triggers/TDTM_Campaign.trigger
+++ b/src/triggers/TDTM_Campaign.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Campaign on Campaign (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Campaign, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Campaign);
 }

--- a/src/triggers/TDTM_CampaignMember.trigger
+++ b/src/triggers/TDTM_CampaignMember.trigger
@@ -30,7 +30,6 @@
 trigger TDTM_CampaignMember on CampaignMember (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.CampaignMember, new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.CampaignMember);
 }

--- a/src/triggers/TDTM_Contact.trigger
+++ b/src/triggers/TDTM_Contact.trigger
@@ -30,7 +30,6 @@
 trigger TDTM_Contact on Contact (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Contact, new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Contact);
 }

--- a/src/triggers/TDTM_EngagementPlan.trigger
+++ b/src/triggers/TDTM_EngagementPlan.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_EngagementPlan on Engagement_Plan__c (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Engagement_Plan__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Engagement_Plan__c);
 }

--- a/src/triggers/TDTM_EngagementPlanTask.trigger
+++ b/src/triggers/TDTM_EngagementPlanTask.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_EngagementPlanTask on Engagement_Plan_Task__c (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Engagement_Plan_Task__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Engagement_Plan_Task__c);
 }

--- a/src/triggers/TDTM_HouseholdObject.trigger
+++ b/src/triggers/TDTM_HouseholdObject.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_HouseholdObject on npo02__Household__c (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
     
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npo02__Household__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npo02__Household__c);
 }

--- a/src/triggers/TDTM_Lead.trigger
+++ b/src/triggers/TDTM_Lead.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Lead on Lead (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Lead, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Lead);
 }

--- a/src/triggers/TDTM_Level.trigger
+++ b/src/triggers/TDTM_Level.trigger
@@ -29,8 +29,6 @@
 */
 trigger TDTM_Level on Level__c (before insert, before update) {
     
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Level__c, 
-        new TDTM_ObjectDataGateway());    
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Level__c);    
 }

--- a/src/triggers/TDTM_Opportunity.trigger
+++ b/src/triggers/TDTM_Opportunity.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Opportunity on Opportunity (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Opportunity, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Opportunity);
 }

--- a/src/triggers/TDTM_PartialSoftCredit.trigger
+++ b/src/triggers/TDTM_PartialSoftCredit.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_PartialSoftCredit on Partial_Soft_Credit__c (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Partial_Soft_Credit__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Partial_Soft_Credit__c);
 }

--- a/src/triggers/TDTM_Payment.trigger
+++ b/src/triggers/TDTM_Payment.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Payment on npe01__OppPayment__c (before insert, before update, before delete, after insert,
         after update, after delete, after undelete) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete,
-            Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe01__OppPayment__c,
-            new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete,
+            Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe01__OppPayment__c);
 }

--- a/src/triggers/TDTM_RecurringDonation.trigger
+++ b/src/triggers/TDTM_RecurringDonation.trigger
@@ -29,8 +29,7 @@
 */ 
 trigger TDTM_RecurringDonation on npe03__Recurring_Donation__c (after delete, after insert, after undelete, 
 after update, before delete, before insert, before update) {
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe03__Recurring_Donation__c, 
-        new TDTM_ObjectDataGateway());
+
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe03__Recurring_Donation__c);
 }

--- a/src/triggers/TDTM_Relationship.trigger
+++ b/src/triggers/TDTM_Relationship.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Relationship on npe4__Relationship__c (before insert, before update, before delete, 
     after insert, after update, after delete, after undelete) {
     
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe4__Relationship__c, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.npe4__Relationship__c);
 }

--- a/src/triggers/TDTM_Task.trigger
+++ b/src/triggers/TDTM_Task.trigger
@@ -30,8 +30,6 @@
 trigger TDTM_Task on Task (after delete, after insert, after undelete, 
     after update, before delete, before insert, before update) {
 
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
-        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Task, 
-        new TDTM_ObjectDataGateway());
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, Trigger.isDelete, 
+        Trigger.isUnDelete, Trigger.new, Trigger.old, Schema.Sobjecttype.Task);
 }

--- a/src/triggers/TDTM_User.trigger
+++ b/src/triggers/TDTM_User.trigger
@@ -31,10 +31,7 @@
 trigger TDTM_User on User (after delete, after insert, after undelete, after update, 
                             before delete, before insert, before update) {
 
-    // Initializes the TDTM handler that figures out which classes need to be called, and calls them.
-    TDTM_TriggerHandler handler = new TDTM_TriggerHandler();  
-    
-    handler.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, 
+    TDTM_Config_API.run(Trigger.isBefore, Trigger.isAfter, Trigger.isInsert, Trigger.isUpdate, 
                 Trigger.isDelete, Trigger.isUnDelete, Trigger.new, Trigger.old, 
-                Schema.Sobjecttype.User, new TDTM_ObjectDataGateway());
+                Schema.Sobjecttype.User);
 }


### PR DESCRIPTION
# Critical Changes

# Changes

- New global `run` method within the TDTM_Config_API class.
- The `run` method lets users create triggers for their custom objects or for standard objects for which NPSP doesn't have a trigger.
- Existing NPSP triggers have been updated to use this method. There is no action required by Admins.

# Issues Closed

Fixes #2569 

# New Metadata

# Deleted Metadata
