### PR TITLE
Prepare to convert remaining beta orgs to use scratch orgs

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -210,6 +210,14 @@ flows:
             5:
                 task: test_data_relationships
 
+    config_offsetfiscal:
+        description: 'Configure an offset fiscal year'
+        steps:
+            1:
+                task: deploy
+                options:
+                    path: dev_config/src_offsetfiscal
+
     test_data_dev_org:
         description: 'WARNING: This flow deletes all data first, then loads the complete test data set based on 100 Contacts into the target org.'
         steps:
@@ -257,6 +265,10 @@ orgs:
             config_file: orgs/beta_middlesuffix.json
         beta_multicurrency:
             config_file: orgs/beta_multicurrency.json
+        beta_personaccounts:
+            config_file: orgs/beta_personaccounts.json
+        beta_statecountry:
+            config_file: orgs/beta_statecountry.json
         beta_wave:
             config_file: orgs/beta_wave.json
         prerelease:

--- a/dev_config/src_offsetfiscal/package.xml
+++ b/dev_config/src_offsetfiscal/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Company</members>
+        <name>Settings</name>
+    </types>
+    <version>43.0</version>
+</Package>

--- a/dev_config/src_offsetfiscal/settings/Company.settings
+++ b/dev_config/src_offsetfiscal/settings/Company.settings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CompanySettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fiscalYear>
+        <fiscalYearNameBasedOn>startingMonth</fiscalYearNameBasedOn>
+        <startMonth>December</startMonth>
+    </fiscalYear>
+</CompanySettings>

--- a/orgs/beta_personaccounts.json
+++ b/orgs/beta_personaccounts.json
@@ -1,8 +1,8 @@
 {
-  "orgName": "NPSP - Beta Org - Multicurrency",
+  "orgName": "NPSP - Beta Org - Person Accounts",
   "edition": "Developer",
   "features": [
-    "MultiCurrency"
+    "PersonAccounts"
   ],
   "hasSampleData": "true",
   "orgPreferences" : {

--- a/orgs/beta_statecountry.json
+++ b/orgs/beta_statecountry.json
@@ -1,8 +1,8 @@
 {
-  "orgName": "NPSP - Beta Org - Multicurrency",
+  "orgName": "NPSP - Beta Org - State / Country Picklist",
   "edition": "Developer",
   "features": [
-    "MultiCurrency"
+    "StateAndCountryPicklist"
   ],
   "hasSampleData": "true",
   "orgPreferences" : {

--- a/orgs/beta_wave.json
+++ b/orgs/beta_wave.json
@@ -1,7 +1,9 @@
 {
   "orgName": "NPSP - Beta Org - Analytics",
   "edition": "Developer",
-  "features": "SalesWave",
+  "features": [
+    "SalesWave"
+  ],
   "instance": "CS46",
   "hasSampleData": "true",
   "orgPreferences" : {


### PR DESCRIPTION
- New scratch org definitions: beta_personaccounts and beta_statecountry
- New config_offsetfiscal flow which can be used with the beta org shape to run the offset fiscal beta

Please review this but don't merge, since I need to adjust Plan configuration on MetaCI before merging.

**lurch: attach W-025426

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
