### PR TITLE
Adding Payment lookup to Allocation object

### DIFF
--- a/src/classes/CRLP_DefaultConfigBuilder.cls
+++ b/src/classes/CRLP_DefaultConfigBuilder.cls
@@ -466,25 +466,25 @@ public class CRLP_DefaultConfigBuilder {
             'General_Accounting_Unit__c.Last_Allocation_Date__c' =>
                     new List<String>{ 'GAU: Last Allocation Date', 'Date of the last Opportunity with an Allocation to this GAU' },
             'General_Accounting_Unit__c.Largest_Allocation__c' =>
-                    new List<String>{ 'GAU: Largest Allocation', 'Largest amount allocated to this GAU' },
+                    new List<String>{ 'GAU: Largest Allocation', 'Largest gift amount to this GAU' },
             'General_Accounting_Unit__c.Smallest_Allocation__c' =>
                     new List<String>{ 'GAU: Smallest Allocation', 'Smallest amount allocated to this GAU' },
             'General_Accounting_Unit__c.Total_Number_of_Allocations__c' =>
-                    new List<String>{ 'GAU: Total Number of Allocations', 'Count of all Allocation Amounts to this GAU' },
+                    new List<String>{ 'GAU: Total Number of Allocations', 'Count of all gifts allocated to this GAU' },
             'General_Accounting_Unit__c.Number_of_Allocations_Last_N_Days__c' =>
-                    new List<String>{ 'GAU: Number of Allocations Last N Days', 'Count of all Allocation Amounts in the last N days to this GAU' },
+                    new List<String>{ 'GAU: Number of Allocations Last N Days', 'Count of all gifts allocated in the last N days to this GAU' },
             'General_Accounting_Unit__c.Number_of_Allocations_Last_Year__c' =>
-                    new List<String>{ 'GAU: Number of Allocations Last Year','Count of all Allocation Amounts in the last calendar year to this GAU' },
+                    new List<String>{ 'GAU: Number of Allocations Last Year','Count of all gifts allocated in the last calendar year to this GAU' },
             'General_Accounting_Unit__c.Number_of_Allocations_This_Year__c' =>
-                    new List<String>{ 'GAU: Number of Allocations This Year', 'Count of all Allocation Amounts in the current calendar year to this GAU' },
+                    new List<String>{ 'GAU: Number of Allocations This Year', 'Count of all gifts allocated in the current calendar year to this GAU' },
             'General_Accounting_Unit__c.Number_of_Allocations_Two_Years_Ago__c' =>
                     new List<String>{ 'GAU: Number of Allocations Two Years Ago', 'Count of all Allocation Amounts two calendar years ago to this GAU' },
             'General_Accounting_Unit__c.Average_Allocation__c' =>
-                    new List<String>{ 'GAU: Average Allocation', 'Average of all Allocation Amounts to this GAU' },
+                    new List<String>{ 'GAU: Average Allocation', 'Average gift amount to this GAU' },
             'General_Accounting_Unit__c.Total_Allocations__c' =>
-                    new List<String>{ 'GAU: Total Allocations', 'Total of all Allocation Amounts to this GAU' },
+                    new List<String>{ 'GAU: Total Allocations', 'Total of all gift amounts to this GAU' },
             'General_Accounting_Unit__c.Total_Allocations_Last_N_Days__c' =>
-                    new List<String>{ 'GAU: Total Allocations Last N Days', 'Total of all Allocation Amounts in the last N days to this GAU' },
+                    new List<String>{ 'GAU: Total Allocations Last N Days', 'Total amount of gifts allocated in the last N days to this GAU' },
             'General_Accounting_Unit__c.Total_Allocations_Last_Year__c' =>
                     new List<String>{ 'GAU: Total Allocations Last Year', 'Total of all Allocation Amounts in the last calendar year to this GAU' },
             'General_Accounting_Unit__c.Total_Allocations_This_Year__c' =>

--- a/src/objects/Allocation__c.object
+++ b/src/objects/Allocation__c.object
@@ -119,12 +119,12 @@
     <fields>
         <fullName>Payment__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <description>Attributes allocations to a Payment. All settled Payments roll up to this Allocation&apos;s GAU.</description>
+        <description>Attributes allocations to a Payment.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Attributes allocations to a Payment. All settled Payments roll up to this Allocation&apos;s GAU.</inlineHelpText>
+        <inlineHelpText>Attributes allocations to a Payment.</inlineHelpText>
         <label>Payment</label>
         <referenceTo>npe01__OppPayment__c</referenceTo>
-        <relationshipLabel>GAU Allocations</relationshipLabel>
+        <relationshipLabel>Payment Allocations</relationshipLabel>
         <relationshipName>Allocations</relationshipName>
         <required>false</required>
         <trackTrending>false</trackTrending>

--- a/src/objects/Allocation__c.object
+++ b/src/objects/Allocation__c.object
@@ -117,6 +117,20 @@
         <type>Lookup</type>
     </fields>
     <fields>
+        <fullName>Payment__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <description>Attributes allocations to a Payment. All settled Payments roll up to this Allocation&apos;s GAU.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Attributes allocations to a Payment. All settled Payments roll up to this Allocation&apos;s GAU.</inlineHelpText>
+        <label>Payment</label>
+        <referenceTo>npe01__OppPayment__c</referenceTo>
+        <relationshipLabel>GAU Allocations</relationshipLabel>
+        <relationshipName>Allocations</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
+    <fields>
         <fullName>Percent__c</fullName>
         <description>Percent of Opportunity amount allocated to this Allocation's General Accounting Unit. If you later modify the Opportunity amount, NPSP will update the allocation amount on the General Accounting Unit.</description>
         <externalId>false</externalId>

--- a/src/objects/General_Accounting_Unit__c.object
+++ b/src/objects/General_Accounting_Unit__c.object
@@ -66,9 +66,9 @@
     <fields>
         <fullName>Average_Allocation__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>The average amount of all Allocations to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</description>
+        <description>Average gift amount to this GAU.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The average amount of all Allocations to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
+        <inlineHelpText>Average gift amount to this GAU.</inlineHelpText>
         <label>Average Allocation</label>
         <precision>18</precision>
         <required>false</required>
@@ -103,9 +103,9 @@
     <fields>
         <fullName>Largest_Allocation__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>The amount of the largest Allocation to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</description>
+        <description>Largest gift amount to this GAU.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The amount of the largest Allocation to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
+        <inlineHelpText>Largest gift amount to this GAU.</inlineHelpText>
         <label>Largest Allocation</label>
         <precision>18</precision>
         <required>false</required>
@@ -128,9 +128,9 @@
     <fields>
         <fullName>Number_of_Allocations_Last_N_Days__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Total number of allocations of opportunities in a closed and won stage in the last N days. The value of N can be modified in settings.</description>
+        <description>Count of all gifts allocated in the last N days to this GAU.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Total number of allocations of opportunities in a closed and won stage in the last N days. The value of N can be modified in settings.</inlineHelpText>
+        <inlineHelpText>Count of all gifts allocated in the last N days to this GAU.</inlineHelpText>
         <label>Number of Allocations Last N Days</label>
         <precision>18</precision>
         <required>false</required>
@@ -143,9 +143,9 @@
     <fields>
         <fullName>Number_of_Allocations_Last_Year__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>The total number of Allocations last year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
+        <description>Count of all gifts allocated in the last calendar year to this GAU.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The total number of Allocations last year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
+        <inlineHelpText>Count of all gifts allocated in the last calendar year to this GAU.</inlineHelpText>
         <label>Number of Allocations Last Year</label>
         <precision>18</precision>
         <required>false</required>
@@ -158,9 +158,9 @@
     <fields>
         <fullName>Number_of_Allocations_This_Year__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>The total number of Allocations this year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
+        <description>Count of all gifts allocated in the current calendar year to this GAU.</description>
         <externalId>false</externalId>
-        <inlineHelpText>TThe total number of Allocations this year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
+        <inlineHelpText>Count of all gifts allocated in the current calendar year to this GAU.</inlineHelpText>
         <label>Number of Allocations This Year</label>
         <precision>18</precision>
         <required>false</required>
@@ -202,9 +202,9 @@
     <fields>
         <fullName>Total_Allocations_Last_N_Days__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>The number of Allocations from Closed/Won Opportunities in the last N days. (The value of N is set in NPSP Settings, under Donations, GAU Allocations.) NPSP updates this field in a nightly Scheduled Job.</description>
+        <description>Total amount of gifts allocated in the last N days to this GAU.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The number of Allocations from Closed/Won Opportunities in the last N days. (The value of N is set in NPSP Settings, under Donations, GAU Allocations.) NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
+        <inlineHelpText>Total amount of gifts allocated in the last N days to this GAU.</inlineHelpText>
         <label>Total Allocations Last N Days</label>
         <precision>18</precision>
         <required>false</required>
@@ -258,9 +258,9 @@
     <fields>
         <fullName>Total_Allocations__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>The total amount from all Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
+        <description>Total of all gift amounts to this GAU.</description>
         <externalId>false</externalId>
-        <inlineHelpText>The total amount from all Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
+        <inlineHelpText>Total of all gift amounts to this GAU.</inlineHelpText>
         <label>Total Allocations</label>
         <precision>18</precision>
         <required>false</required>
@@ -272,9 +272,9 @@
     <fields>
         <fullName>Total_Number_of_Allocations__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>The total number of Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
+        <description>Count of all gifts allocated to this GAU</description>
         <externalId>false</externalId>
-        <inlineHelpText>The total number of Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
+        <inlineHelpText>Count of all gifts allocated to this GAU</inlineHelpText>
         <label>Total Number of Allocations</label>
         <precision>18</precision>
         <required>false</required>

--- a/src/objects/General_Accounting_Unit__c.object
+++ b/src/objects/General_Accounting_Unit__c.object
@@ -66,9 +66,9 @@
     <fields>
         <fullName>Average_Allocation__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Average gift amount to this GAU.</description>
+        <description>The average amount of all Allocations to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Average gift amount to this GAU.</inlineHelpText>
+        <inlineHelpText>The average amount of all Allocations to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
         <label>Average Allocation</label>
         <precision>18</precision>
         <required>false</required>
@@ -103,9 +103,9 @@
     <fields>
         <fullName>Largest_Allocation__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Largest gift amount to this GAU.</description>
+        <description>The amount of the largest Allocation to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Largest gift amount to this GAU.</inlineHelpText>
+        <inlineHelpText>The amount of the largest Allocation to this General Accounting Unit. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
         <label>Largest Allocation</label>
         <precision>18</precision>
         <required>false</required>
@@ -128,9 +128,9 @@
     <fields>
         <fullName>Number_of_Allocations_Last_N_Days__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Count of all gifts allocated in the last N days to this GAU.</description>
+        <description>Total number of allocations of opportunities in a closed and won stage in the last N days. The value of N can be modified in settings.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Count of all gifts allocated in the last N days to this GAU.</inlineHelpText>
+        <inlineHelpText>Total number of allocations of opportunities in a closed and won stage in the last N days. The value of N can be modified in settings.</inlineHelpText>
         <label>Number of Allocations Last N Days</label>
         <precision>18</precision>
         <required>false</required>
@@ -143,9 +143,9 @@
     <fields>
         <fullName>Number_of_Allocations_Last_Year__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Count of all gifts allocated in the last calendar year to this GAU.</description>
+        <description>The total number of Allocations last year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Count of all gifts allocated in the last calendar year to this GAU.</inlineHelpText>
+        <inlineHelpText>The total number of Allocations last year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
         <label>Number of Allocations Last Year</label>
         <precision>18</precision>
         <required>false</required>
@@ -158,9 +158,9 @@
     <fields>
         <fullName>Number_of_Allocations_This_Year__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Count of all gifts allocated in the current calendar year to this GAU.</description>
+        <description>The total number of Allocations this year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Count of all gifts allocated in the current calendar year to this GAU.</inlineHelpText>
+        <inlineHelpText>TThe total number of Allocations this year from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
         <label>Number of Allocations This Year</label>
         <precision>18</precision>
         <required>false</required>
@@ -202,9 +202,9 @@
     <fields>
         <fullName>Total_Allocations_Last_N_Days__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Total amount of gifts allocated in the last N days to this GAU.</description>
+        <description>The number of Allocations from Closed/Won Opportunities in the last N days. (The value of N is set in NPSP Settings, under Donations, GAU Allocations.) NPSP updates this field in a nightly Scheduled Job.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Total amount of gifts allocated in the last N days to this GAU.</inlineHelpText>
+        <inlineHelpText>The number of Allocations from Closed/Won Opportunities in the last N days. (The value of N is set in NPSP Settings, under Donations, GAU Allocations.) NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
         <label>Total Allocations Last N Days</label>
         <precision>18</precision>
         <required>false</required>
@@ -258,9 +258,9 @@
     <fields>
         <fullName>Total_Allocations__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Total of all gift amounts to this GAU.</description>
+        <description>The total amount from all Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Total of all gift amounts to this GAU.</inlineHelpText>
+        <inlineHelpText>The total amount from all Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
         <label>Total Allocations</label>
         <precision>18</precision>
         <required>false</required>
@@ -272,9 +272,9 @@
     <fields>
         <fullName>Total_Number_of_Allocations__c</fullName>
         <defaultValue>0</defaultValue>
-        <description>Count of all gifts allocated to this GAU</description>
+        <description>The total number of Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Count of all gifts allocated to this GAU</inlineHelpText>
+        <inlineHelpText>The total number of Allocations from Closed/Won Opportunities. NPSP updates this field in a nightly Scheduled Job.</inlineHelpText>
         <label>Total Number of Allocations</label>
         <precision>18</precision>
         <required>false</required>

--- a/src/package.xml
+++ b/src/package.xml
@@ -682,6 +682,7 @@
         <members>Allocation__c.Campaign__c</members>
         <members>Allocation__c.General_Accounting_Unit__c</members>
         <members>Allocation__c.Opportunity__c</members>
+        <members>Allocation__c.Payment__c</members>
         <members>Allocation__c.Percent__c</members>
         <members>Allocation__c.Recurring_Donation__c</members>
         <members>Allocations_Settings__c.Default_Allocations_Enabled__c</members>


### PR DESCRIPTION
- We've added a Payment lookup field to Allocation object, which attributes allocations to a Payment.
- New Metadata: Allocation__c.Payment__c field

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
