### PR TITLE
CCI: fix redeployments to developer edition orgs

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -177,6 +177,16 @@ tasks:
         options:
             apex: new STG_PanelCustomizableRollup_CTRL().enableCRLPs();
 
+    uninstall_packaged_incremental:
+        description: Deletes any metadata from the package in the target org not in the local workspace
+        class_path: cumulusci.tasks.salesforce.UninstallPackagedIncremental
+        options:
+            ignore:
+                QuickAction:
+                    - NewEvent
+                    - NewCase
+                    - SendEmail
+
 flows:
     config_dev:
         steps:


### PR DESCRIPTION
Customize the uninstall_packaged_incremental task to ignore some QuickActions that get implicitly added to the package in Developer Edition orgs for unknown reasons.

This fixes running dev_org a second time to redeploy to DE orgs.

(Note: This requires cumulusci 2.1.1b1 to work, but should not break earlier versions)

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
