### PR TITLE
BGE Live Save 

### DIFF
--- a/src/aura/BGE_DataImportBatchEntry/BGE_DataImportBatchEntry.cmp
+++ b/src/aura/BGE_DataImportBatchEntry/BGE_DataImportBatchEntry.cmp
@@ -154,7 +154,7 @@
                                 columns="{!v.columns}"
                                 data="{!v.data}"
                                 keyField="Id"
-                                onsave="{!c.onTableSave}"
+                                oncellchange="{!c.onCellChange}"
                                 minColumnWidth="150"
                                 hideCheckboxColumn="true"
                                 onrowaction="{!c.handleRowAction}"

--- a/src/aura/BGE_DataImportBatchEntry/BGE_DataImportBatchEntryController.js
+++ b/src/aura/BGE_DataImportBatchEntry/BGE_DataImportBatchEntryController.js
@@ -56,10 +56,10 @@
     },
 
     /**
-     * @description: callback function for lightning:recordEditForm. Queries DataImport__c records,
-     * shows toast, and clears recordEditForm.
+     * @description: cell change handler for lightning:dataTable
+     * Saves updated cell value and re-runs Dry Run on that row.
      */
-    onTableSave: function (component, event, helper) {
+    onCellChange: function (component, event, helper) {
         var values = event.getParam('draftValues');
         // validation would happen here
         helper.handleTableSave(component, values);


### PR DESCRIPTION
# Critical Changes

# Changes
- Data Import records are saved every time a user tabs out of a cell, enabling Dry Run to occur with live changes.
# Issues Closed

# New Metadata

# Deleted Metadata
