### PR TITLE
Disable debug logging in unit tests to improve test performance.

### DIFF
--- a/src/classes/UTIL_Debug.cls
+++ b/src/classes/UTIL_Debug.cls
@@ -35,8 +35,9 @@
 */
 public class UTIL_Debug {
 
-    //enable debug logs in all tests, otherwise get the setting
-    public static boolean enabled = test.isRunningTest() ? true : UTIL_CustomSettingsFacade.getErrorSettings().Enable_Debug__c;
+    // Disable debug logs in all tests, otherwise get the setting
+    // August 2018: Previously, debugging was enabled in all tests. Disabling should significantly help with performance.
+    public static boolean enabled = test.isRunningTest() ? false : UTIL_CustomSettingsFacade.getErrorSettings().Enable_Debug__c;
 
     /*******************************************************************************************************
     * @description Prints a debug message to the debug log, if debugging is enabled or a test is being run.

--- a/src/classes/UTIL_Debug.cls
+++ b/src/classes/UTIL_Debug.cls
@@ -37,7 +37,7 @@ public class UTIL_Debug {
 
     // Disable debug logs in all tests, otherwise get the setting
     // August 2018: Previously, debugging was enabled in all tests. Disabling should significantly help with performance.
-    public static boolean enabled = test.isRunningTest() ? false : UTIL_CustomSettingsFacade.getErrorSettings().Enable_Debug__c;
+    public static Boolean enabled = Test.isRunningTest() ? false : UTIL_CustomSettingsFacade.getErrorSettings().Enable_Debug__c;
 
     /*******************************************************************************************************
     * @description Prints a debug message to the debug log, if debugging is enabled or a test is being run.


### PR DESCRIPTION
It seems that the UTIL_Debug class was always enabling debug logging (i.e. `system.debug()`) during unit tests. The issue is that `system.debug()` statements are a cpu expensive operation. The feeling is that this has contributed heavily to the Apex CPU Timeout Errors that our builds have been suffering through. Forcing Debug Logging to disable in Unit Tests appears to have resolved this problem. 

Overall though, there isn't necessarily a good reason to force debugging to be enabled in unit tests anyway. If a developer needs to see the debug statements in a debug log when manually debugging the package, they should manually edit the UTIL_Debug class in their local dev environment to set the default to enabled. That change should not be committed back into the repository.

A big thank you to @davisagli and @cdcarter 

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
