### PR TITLE
Revert empty UTIL_JobProgress component

### DIFF
--- a/src/components/UTIL_JobProgress.component
+++ b/src/components/UTIL_JobProgress.component
@@ -1,2 +1,0 @@
-<apex:component>
-</apex:component>

--- a/src/components/UTIL_JobProgress.component-meta.xml
+++ b/src/components/UTIL_JobProgress.component-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
-    <label>UTIL_JobProgress</label>
-</ApexComponent>


### PR DESCRIPTION
Turns out that packaging rules won't allow us to re-add this after all, and the release is working without the empty component.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
