### PR TITLE
Mark unstable robot tests that should not fail the build yet

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -65,6 +65,14 @@ tasks:
         options:
             path: unpackaged/config/delete
 
+    robot:
+        description: Runs a Robot Framework test from a .robot file
+        class_path: cumulusci.tasks.robotframework.Robot
+        options:
+            suites: tests
+            options:
+                noncritical: unstable
+
     robot_libdoc:
         class_path: cumulusci.tasks.robotframework.RobotLibDoc
         options:

--- a/tests/browser/affiliations/create_secondary_affiliation.robot
+++ b/tests/browser/affiliations/create_secondary_affiliation.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create Secondary Affiliation for Contact
+    [tags]  unstable
     &{account} =  API Create Organization Account   
     &{contact} =  API Create Contact    Email=skristem@robot.com
     Create Secondary Affiliation    &{account}[Name]    &{contact}[Id]

--- a/tests/browser/contacts_accounts/create_household.robot
+++ b/tests/browser/contacts_accounts/create_household.robot
@@ -15,6 +15,7 @@ Create Household With Name Only
 
     
 Create Household With Name and Email
+    [tags]  unstable
     ${contact_id} =  Create Contact with Email
     &{contact} =  Salesforce Get  Contact  ${contact_id}
     Header Field Value    Account Name    &{contact}[LastName] Household

--- a/tests/browser/donations/create_donation_payment.robot
+++ b/tests/browser/donations/create_donation_payment.robot
@@ -8,6 +8,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create Donation and Opportunity and Create Payment Manually
+    [tags]  unstable
     #1 contact HouseHold Validation
     ${contact_id} =  Create Contact with Email
     &{contact} =  Salesforce Get  Contact  ${contact_id}

--- a/tests/browser/donations_payments/create_donation_and_payment.robot
+++ b/tests/browser/donations_payments/create_donation_and_payment.robot
@@ -13,6 +13,7 @@ ${opp_name}
 *** Test Cases ***
 
 Create Donation from a Contact
+    [tags]  unstable
     ${contact_id} =  Create Contact with Email
     &{contact} =  Salesforce Get  Contact  ${contact_id}
     Header Field Value    Account Name    &{contact}[LastName] Household
@@ -42,6 +43,7 @@ Create Donation from a Contact
     Should not be equal as strings    ${value}    0
     
 Verify Payments 
+    [tags]  unstable
     Go To Object Home         Opportunity
     Click Link    ${opp_name}  
     Click ViewAll Related List    Payments

--- a/tests/browser/donations_payments/create_matching_donation.robot
+++ b/tests/browser/donations_payments/create_matching_donation.robot
@@ -8,6 +8,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create Matching Donation
+    [tags]  unstable
     ${contact_id} =  Create Contact with Email
     &{contact} =  Salesforce Get  Contact  ${contact_id}
     Header Field Value    Account Name    &{contact}[LastName] Household

--- a/tests/browser/donations_payments/data_imports.robot
+++ b/tests/browser/donations_payments/data_imports.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Data Imports
+    [tags]  unstable
     ${first_name1} =           Generate Random String
     ${last_name1} =            Generate Random String
     ${acc1}=                   Generate Random String 

--- a/tests/browser/engagement_plans/add_engagement_plan_to_contact.robot
+++ b/tests/browser/engagement_plans/add_engagement_plan_to_contact.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create a Contact and Add Engagement Plan
+    [tags]  unstable
     ${plan_name}     ${task1_1}    ${sub_task1_1}     ${task2_1}     Create Engagement Plan
     ${contact_id} =  Create Contact with Address
     &{contact} =  Salesforce Get  Contact  ${contact_id}
@@ -20,6 +21,7 @@ Create a Contact and Add Engagement Plan
     Log To Console    ${plan_num}
     
 Delete Engagement Plan
+    [tags]  unstable
     Sleep    2
     ${plan_num}    Verify Eng Plan Exists    Engagement Plans    True
     Sleep    2
@@ -28,6 +30,7 @@ Delete Engagement Plan
     Verify Occurance    Engagement Plans    0    
     
 Verify Tasks Exist Under Activity
+    [tags]  unstable
     Sleep    2
     Scroll Page To Location    0    0
     Click Span Button    More Steps

--- a/tests/browser/engagement_plans/create_engagement_plan.robot
+++ b/tests/browser/engagement_plans/create_engagement_plan.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create Engagement Plan and Verify
+    [tags]  unstable
     ${plan_name}     ${task1_1}    ${sub_task1_1}     ${task2_1}     Create Engagement Plan
     Verify Engagement Plan    ${plan_name}    ${task1_1}    ${sub_task1_1}     ${task2_1}
     

