### PR TITLE
Enforce minimum CCI version

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,3 +1,5 @@
+minimum_cumulusci_version: "2.0.10"
+
 project:
     name: Cumulus
     package:


### PR DESCRIPTION
The npsp_default_settings task doesn't work in earlier versions because I moved the anon apex task.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
