### PR TITLE
Rollups: force standard controller to add Name and Id fields on Recalculate Rollups pages

### DIFF
--- a/src/classes/CRLP_RecalculateBTN_CTRL.cls
+++ b/src/classes/CRLP_RecalculateBTN_CTRL.cls
@@ -56,6 +56,8 @@ public with sharing class CRLP_RecalculateBTN_CTRL {
             this.returnLabel = String.format(Label.CRLP_Return, new List<String> {this.objType.getDescribe().getLabel()});
         }
 
+        sc.addFields(new List<String>{ 'Name', 'Id' });
+
         // if the current User does not have permissions to modify the object (though not checking specific fields)
         // then prevent them from using the recalculate button.
         if (!this.objType.getDescribe().isUpdateable()) {


### PR DESCRIPTION
# Critical Changes

# Changes
- Force standard controller to add Name and Id fields on Recalculate Rollups pages

# Issues Closed

# New Metadata

# Deleted Metadata
