### PR TITLE
Allow allocation fields to roll up when creating new GAU rollups

### DIFF
--- a/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
+++ b/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
@@ -751,10 +751,10 @@
         } else if (summaryObject === labels.objectGAU) {
             //check for the detail object to ensure correct value is selected on edit mode
             var detailName;
-            if (activeRollup.detailObject === labels.objectAllocation) {
-                detailName = labels.objectAllocation;
-            } else {
+            if (activeRollup.detailObject === labels.objectOpportunity) {
                 detailName = labels.objectOpportunity;
+            } else {
+                detailName = labels.objectAllocation;
             }
             templateList.push({
                 label: labels.labelAllocation + ' -> ' + labels.labelGAU

--- a/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
+++ b/src/aura/CRLP_Rollup/CRLP_RollupHelper.js
@@ -1007,7 +1007,7 @@
             rollupType.name = labels.objectOpportunity;
             rollupType.summaryObject = labels.labelGAU;
             rollupType.label = labels.labelAllocation + ' -> ' + labels.labelGAU;
-            cmp.set("v.activeRollup.rollupTypeObject", labels.objectAllocation);
+            cmp.set("v.activeRollup.rollupTypeObject", labels.objectOpportunity);
 
         } else if (detailObject === labels.objectOpportunity && summaryObject === labels.objectRD){
             rollupType.name = labels.objectOpportunity;


### PR DESCRIPTION
# Critical Changes

# Changes
Fixes #3376 
Fixed issue where Rollup Type was not selected on Edit for GAU rollup when Detail Object was Opportunity (ex: GAU: First Allocation Date)
# Issues Closed

# New Metadata

# Deleted Metadata
