### PR TITLE
clear payment fields after inline edit

### DIFF
--- a/src/classes/BGE_DataImportBatchEntry_CTRL.cls
+++ b/src/classes/BGE_DataImportBatchEntry_CTRL.cls
@@ -182,6 +182,8 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
             dataImport.FailureInformation__c = null;
             dataImport.DonationImported__c = null;
             dataImport.DonationImportStatus__c = null;
+            dataImport.PaymentImported__c = null;
+            dataImport.PaymentImportStatus__c = null;
         }
         update dataImportRecords;
 


### PR DESCRIPTION
# Critical Changes

# Changes
- When a row with a matched payment is edited so the payment no longer matches, the matched record field clears.

# Issues Closed

# New Metadata

# Deleted Metadata
