### PR TITLE
[DO NOT MERGE] List default trigger actions in canonical order

### DIFF
--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -197,7 +197,7 @@ public without sharing class TDTM_DefaultConfig {
         // Payment records - currency code validation
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
                 Class__c = 'PMT_Payment_TDTM', Load_Order__c = 0, Object__c = 'npe01__OppPayment__c',
-                Trigger_Action__c = 'BeforeUpdate;BeforeInsert;AfterInsert;AfterUpdate'));
+                Trigger_Action__c = 'BeforeInsert;BeforeUpdate;AfterInsert;AfterUpdate'));
 
         // OpportunityContactRoles on Opportunity
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,


### PR DESCRIPTION
The non-canonical order causes an unsaved instance to not match a
saved record in canonical order.

# Critical Changes

# Changes

# Issues Closed
Fixes #3704 

# New Metadata

# Deleted Metadata
