### PR TITLE
Fix button URLs to work in unmanaged NPSP

### DIFF
--- a/scripts/configure_npsp_default_settings.cls
+++ b/scripts/configure_npsp_default_settings.cls
@@ -33,6 +33,10 @@ public static void initializeNPSPSettings() {
     cos.%%%NAMESPACE%%%Notification_Recipient_Opp_Contact_Role__c = 'Notification Contact';
     cos.%%%NAMESPACE%%%Payments_Auto_Close_Stage_Name__c = getClosedWonStage();
     upsert cos;
+
+    %%%NAMESPACE%%%Package_Settings__c pkg = %%%NAMESPACE%%%Package_Settings__c.getOrgDefaults();
+    pkg.%%%NAMESPACE%%%Namespace_Prefix__c = %%%NAMESPACE%%%UTIL_Namespace.StrTokenNSPrefix('');
+    upsert pkg;
 }
 
 private static String getClosedWonStage(){

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -40,8 +40,8 @@ global without sharing class STG_InstallScript implements InstallHandler {
         POPULATE_RD_INSTALLMENT_NUMBER, RUN_NEW_ORG_SCRIPT, 
         INSERT_TDTM_DEFAULTS, ABORT_OLD_SCHEDULED_JOBS, 
         CLEANUP_RECORD_TYPE_SETTINGS, UPDATE_CAMPAIGN_LIST_REPORT,
-        UPDATE_ORG_TELEMETRY, CREATE_DEFAULT_SETTINGS,
-        POPULATE_NAMESPACE_PREFIX
+        UPDATE_ORG_TELEMETRY, CREATE_DEFAULT_SETTINGS_FOR_UPGRADE,
+        CREATE_DEFAULT_SETTINGS_FOR_NEW_INSTALL
     }
 
     /*******************************************************************************************************
@@ -52,19 +52,21 @@ global without sharing class STG_InstallScript implements InstallHandler {
     global void onInstall(InstallContext context) {
         ErrorLogger logger = new ErrorLogger(context, ERR_Handler_API.Context.STTG);
 
-        executeAction(InstallAction.POPULATE_NAMESPACE_PREFIX, logger);
-
-        //First install of Cumulus. NPSP is a requirement to install Cumulus, so we don't need to check if it's installed
+        // First install of Cumulus
         if (context.previousVersion() == null) {
-            //Populate Recurring Donation Installment Number on Opportunity for fresh installs; 
-            //This also covers upgrades from v2
+            // Ensure custom settings that we manage are populated
+            executeAction(InstallAction.CREATE_DEFAULT_SETTINGS_FOR_NEW_INSTALL, logger);
+
+            // Populate Recurring Donation Installment Number on Opportunity for fresh installs;
+            // This also covers upgrades from v2
             executeAction(InstallAction.POPULATE_RD_INSTALLMENT_NUMBER, logger);
             
             executeAction(InstallAction.RUN_NEW_ORG_SCRIPT, logger);
 
+        // Upgrade of existing Cumulus installation
         } else if (context.isUpgrade() || context.isPush()) {
             // Ensure the any new Custom Settings objects are populated
-            executeAction(InstallAction.CREATE_DEFAULT_SETTINGS, logger);
+            executeAction(InstallAction.CREATE_DEFAULT_SETTINGS_FOR_UPGRADE, logger);
 
             // Insert/Update the TDTM defaults as needed
             executeAction(InstallAction.INSERT_TDTM_DEFAULTS, logger);
@@ -75,10 +77,12 @@ global without sharing class STG_InstallScript implements InstallHandler {
 
         executeAction(InstallAction.ABORT_OLD_SCHEDULED_JOBS, logger);
 
+        // Upgrade from NPSP 3.79
         if (context.previousVersion() == null || context.previousVersion().compareTo(new Version(3, 79)) < 0) {
             executeAction(InstallAction.CLEANUP_RECORD_TYPE_SETTINGS, logger);
         }
 
+        // Upgrade from NPSP 3.112
         if (context.previousVersion() == null || context.previousVersion().compareTo(new Version(3, 112)) < 0) {
             executeAction(InstallAction.UPDATE_CAMPAIGN_LIST_REPORT, logger);
         }
@@ -112,10 +116,11 @@ global without sharing class STG_InstallScript implements InstallHandler {
             } else if (action == InstallAction.UPDATE_ORG_TELEMETRY && !Test.isRunningTest()) {
                 UTIL_OrgTelemetry_SVC.dispatchTelemetryBatchJob();
 
-            } else if (action == InstallAction.CREATE_DEFAULT_SETTINGS) {
+            } else if (action == InstallAction.CREATE_DEFAULT_SETTINGS_FOR_UPGRADE) {
+                populateNamespacePrefix();
                 createNewDefaultCustomSettingRecords();
 
-            } else if (action == InstallAction.POPULATE_NAMESPACE_PREFIX) {
+            } else if (action == InstallAction.CREATE_DEFAULT_SETTINGS_FOR_NEW_INSTALL) {
                 populateNamespacePrefix();
             }
 
@@ -332,9 +337,11 @@ global without sharing class STG_InstallScript implements InstallHandler {
     * @description Make sure a value is set for the namespace prefix custom setting.
     */
     private void populateNamespacePrefix() {
-        Package_Settings__c settings = Package_Settings__c.getOrgDefaults();
-        settings.Namespace_Prefix__c = UTIL_Namespace.StrTokenNSPrefix('');
-        upsert settings;
+        Package_Settings__c pkgSettings = Package_Settings__c.getOrgDefaults();
+        if (pkgSettings.Id == null) {
+            pkgSettings.Namespace_Prefix__c = UTIL_Namespace.StrTokenNSPrefix('');
+            insert pkgSettings;
+        }
     }
 
     /*******************************************************************************************************

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -40,7 +40,8 @@ global without sharing class STG_InstallScript implements InstallHandler {
         POPULATE_RD_INSTALLMENT_NUMBER, RUN_NEW_ORG_SCRIPT, 
         INSERT_TDTM_DEFAULTS, ABORT_OLD_SCHEDULED_JOBS, 
         CLEANUP_RECORD_TYPE_SETTINGS, UPDATE_CAMPAIGN_LIST_REPORT,
-        UPDATE_ORG_TELEMETRY, CREATE_DEFAULT_SETTINGS
+        UPDATE_ORG_TELEMETRY, CREATE_DEFAULT_SETTINGS,
+        POPULATE_NAMESPACE_PREFIX
     }
 
     /*******************************************************************************************************
@@ -50,7 +51,9 @@ global without sharing class STG_InstallScript implements InstallHandler {
     */
     global void onInstall(InstallContext context) {
         ErrorLogger logger = new ErrorLogger(context, ERR_Handler_API.Context.STTG);
-                     
+
+        executeAction(InstallAction.POPULATE_NAMESPACE_PREFIX, logger);
+
         //First install of Cumulus. NPSP is a requirement to install Cumulus, so we don't need to check if it's installed
         if (context.previousVersion() == null) {
             //Populate Recurring Donation Installment Number on Opportunity for fresh installs; 
@@ -112,6 +115,8 @@ global without sharing class STG_InstallScript implements InstallHandler {
             } else if (action == InstallAction.CREATE_DEFAULT_SETTINGS) {
                 createNewDefaultCustomSettingRecords();
 
+            } else if (action == InstallAction.POPULATE_NAMESPACE_PREFIX) {
+                populateNamespacePrefix();
             }
 
         } catch(Exception e) {
@@ -303,24 +308,33 @@ global without sharing class STG_InstallScript implements InstallHandler {
     }
 
     /*******************************************************************************************************
-     * @description Ensure that any default Custom Settings Records are created for "new" custom settings objects
-     * added
-     */
+    * @description Ensure that any default Custom Settings Records are created for "new" custom settings objects
+    * added
+    */
     private void createNewDefaultCustomSettingRecords() {
         UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
         updateDefaultOrgContactsSettings();
     }
 
     /*******************************************************************************************************
-     * @description Ensure that any default Org Contacts Settings Records are updated for custom settings
-     * objects accordingly.
-     */
-     public static void updateDefaultOrgContactsSettings() {
+    * @description Ensure that any default Org Contacts Settings Records are updated for custom settings
+    * objects accordingly.
+    */
+    public static void updateDefaultOrgContactsSettings() {
         npe01__Contacts_And_Orgs_Settings__c npe01Settings = UTIL_CustomSettingsFacade.getOrgContactsSettings();
         if (npe01Settings.Contact_Role_for_Organizational_Opps__c == null) {
             npe01Settings.Contact_Role_for_Organizational_Opps__c = UTIL_CustomSettingsFacade.DEFAULT_OPPORTUNITY_CONTACT_ROLE_SOFT_CREDIT;
             update npe01Settings;
         }
+    }
+
+    /*******************************************************************************************************
+    * @description Make sure a value is set for the namespace prefix custom setting.
+    */
+    private void populateNamespacePrefix() {
+        Package_Settings__c settings = Package_Settings__c.getOrgDefaults();
+        settings.Namespace_Prefix__c = UTIL_Namespace.StrTokenNSPrefix('');
+        upsert settings;
     }
 
     /*******************************************************************************************************

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -36,10 +36,6 @@
 @isTest
 public with sharing class STG_InstallScript_TEST {
 
-    // if you only want to run one test in this class, fill in its name here.
-    // if you want to run all tests, then use '*'
-    private static string strTestOnly = '*';
-
     /*******************************************************************************************************
     * @description A test exception class 
     */
@@ -47,8 +43,6 @@ public with sharing class STG_InstallScript_TEST {
     
     /** NPSP to TDTM test - to verify no exception is thrown if the custom settings don't exist **/
     public testmethod static void mappingsTest_runScriptNoCustomSettings() {
-        if (strTestOnly != '*' && strTestOnly != 'mappingsTest_runScriptNoCustomSettings') return;
-               
         //Don't create NPSP custom settings
         
         //Run the install script
@@ -60,8 +54,6 @@ public with sharing class STG_InstallScript_TEST {
     
     /** Tests that missing trigger handlers get created **/
     public static testmethod void missingSettingsCreated() {
-        if (strTestOnly != '*' && strTestOnly != 'missingSettingsCreated') return;
-        
         //Create some of the default settings
         createSomeDefaultSettings();
         
@@ -74,8 +66,6 @@ public with sharing class STG_InstallScript_TEST {
 
     /** Tests that deleted class trigger handlers get deleted **/
     public static testmethod void deletedHandlers() {
-        if (strTestOnly != '*' && strTestOnly != 'deletedHandlers') return;
-        
         //Create some of the default settings
         createSomeDefaultSettings();
 
@@ -92,8 +82,6 @@ public with sharing class STG_InstallScript_TEST {
     }
     
     public testmethod static void push() {
-        if (strTestOnly != '*' && strTestOnly != 'push') return;
-        
         //Create some of the default settings
         createSomeDefaultSettings();
         
@@ -105,8 +93,6 @@ public with sharing class STG_InstallScript_TEST {
     }
     
     public testmethod static void upgrade() {
-        if (strTestOnly != '*' && strTestOnly != 'upgrade') return;
-        
         //Create some of the default settings
         createSomeDefaultSettings();
         
@@ -119,8 +105,6 @@ public with sharing class STG_InstallScript_TEST {
     
     /** NPSP to TDTM test - If it's the first time we install Cumulus and there was no custom DISABLE flag enabled **/
     public testmethod static void mappingsTest_runScriptNoCustomConfigOnInstall() {
-        if (strTestOnly != '*' && strTestOnly != 'mappingsTest_runScriptNoCustomConfigOnInstall') return;
-         
         //Create NPSP custom settings with all disable flags off
         setAllNpspFlags(false);
                
@@ -131,8 +115,6 @@ public with sharing class STG_InstallScript_TEST {
     
     /** NPSP to TDTM test - If it's the first time we install Cumulus and all the custom DISABLE flag were enabled **/
     public testmethod static void mappingsTest_runScriptCustomConfigOnInstallAllFlags() {
-        if (strTestOnly != '*' && strTestOnly != 'mappingsTest_runScriptCustomConfigOnInstallAllFlags') return;
-        
         //Create NPSP custom settings with all disable flags on
         setAllNpspFlags(true);
 
@@ -164,8 +146,6 @@ public with sharing class STG_InstallScript_TEST {
     
      /** NPSP to TDTM test - If it's the first time we install Cumulus and some the custom DISABLE flag were enabled **/
     public testmethod static void mappingsTest_runScriptCustomConfigOnInstallSomeFlags() {
-        if (strTestOnly != '*' && strTestOnly != 'mappingsTest_runScriptCustomConfigOnInstallSomeFlags') return;
-        
         //Create NPSP custom settings with some disable flags on
         List<SObject> settingsToUpdate = new List<SObject>();
         
@@ -192,8 +172,6 @@ public with sharing class STG_InstallScript_TEST {
     }
 
     public static testmethod void defaultSettingsCreated() {
-        if (strTestOnly != '*' && strTestOnly != 'defaultSettingsCreated') return;
-        
         //Clear all custom settings
         deleteAllCustomSettings();
                        
@@ -210,6 +188,7 @@ public with sharing class STG_InstallScript_TEST {
         Household_Naming_Settings__c householdNamingSettings = UTIL_CustomSettingsFacade.getOrgHouseholdNamingSettings();
         Allocations_Settings__c allocationsSettings = UTIL_CustomSettingsFacade.getOrgAllocationsSettings();
         Data_Import_Settings__c dataImportSettings = UTIL_CustomSettingsFacade.getOrgDataImportSettings();
+        Package_Settings__c pkgSettings = Package_Settings__c.getOrgDefaults();
 
         //If it's a new install we want to set the Household model by default
         System.assertEquals(CAO_Constants.HH_ACCOUNT_PROCESSOR, npe01Settings.npe01__Account_Processor__c);
@@ -266,6 +245,8 @@ public with sharing class STG_InstallScript_TEST {
         System.assertEquals('HH_NameSpec',householdNamingSettings.Implementing_Class__c);
         System.assertEquals(365,allocationsSettings.Rollup_N_Day_Value__c);
         System.assertEquals(50,dataImportSettings.Batch_Size__c);
+
+        System.assertNotEquals(pkgSettings.Id, null);
     }
 
     /*********************************************************************************************************

--- a/src/objects/DataImportBatch__c.object
+++ b/src/objects/DataImportBatch__c.object
@@ -323,6 +323,6 @@
         <masterLabel>Process Batch</masterLabel>
         <openType>sidebar</openType>
         <protected>false</protected>
-        <url>/apex/npsp__BDI_DataImport?batchId={!DataImportBatch__c.Id}&amp;retURL={!URLFOR(&apos;/&apos; + DataImportBatch__c.Id)}</url>
+        <url>/apex/{!$Setup.Package_Settings__c.Namespace_Prefix__c}BDI_DataImport?batchId={!DataImportBatch__c.Id}&amp;retURL={!URLFOR(&apos;/&apos; + DataImportBatch__c.Id)}</url>
     </webLinks>
 </CustomObject>

--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -1238,7 +1238,7 @@
         <openType>sidebar</openType>
         <protected>false</protected>
         <requireRowSelection>false</requireRowSelection>
-        <url>/apex/npsp__BDI_DataImportDeleteBTN?action=deleteAll&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
+        <url>/apex/{!$Setup.Package_Settings__c.Namespace_Prefix__c}BDI_DataImportDeleteBTN?action=deleteAll&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
     </webLinks>
     <webLinks>
         <fullName>Delete_Imported_Data_Import_Records</fullName>
@@ -1251,7 +1251,7 @@
         <openType>sidebar</openType>
         <protected>false</protected>
         <requireRowSelection>false</requireRowSelection>
-        <url>/apex/npsp__BDI_DataImportDeleteBTN?action=deleteImported&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
+        <url>/apex/{!$Setup.Package_Settings__c.Namespace_Prefix__c}BDI_DataImportDeleteBTN?action=deleteImported&amp;retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
     </webLinks>
     <webLinks>
         <fullName>Process_Data_Import</fullName>
@@ -1264,6 +1264,6 @@
         <openType>sidebar</openType>
         <protected>false</protected>
         <requireRowSelection>false</requireRowSelection>
-        <url>/apex/npsp__BDI_DataImport?retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
+        <url>/apex/{!$Setup.Package_Settings__c.Namespace_Prefix__c}BDI_DataImport?retURL={!URLFOR($Action.DataImport__c.Tab, $ObjectType.DataImport__c)}</url>
     </webLinks>
 </CustomObject>

--- a/src/objects/Opportunity.object
+++ b/src/objects/Opportunity.object
@@ -1382,7 +1382,7 @@ ISBLANK(npe03__Recurring_Donation__c),
         <masterLabel>Email Acknowledgment</masterLabel>
         <openType>sidebar</openType>
         <protected>false</protected>
-        <url>/apex/NPSP__OPP_SendAcknowledgmentBTN?OppId={!Opportunity.Id}</url>
+        <url>/apex/{!$Setup.Package_Settings__c.Namespace_Prefix__c}OPP_SendAcknowledgmentBTN?OppId={!Opportunity.Id}</url>
     </webLinks>
     <webLinks>
         <fullName>Email_Acknowledgments</fullName>

--- a/src/objects/Package_Settings__c.object
+++ b/src/objects/Package_Settings__c.object
@@ -8,7 +8,7 @@
         <fullName>Namespace_Prefix__c</fullName>
         <description>The active package namespace prefix for NPSP.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Do not edit.</inlineHelpText>
+        <inlineHelpText>The active package namespace prefix for NPSP. Do not edit manually.</inlineHelpText>
         <label>Namespace Prefix</label>
         <length>17</length>
         <required>false</required>

--- a/src/objects/Package_Settings__c.object
+++ b/src/objects/Package_Settings__c.object
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>Hierarchy</customSettingsType>
+    <enableFeeds>false</enableFeeds>
+    <label>NPSP Package Settings</label>
+    <visibility>Protected</visibility>
+    <fields>
+        <fullName>Namespace_Prefix__c</fullName>
+        <description>The active package namespace prefix for NPSP.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Do not edit.</inlineHelpText>
+        <label>Namespace Prefix</label>
+        <length>17</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+</CustomObject>

--- a/src/objects/Partial_Soft_Credit__c.object
+++ b/src/objects/Partial_Soft_Credit__c.object
@@ -157,6 +157,6 @@
         <openType>sidebar</openType>
         <protected>false</protected>
         <requireRowSelection>false</requireRowSelection>
-        <url>/apex/npsp__PSC_ManageSoftCredits?id={!Opportunity.Id}</url>
+        <url>/apex/{!$Setup.Package_Settings__c.Namespace_Prefix__c}PSC_ManageSoftCredits?id={!Opportunity.Id}</url>
     </webLinks>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -975,6 +975,7 @@
         <members>Opportunity_Naming_Settings__c.Date_Format__c</members>
         <members>Opportunity_Naming_Settings__c.Opportunity_Name_Format__c</members>
         <members>Opportunity_Naming_Settings__c.Opportunity_Record_Types__c</members>
+        <members>Package_Settings__c.Namespace_Prefix__c</members>
         <members>Partial_Soft_Credit__c.Amount__c</members>
         <members>Partial_Soft_Credit__c.Contact_Name__c</members>
         <members>Partial_Soft_Credit__c.Contact_Role_ID__c</members>
@@ -2000,6 +2001,7 @@
         <members>Household_Naming_Settings__c</members>
         <members>Level__c</members>
         <members>Opportunity_Naming_Settings__c</members>
+        <members>Package_Settings__c</members>
         <members>Partial_Soft_Credit__c</members>
         <members>Relationship_Sync_Excluded_Fields__c</members>
         <members>Schedulable__c</members>


### PR DESCRIPTION
This adds a new Package_Settings__c custom setting object with a Namespace_Prefix__c field,
and uses it to get the namespace for use in Cumulus' own button URLs.
The goal is to have buttons linking to VF pages that work in both managed and unmanaged deployments of NPSP.

For managed NPSP, the setting is initialized in the STG_InstallScript after installation or push upgrades.
For unmanaged NPSP, the setting is initialized in the anon apex run by the `npsp_default_settings` CCI task.

The new setting object is set as Protected because to use it from outside the package you would need to already know the namespace.

We should be sure to test this as a beta release to make sure there are no surprises.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