--- a/tests/browser/engagement_plans/edit_engagement_plan.robot
+++ b/tests/browser/engagement_plans/edit_engagement_plan.robot
@@ -11,6 +11,7 @@ ${task3_1}  Follow-Up Phone Call
 *** Test Cases ***
 
 Create Engagement Plan and Edit to Add New Task
+    [tags]  unstable
     ${plan_name}     ${task1_1}    ${sub_task1_1}     ${task2_1}     Create Engagement Plan
     Go To Object Home         npsp__Engagement_Plan_Template__c
     Click Link    link=${plan_name}

--- a/tests/browser/gaus/assign_gau_to_opportunity.robot
+++ b/tests/browser/gaus/assign_gau_to_opportunity.robot
@@ -8,6 +8,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Assign GAU to Opportunity
+    [tags]  unstable
     ${gau_name1}    Create GAU
     ${gau_name2}    Create GAU
     Go To Object Home    Opportunity

--- a/tests/browser/gaus/create_gau.robot
+++ b/tests/browser/gaus/create_gau.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create GAU and Verify
+    [tags]  unstable
     ${gau_name}    Create GAU
     ${gau_name1}    Get Main Header
     Should be Equal as Strings    ${gau_name1}      ${gau_name} 

--- a/tests/browser/levels/create_edit_delete_level.robot
+++ b/tests/browser/levels/create_edit_delete_level.robot
@@ -10,6 +10,7 @@ ${level_name}
 *** Test Cases ***
 
 Create Level and Verify
+    [tags]  unstable
     ${level_name}     Create Level
     Set Global Variable      ${level_name}
     Go To Object Home         npsp__Level__c
@@ -21,6 +22,7 @@ Create Level and Verify
     
     
 Edit Level and Verify
+    [tags]  unstable
     Click Link    link=Edit
     Sleep    2
     Select Frame With Title    Levels
@@ -38,6 +40,7 @@ Edit Level and Verify
     Confirm Value    Source Field    npo02__SmallestAmount__c    Y
             
 Delete Level
+    [tags]  unstable
     ${contact_id} =  Create Contact
     &{contact} =  Salesforce Get  Contact  ${contact_id} 
     Header Field Value    Account Name    &{contact}[LastName] Household

--- a/tests/browser/levels/delete_level.robot
+++ b/tests/browser/levels/delete_level.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Delete Level
+    [tags]  unstable
     ${level_name}     Create Level
     ${contact_id} =  Create Contact
     &{contact} =  Salesforce Get  Contact  ${contact_id} 

--- a/tests/browser/levels/edit_level.robot
+++ b/tests/browser/levels/edit_level.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Edit Level and Verify
+    [tags]  unstable
     ${level_name}     Create Level
     Go To Object Home         npsp__Level__c
     Click Link    link=${level_name}

--- a/tests/browser/manage_households/add_existingcontact_managehh.robot
+++ b/tests/browser/manage_households/add_existingcontact_managehh.robot
@@ -7,7 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Add Existing Contact to Existing Household through Manage Household Page
-    
+    [tags]  unstable
     &{contact1} =  API Create Contact    Email=skristem@robot.com   
     &{contact2} =  API Create Contact
     Go To Record Home  &{contact2}[AccountId] 

--- a/tests/browser/npsp_settings/edit_and_verify_setting.robot
+++ b/tests/browser/npsp_settings/edit_and_verify_setting.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Make Changes to Settings and Verify Changes
+    [tags]  unstable
     Sleep    5
     Open App Launcher
     Populate Address    Search apps or items...    NPSP Settings

--- a/tests/browser/recurring_donations/create_recurring_donation.robot
+++ b/tests/browser/recurring_donations/create_recurring_donation.robot
@@ -8,6 +8,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create Open Recurring Donation With Monthly Installment
+    [tags]  unstable
     Sleep    5
     Open App Launcher
     Populate Address    Search apps or items...    NPSP Settings

--- a/tests/browser/relationships/create_relationships.robot
+++ b/tests/browser/relationships/create_relationships.robot
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Create Relationships for contacts
+    [tags]  unstable
     #1 contact HouseHold Validation
     ${contact_id1} =  Create Contact with Email
     &{contact1} =  Salesforce Get  Contact  ${contact_id1}


### PR DESCRIPTION
This tells robotframework to ignore failures of tests tagged as unstable, and adds that tag to the tests that are still failing. I'm hoping this gives us a path to merging the tests that _are_ stable sooner rather than later.

The build as a whole shows as passing https://mrbelvedereci.herokuapp.com/builds/41032 but it's still possible to review the failed tests in MetaCI https://mrbelvedereci.herokuapp.com/builds/41032/tests

We'll want to kick off some more builds to make sure there aren't other flaky tests which should get the tag.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
