### PR TITLE
UseBGEGrid defaults false and is set true by wizard

### DIFF
--- a/src/classes/BGE_ConfigurationWizard_CTRL.cls
+++ b/src/classes/BGE_ConfigurationWizard_CTRL.cls
@@ -279,6 +279,7 @@ public with sharing class BGE_ConfigurationWizard_CTRL {
         dataImportBatch.Expected_Count_of_Gifts__c = recordDetails.expectedCount;
         dataImportBatch.Expected_Total_Batch_Amount__c = recordDetails.expectedTotal;
         dataImportBatch.Active_Fields__c = activeFields;
+        dataImportBatch.UseBatchGiftEntryGrid__c = true;
 
         upsert dataImportBatch;
 

--- a/src/objects/DataImportBatch__c.object
+++ b/src/objects/DataImportBatch__c.object
@@ -369,7 +369,7 @@
     </fields>
     <fields>
         <fullName>UseBatchGiftEntryGrid__c</fullName>
-        <defaultValue>true</defaultValue>
+        <defaultValue>false</defaultValue>
         <description>This flag is set during batch creation to use the gift entry batch feature.</description>
         <externalId>false</externalId>
         <inlineHelpText>Set this flag during batch creation to create a gift entry batch.</inlineHelpText>


### PR DESCRIPTION
# Critical Changes

# Changes
- Batches made from Batch Entry Grid tab have UseBatchEntryGrid true
- Batches made from standard Data Import Batch tab have UseBatchEntryGrid false

# Issues Closed

# New Metadata

# Deleted Metadata
