### PR TITLE
Deactivate rollup triggers in BDI when rollup settings is not checked

### DIFF
--- a/src/classes/BDI_DataImportService.cls
+++ b/src/classes/BDI_DataImportService.cls
@@ -763,23 +763,7 @@ global with sharing class BDI_DataImportService {
             return;
         }
 
-        List<Trigger_Handler__c> handlers = TDTM_Config_API.getCachedRecords();
-        for (Trigger_Handler__c th : handlers) {
-            if (isRollupTriggerHandler(th)) {
-                th.Active__c = false;
-            }
-        }
-    }
-
-    /*******************************************************************************************************
-    * @description Returns true if the trigger handler is used to calculate rollups
-    * @param handler The trigger handler
-    * @return Boolean
-    */
-    private Boolean isRollupTriggerHandler(Trigger_Handler__c handler) {
-        return (handler.Object__c == 'Opportunity' && handler.Class__c == 'RLLP_OppRollup_TDTM') ||
-            (handler.Object__c == 'Opportunity' && handler.Class__c == 'CRLP_Rollup_TDTM') ||
-            (handler.Object__c == 'npe01__OppPayment__c' && handler.Class__c == 'CRLP_Rollup_TDTM'); 
+        TDTM_Config_API.disableAllRollupTriggers();
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_DataImportService.cls
+++ b/src/classes/BDI_DataImportService.cls
@@ -94,7 +94,7 @@ global with sharing class BDI_DataImportService {
     * @return Data_Import_Settings__c
     */
     public static Data_Import_Settings__c loadSettings(Id batchId) {
-
+        
         // load up the default or specific settings
         if (batchId == null) {
             return UTIL_CustomSettingsFacade.getDataImportSettings();
@@ -285,7 +285,7 @@ global with sharing class BDI_DataImportService {
     * @description holds the data import settings to use for this batch.  these may be either from
     * custom settings, or if a specific BatchId was specified, the settings specified for that batch.
     */
-    global Data_Import_Settings__c diSettings { get; private set; }
+    global Data_Import_Settings__c diSettings { get; set; }
 
     /*******************************************************************************************************
     * @description whether the processing should be done in Dry Run mode (vs. normal mode).
@@ -622,7 +622,6 @@ global with sharing class BDI_DataImportService {
     * @return void
     */
     public void LogBDIError(DataImport__c di, String strError, String strStatusField) {
-        //system.debug('****DJH: LogBDIError di: ' + di + ' strError: ' + strError + ' field: ' + strStatusField);
         di.Status__c = BDI_DataImport_API.bdiFailed;
         di.FailureInformation__c = strError;
         if (strStatusField != null)
@@ -748,15 +747,28 @@ global with sharing class BDI_DataImportService {
     * otherwise!)
     * @return void
     */
-    private void disableAllOppRollups() {
-        if (!diSettings.Run_Opportunity_Rollups_while_Processing__c) {
-            List<Trigger_Handler__c> handlers = TDTM_Config_API.getCachedRecords();
-            for (Trigger_Handler__c th : handlers) {
-                if (th.Object__c == 'Opportunity' && (th.Class__c == 'RLLP_OppRollup_TDTM' || th.Class__c == 'CRLP_Rollup_TDTM')) {
-                    th.Active__c = false;
-                }
+    @TestVisible private void disableAllOppRollups() {
+        if (diSettings.Run_Opportunity_Rollups_while_Processing__c) {
+            return;
+        }
+
+        List<Trigger_Handler__c> handlers = TDTM_Config_API.getCachedRecords();
+        for (Trigger_Handler__c th : handlers) {
+            if (isRollupTriggerHandler(th)) {
+                th.Active__c = false;
             }
         }
+    }
+
+    /*******************************************************************************************************
+    * @description Returns true if the trigger handler is used to calculate rollups
+    * @param handler The trigger handler
+    * @return Boolean
+    */
+    private Boolean isRollupTriggerHandler(Trigger_Handler__c handler) {
+        return (handler.Object__c == 'Opportunity' && handler.Class__c == 'RLLP_OppRollup_TDTM') ||
+            (handler.Object__c == 'Opportunity' && handler.Class__c == 'CRLP_Rollup_TDTM') ||
+            (handler.Object__c == 'npe01__OppPayment__c' && handler.Class__c == 'CRLP_Rollup_TDTM'); 
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_DataImportService.cls
+++ b/src/classes/BDI_DataImportService.cls
@@ -285,7 +285,7 @@ global with sharing class BDI_DataImportService {
     * @description holds the data import settings to use for this batch.  these may be either from
     * custom settings, or if a specific BatchId was specified, the settings specified for that batch.
     */
-    global Data_Import_Settings__c diSettings { get; set; }
+    global Data_Import_Settings__c diSettings { get; private set; }
 
     /*******************************************************************************************************
     * @description whether the processing should be done in Dry Run mode (vs. normal mode).
@@ -335,6 +335,17 @@ global with sharing class BDI_DataImportService {
             return isCustomIdInAccountDatatypeString;
         }
         set;
+    }
+
+    /*******************************************************************************************************
+    * @description Sets diSettings based on the input settings. The method is called from tests only 
+    * since the variable is global with private set().
+    * @param diSettings Data Import Settings
+    * @return void
+    */
+    @TestVisible
+    private void injectDataImportSettings(Data_Import_Settings__c settings) {
+        this.diSettings = settings;
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_DataImportService_TEST.cls
+++ b/src/classes/BDI_DataImportService_TEST.cls
@@ -75,7 +75,7 @@ private with sharing class BDI_DataImportService_TEST {
 
         Boolean isDryRun = false;
         BDI_DataImportService service = new BDI_DataImportService(isDryRun);
-        service.diSettings = diSettings;
+        service.injectDataImportSettings(diSettings);
 
         List<Trigger_Handler__c> expectedHandlers = TDTM_Config_API.getCachedRecords();
 
@@ -95,7 +95,7 @@ private with sharing class BDI_DataImportService_TEST {
 
         Boolean isDryRun = false;
         BDI_DataImportService service = new BDI_DataImportService(isDryRun);
-        service.diSettings = diSettings;
+        service.injectDataImportSettings(diSettings);
 
         Map<String, Trigger_Handler__c> handlerByKey = new Map<String, Trigger_Handler__c>();
         for (Trigger_Handler__c handler : TDTM_Config_API.getCachedRecords()) {

--- a/src/classes/BDI_DataImportService_TEST.cls
+++ b/src/classes/BDI_DataImportService_TEST.cls
@@ -1,0 +1,142 @@
+/*
+    Copyright (c) 2018 Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group Batch Data Import
+* @group-content ../../ApexDocContent/BatchDataImport.htm
+* @description Tests for BDI_DataImportService
+*/
+@isTest
+private with sharing class BDI_DataImportService_TEST {
+    
+    
+    /*******************************************************************************************************************
+    * @description Verifies UniqueID handling.
+    * The method returns expected results for various types of fields.
+    */
+    @isTest
+    private static void testUniqueIdHandling() {
+        System.assertEquals(
+            UTIL_Namespace.StrTokenNSPrefix('Contact1_Website__c'),
+            BDI_DataImportService.strDICustomIDField('Contact1', 'Website')
+        );
+
+        System.assertEquals('Contact1_Foo__c', BDI_DataImportService.strDICustomIDField('Contact1', 'Foo__c'));
+
+        String expectedCustomIdField = UTIL_Namespace.getNamespace().equalsIgnoreCase('npsp')
+            ? 'npsp__Contact1_Bar__c'
+            : 'Contact1_Bar__c';
+        System.assertEquals(expectedCustomIdField, BDI_DataImportService.strDICustomIDField('Contact1', 'npsp__Bar__c'));
+
+        System.assertEquals('Contact1_Baz__c', BDI_DataImportService.strDICustomIDField('Contact1', 'randomNS__Baz__c'));
+
+        System.assertEquals(
+            UTIL_Namespace.StrTokenNSPrefix('Contact1_Buz__c'),
+            BDI_DataImportService.strDICustomIDField('Contact1', UTIL_Namespace.StrTokenNSPrefix('Buz__c'))
+        );
+    }
+
+    /*******************************************************************************************************************
+    * @description Verifies rollup trigger handlers are not deactivated if the data import settings to process rollups
+    * is checked.
+    */
+    @isTest
+    private static void rollupTriggersAreNotDeactivatedWhenRunRollupSettingsIsChecked() {
+        Data_Import_Settings__c diSettings = getDataImportSettings();
+        diSettings.Run_Opportunity_Rollups_while_Processing__c = true;
+
+        Boolean isDryRun = false;
+        BDI_DataImportService service = new BDI_DataImportService(isDryRun);
+        service.diSettings = diSettings;
+
+        List<Trigger_Handler__c> expectedHandlers = TDTM_Config_API.getCachedRecords();
+
+        service.disableAllOppRollups();
+
+        System.assertEquals(expectedHandlers, TDTM_Config_API.getCachedRecords());
+    }
+
+    /*******************************************************************************************************************
+    * @description Verifies rollup trigger handlers are deactivated if the data import settings to process rollups
+    * is not checked.
+    */
+    @isTest
+    private static void rollupTriggersAreDeactivatedWhenRunRollupSettingsIsNotChecked() {
+        Data_Import_Settings__c diSettings = getDataImportSettings();
+        diSettings.Run_Opportunity_Rollups_while_Processing__c = false;
+
+        Boolean isDryRun = false;
+        BDI_DataImportService service = new BDI_DataImportService(isDryRun);
+        service.diSettings = diSettings;
+
+        Map<String, Trigger_Handler__c> handlerByKey = new Map<String, Trigger_Handler__c>();
+        for (Trigger_Handler__c handler : TDTM_Config_API.getCachedRecords()) {
+            handlerByKey.put(handler.Object__c + handler.Class__c, handler);
+        }
+
+        service.disableAllOppRollups();
+
+        for (Trigger_Handler__c handler : TDTM_Config_API.getCachedRecords()) {
+            Boolean isActive = isRollupTriggerHandler(handler) 
+                ? false 
+                : handlerByKey.get(handler.Object__c + handler.Class__c).Active__c;
+
+            System.assertEquals(isActive, handler.Active__c, 'Only rollup trigger handlers should be deactivated: ' + handler);
+        }
+    }
+
+
+    // Helpers
+    ////////////
+
+    /*******************************************************************************************************************
+    * @description Retrieves and sets default on the data import settings
+    */
+    private static Data_Import_Settings__c getDataImportSettings() {
+        Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
+
+        diSettings.Donation_Matching_Rule__c = UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c');
+        diSettings.Donation_Matching_Behavior__c = BDI_DataImport_API.ExactMatchOrCreate;
+
+        return diSettings;
+    }
+
+
+    /*******************************************************************************************************************
+    * @description Returns true if the trigger handler calculates rollups
+    */
+    private static Boolean isRollupTriggerHandler(Trigger_Handler__c handler) {
+         return (handler.Object__c == 'Opportunity' && handler.Class__c == 'RLLP_OppRollup_TDTM') ||
+            (handler.Object__c == 'Opportunity' && handler.Class__c == 'CRLP_Rollup_TDTM') ||
+            (handler.Object__c == 'npe01__OppPayment__c' && handler.Class__c == 'CRLP_Rollup_TDTM'); 
+    }
+}

--- a/src/classes/BDI_DataImportService_TEST.cls-meta.xml
+++ b/src/classes/BDI_DataImportService_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_DataImportService_TEST.cls-meta.xml
+++ b/src/classes/BDI_DataImportService_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>43.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -1480,7 +1480,6 @@ private with sharing class BDI_DataImport_TEST2 {
             string flsError = label.flsError;
             flsError = flsError.replace('{0}', '');
             flsError = flsError.replace('.', '');
-            //System.assertEquals(listDI[i].FailureInformation__c, flsError);
             System.assert(listDI[i].FailureInformation__c.contains(flsError));
         }
     }
@@ -1587,35 +1586,6 @@ private with sharing class BDI_DataImport_TEST2 {
         Test.stopTest();
     }
 
-    /*********************************************************************************************************
-    * @description operation:
-    *    unit test for UniqueID handling
-    * verify:
-    *    method returns expected results for various types of fields.
-    **********************************************************************************************************/
-    static testMethod void testUniqueIdHandling() {
-        if (strTestOnly != '*' && strTestOnly != 'testUniqueIdHandling') return;
-
-        Test.startTest();
-
-        System.assertEquals(UTIL_Namespace.StrTokenNSPrefix('Contact1_Website__c'),
-            BDI_DataImportService.strDICustomIDField('Contact1', 'Website'));
-
-        System.assertEquals('Contact1_Foo__c', BDI_DataImportService.strDICustomIDField('Contact1', 'Foo__c'));
-
-        if (UTIL_Namespace.getNamespace().equalsIgnoreCase('npsp')) {
-            System.assertEquals('npsp__Contact1_Bar__c', BDI_DataImportService.strDICustomIDField('Contact1', 'npsp__Bar__c'));
-        } else {
-            System.assertEquals('Contact1_Bar__c', BDI_DataImportService.strDICustomIDField('Contact1', 'npsp__Bar__c'));
-        }
-
-        System.assertEquals('Contact1_Baz__c', BDI_DataImportService.strDICustomIDField('Contact1', 'randomNS__Baz__c'));
-
-        System.assertEquals(UTIL_Namespace.StrTokenNSPrefix('Contact1_Buz__c'),
-            BDI_DataImportService.strDICustomIDField('Contact1', UTIL_Namespace.StrTokenNSPrefix('Buz__c')));
-
-        Test.stopTest();
-    }
 
     /*********************************************************************************************************
     * @description operation:

--- a/src/classes/BDI_Donations_TEST.cls
+++ b/src/classes/BDI_Donations_TEST.cls
@@ -67,6 +67,52 @@ public with sharing class BDI_Donations_TEST {
             UTIL_unitTestData_TEST.getOpenStage(), system.Today(), 100, null, null);
         insert listOppT;
     }
+    /*********************************************************************************************************
+    * @description Verifies rollups are not calculated when rollup settings if not checked
+    */
+    @isTest
+    static void rollupShouldNotBeCalculatedWhenRollupSettingsIsNotChecked() {
+        if (ADV_PackageInfo_SVC.useAdv()) return;  
+        
+        Data_Import_Settings__c diSettings = UTIL_CustomSettingsFacade.getDataImportSettings();
+        diSettings.Donation_Matching_Rule__c = UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+            UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c');
+        diSettings.Donation_Matching_Behavior__c = BDI_DataImport_API.ExactMatchOrCreate;
+        diSettings.Run_Opportunity_Rollups_while_Processing__c = false;    
+            
+        DataImport__c dataImport = new DataImport__c(
+            Contact1_Firstname__c = 'Jane', Contact1_Lastname__c = 'Smith',
+            Contact1_Personal_Email__c = 'jane.smith@norollups.com',
+            Donation_Donor__c = 'Contact1',
+            Donation_Name__c = 'Test',
+            Donation_Amount__c = 1000,
+            Donation_Date__c = Date.today().addMonths(3),
+            Donation_Stage__c = UTIL_UnitTestData_TEST.getClosedWonStage()
+        );
+        insert dataImport;
+
+        Test.StartTest();
+        BDI_DataImport_BATCH batch = new BDI_DataImport_BATCH();
+        Database.executeBatch(batch, 10);
+        Test.stopTest();
+    
+        List<Contact> contacts = [SELECT npo02__TotalOppAmount__c, npo02__FirstCloseDate__c FROM Contact];
+        System.assertEquals(1, contacts.size());
+        System.assertEquals(0, contacts[0].npo02__TotalOppAmount__c);
+        System.assertEquals(null, contacts[0].npo02__FirstCloseDate__c);
+        
+        List<Opportunity> opps = [SELECT Name, Amount, StageName, isWon FROM Opportunity];
+        System.assertEquals(1, opps.size());
+        System.assertEquals(true, opps[0].isWon);
+        
+        List<npe01__OppPayment__c> payments = [SELECT Id FROM npe01__OppPayment__c];
+        System.assertEquals(1, payments.size());
+
+        List<DataImport__c> dataImports = [SELECT DonationImported__c, DonationImportStatus__c FROM DataImport__c];
+        System.assertEquals(1, dataImports.size());
+        System.assertEquals(opps[0].Id, dataImports[0].DonationImported__c);  
+        System.assertEquals(label.bdiCreated, dataImports[0].DonationImportStatus__c);     
+    }
 
     /*********************************************************************************************************
     * @description operation
@@ -77,7 +123,7 @@ public with sharing class BDI_Donations_TEST {
     */
     static testMethod void TwoDIWithExistingDonations() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'TwoDIWithExistingDonations') return;
         
@@ -295,7 +341,7 @@ public with sharing class BDI_Donations_TEST {
     */
     static testMethod void TwoDIWithExistingDonationsSpecified() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'TwoDIWithExistingDonationsSpecified') return;
         
@@ -374,7 +420,7 @@ public with sharing class BDI_Donations_TEST {
     */
     static testMethod void TwoDIWithExistingPaymentsSpecified() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'TwoDIWithExistingPaymentsSpecified') return;
         
@@ -475,7 +521,7 @@ public with sharing class BDI_Donations_TEST {
     */
     static testMethod void TwoDIWithExistingDonationsOneDupe() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'TwoDIWithExistingDonationsOneDupe') return;
         
@@ -795,7 +841,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules1() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules1') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -819,7 +865,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules1b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules1b') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -843,7 +889,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules1c() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules1c') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -867,7 +913,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules1d() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules1d') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -890,7 +936,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules2() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules2') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -943,7 +989,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules4() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules4') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -967,7 +1013,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules4b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules4b') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -990,7 +1036,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules5() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules5') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1014,7 +1060,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules5b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules5b') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1037,7 +1083,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules6() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules6') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1061,7 +1107,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules7() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules7') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1084,7 +1130,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules7b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules7b') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1108,7 +1154,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules8() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules8') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1132,7 +1178,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules9() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules9') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1156,7 +1202,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules9b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules9b') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1180,7 +1226,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules10() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules10') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1204,7 +1250,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules10b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules10b') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1228,7 +1274,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules11() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules11') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1252,7 +1298,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules11b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules11b') return;
         insert new DataImport__c(Contact1_Firstname__c='c0', Contact1_Lastname__c='c0', Contact1_Personal_Email__c='c0@c0.com',
@@ -1275,7 +1321,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules12() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules12') return;
 
@@ -1300,7 +1346,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules13() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules13') return;
 
@@ -1325,7 +1371,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules14() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules14') return;
 
@@ -1353,7 +1399,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules14b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules14b') return;
 
@@ -1384,7 +1430,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules14c() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules14c') return;
 
@@ -1425,7 +1471,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules15() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules15') return;
 
@@ -1452,7 +1498,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules16() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
         
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules16') return;
 
@@ -1479,7 +1525,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/            
     static testMethod void donationMatchRules17() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules17') return;
 
@@ -1508,7 +1554,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules18a() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18a') return;
 
@@ -1551,7 +1597,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules18b() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18a') return;
 
@@ -1595,7 +1641,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules18c() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18c') return;
 
@@ -1636,7 +1682,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules18d() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules18d') return;
 
@@ -1663,7 +1709,7 @@ public with sharing class BDI_Donations_TEST {
     **********************************************************************************************************/
     static testMethod void donationMatchRules19() {
         //skip the test if Advancement is installed
-        if(ADV_PackageInfo_SVC.useAdv()) return;
+        if (ADV_PackageInfo_SVC.useAdv()) return;
 
         if (strTestOnly != '*' && strTestOnly != 'donationMatchRules19') return;
 

--- a/src/classes/TDTM_Config_API.cls
+++ b/src/classes/TDTM_Config_API.cls
@@ -94,7 +94,6 @@ global class TDTM_Config_API {
         TDTM_ProcessControl.toggleTriggerState('Opportunity', 'RLLP_OppRollup_TDTM', false);
         TDTM_ProcessControl.toggleTriggerState('Opportunity', 'CRLP_Rollup_TDTM', false);
         TDTM_ProcessControl.toggleTriggerState('npe01__OppPayment__c', 'CRLP_Rollup_TDTM', false);
-        TDTM_ProcessControl.toggleTriggerState('Allocation__c', 'CRLP_Rollup_TDTM', false);
     }
 
 }

--- a/src/package.xml
+++ b/src/package.xml
@@ -65,6 +65,7 @@
         <members>BDI_DataImportDeleteBTN_CTRL</members>
         <members>BDI_DataImportDeleteBTN_TEST</members>
         <members>BDI_DataImportService</members>
+        <members>BDI_DataImportService_TEST</members>
         <members>BDI_DataImport_API</members>
         <members>BDI_DataImport_BATCH</members>
         <members>BDI_DataImport_CTRL</members>
@@ -148,6 +149,7 @@
         <members>CRLP_RecalculateBTN_TEST</members>
         <members>CRLP_Rollup</members>
         <members>CRLP_RollupAccSoftCredit_SVC</members>
+        <members>CRLP_RollupAccSoftCredit_TEST</members>
         <members>CRLP_RollupAccount_SVC</members>
         <members>CRLP_RollupAccount_TEST</members>
         <members>CRLP_RollupBatch_SVC</members>
@@ -427,7 +429,6 @@
         <members>UTIL_Where</members>
         <members>UTIL_Where_TEST</members>
         <members>UTIL_iSoqlListViewConsumer</members>
-        <members>CRLP_RollupAccSoftCredit_TEST</members>
         <name>ApexClass</name>
     </types>
     <types>


### PR DESCRIPTION
Rollups are not calculated upon data import when Data Import Settings > "Calculate Donation Rollups with Batch" field is unchecked.

# Critical Changes

# Changes

# Issues Closed
Fixes #3630

# New Metadata
Apex Class:
- BDI_DataImportService_TEST

# Deleted Metadata
