### PR TITLE
Do not display 'Manage Soft Credits' page when user does not have required permissions

### DIFF
--- a/src/classes/PSC_ManageSoftCredits_CTRL.cls
+++ b/src/classes/PSC_ManageSoftCredits_CTRL.cls
@@ -37,18 +37,26 @@
 public with sharing class PSC_ManageSoftCredits_CTRL {
 
     public Opportunity opp {get; set;}
-    public boolean isAmount {get; set;} // true = amount, false = percentage
-    public boolean allowTooManySoftCredits {get; set;}
+    public Boolean isAmount {get; set;} // true = amount, false = percentage
+    public Boolean allowTooManySoftCredits {get; set;}
     public List<SoftCredit> softCredits {get; set;}
     /** @description List of soft credits to delete when the user clicks Save.*/
-    public List<sObject> listSoftCreditsForDelete = new List<sObject>();
+    public List<SObject> listSoftCreditsForDelete = new List<sObject>();
     public List<SelectOption> contactRoles {get; private set;}
     /** @description Row number sent back by page for delete row method.*/
-    public integer rowNumber {get;set;}
-
+    public Integer rowNumber {get;set;}
     /** @description The currency symbol or ISO code of the related record or org default */
-    @TestVisible
-    private String currencySymbol;
+    @TestVisible private String currencySymbol;
+    /** @description Set to true if the user has the appropriate permissions to access the page */
+    public Boolean hasAccess {
+        get {
+            if (hasAccess == null) {
+                hasAccess = getCurrentUserHasAccess();
+            }
+            return hasAccess;
+        }
+        private set;
+    }
 
     /*******************************************************************************************************
     * @description temporary Opp to hold the current Total Soft Credit Amount and currency
@@ -99,6 +107,14 @@ public with sharing class PSC_ManageSoftCredits_CTRL {
     */ 
     public PSC_ManageSoftCredits_CTRL(ApexPages.StandardController controller) {
         Id recordId = controller.getRecord().Id;
+
+        if (!hasAccess) {
+            opp = new Opportunity(Id = recordId);
+
+            Apexpages.addMessage(new ApexPages.Message(ApexPages.Severity.INFO, System.Label.pscManageSoftCreditsPermissionDenied));
+            return;
+        }
+
         String oppQuery = 'SELECT Id, Name, Amount, AccountId, Account.Name, npe01__Is_Opp_From_Individual__c, Primary_Contact__c, Primary_Contact__r.Name';
 
         if (userInfo.isMultiCurrencyOrganization()) {
@@ -188,6 +204,16 @@ public with sharing class PSC_ManageSoftCredits_CTRL {
         if (softCreditRoles.isEmpty())
             Apexpages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, Label.pscManageSoftCreditsNoRoles));
         
+    }
+
+    /*******************************************************************************************************
+    * @description Verifies the user has Create/Edit/Delete permissions for Partial Soft Credits.
+    * @return true when the user has the appropriate access
+    */
+    private Boolean getCurrentUserHasAccess() {
+        return Schema.SObjectType.Partial_Soft_Credit__c.isCreateable()
+            && Schema.SObjectType.Partial_Soft_Credit__c.isUpdateable()
+            && Schema.SObjectType.Partial_Soft_Credit__c.isDeletable();
     }
 
     /** @description Removes a row from the page, and adds to the list for deletion once the user saves.*/

--- a/src/classes/PSC_ManageSoftCredits_CTRL.cls
+++ b/src/classes/PSC_ManageSoftCredits_CTRL.cls
@@ -47,6 +47,7 @@ public with sharing class PSC_ManageSoftCredits_CTRL {
     public Integer rowNumber {get;set;}
     /** @description The currency symbol or ISO code of the related record or org default */
     @TestVisible private String currencySymbol;
+
     /** @description Set to true if the user has the appropriate permissions to access the page */
     public Boolean hasAccess {
         get {

--- a/src/classes/PSC_ManageSoftCredits_TEST.cls
+++ b/src/classes/PSC_ManageSoftCredits_TEST.cls
@@ -567,7 +567,7 @@ public with sharing class PSC_ManageSoftCredits_TEST {
         ctrl.refresh();
         system.assertNotEquals(null, ctrl.cancel());
     }
- 
+
     /*******************************************************************************************************
     * @description test handling of no Soft Credit Roles in NPSP Settings
     * verify errors detected and reported
@@ -591,5 +591,25 @@ public with sharing class PSC_ManageSoftCredits_TEST {
         system.assertEquals(0, ctrl.softCredits.size());
         
         system.assertNotEquals(0, ApexPages.getMessages().size());
+    }
+
+    /*******************************************************************************************************
+    * @description Verify the page displays an error when the user does not have the access required to
+    * view the page
+    */
+    @isTest
+    private static void shouldDisplayMessageWhenUserDoesNotHavePermissions() {
+        initTestDataWithoutPscs();
+        User user = UTIL_UnitTestData_TEST.createNewUserForTests(Datetime.now().getTime() + 'managepsc@salesforce.org.test');
+
+        System.runAs(user) {
+            Test.startTest();
+            Test.setCurrentPage(Page.PSC_ManageSoftCredits);
+            PSC_ManageSoftCredits_CTRL ctrl = new PSC_ManageSoftCredits_CTRL(new ApexPages.StandardController(opp));
+            Test.stopTest();
+
+            System.assertEquals(null, ctrl.opp.Name, 'The opportunity query should not be executed.');
+            System.assertNotEquals(0, ApexPages.getMessages().size(), 'A message should be displayed on the page.');
+        }
     }
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4685,6 +4685,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>You can&apos;t modify soft credit currencies directly. Update the parent Opportunity&apos;s currency, and NPSP will automatically update the currency of all related soft credits.</value>
     </labels>
     <labels>
+        <fullName>pscManageSoftCreditsPermissionDenied</fullName>
+        <categories>Manage Soft Credits, Error</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>You do not have permission to manage soft credits</shortDescription>
+        <value>You do not have permissions to manage Partial Soft Credits. Please contact your system administrator for more information.</value>
+    </labels>
+    <labels>
         <fullName>pscManageSoftCreditsFull</fullName>
         <categories>Manage Soft Credits</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Cumulus</fullName>
     <types>
@@ -1644,6 +1644,7 @@
         <members>pscManageSoftCreditsAmountMissing</members>
         <members>pscManageSoftCreditsAmountOrPercent</members>
         <members>pscManageSoftCreditsCantChangeCurrency</members>
+        <members>pscManageSoftCreditsPermissionDenied</members>
         <members>pscManageSoftCreditsFull</members>
         <members>pscManageSoftCreditsInvalidContact</members>
         <members>pscManageSoftCreditsNoRoles</members>

--- a/src/pages/PSC_ManageSoftCredits.page
+++ b/src/pages/PSC_ManageSoftCredits.page
@@ -8,18 +8,18 @@
 
         <apex:variable var="headerSubtitle" value="{! SUBSTITUTE($Label.mtchItems, '{0}', TEXT(numberOfSoftCredits))}" />
         <c:UTIL_PageHeader showBreadcrumb="true" parentEntityLabel="Opportunity"
-                         parentAction="{!If (NOT(ISNULL(opp)), URLFOR($Action.Opportunity.View, opp.Id), '')}" parentRecordName="{!opp.Name}"
-                         parentRecordAction="/{!opp.Id}"
+                         parentAction="{!If (NOT(ISNULL(opp)), URLFOR($Action.Opportunity.View, opp.Id), '')}"
+                         parentRecordName="{!opp.Name}" parentRecordAction="/{!opp.Id}"
                          header="{! $Label.pscManageSoftCreditsTitle }" headerLabel="{!headerSubtitle}"
                          icon="opportunity" iconCategory="standard"
-                         saveAction="{!save}" cancelAction="{!cancel}"/>
+                         saveAction="{!save}" showSaveBtn="{!hasAccess}" cancelAction="{!cancel}"/>
 
         <apex:actionFunction name="refresh" action="{!refresh}" reRender="totalSelected, totalUn" />
         <c:UTIL_PageMessages />
         
         <!-- outer div of body below header -->
-        <div class="myBodyContent">
-        
+        <apex:outputPanel styleClass="myBodyContent" layout="block" rendered="{!hasAccess}">
+
             <!-- SUMMARY INFO PANEL -->
             <div class="slds-grid slds-p-around_medium slds-p-bottom_large slds-theme_default">
                 <div class="slds-col slds-align-middle" id="account">
@@ -132,7 +132,7 @@
             <div class="slds-p-around_medium">
                 <apex:commandLink action="{!addAnotherSoftCredit}" value="{!$Label.pscManageSoftCreditsAdd}" reRender="tablePanel" />
             </div>
-        </div> <!-- myBodyContent -->
+        </apex:outputPanel> <!-- myBodyContent -->
     </div> <!-- slds -->
     </apex:form>
 </apex:page>


### PR DESCRIPTION
# Critical Changes

# Changes
- To access the Manage Soft Credits page, users must have Create, Edit, and Delete permissions on the Partial Soft Credit object.

# Issues Closed

# New Metadata

# Deleted Metadata
