### PR TITLE
Add a flow to add a 2nd currency for the multicurrency beta build

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -177,6 +177,10 @@ tasks:
         options:
             apex: new STG_PanelCustomizableRollup_CTRL().enableCRLPs();
 
+    add_second_currency:
+        description: Add CAD as a 2nd currency for a multicurrency org
+        class_path: tasks.multicurrency.ConfigureCAD
+
     uninstall_packaged_incremental:
         description: Deletes any metadata from the package in the target org not in the local workspace
         class_path: cumulusci.tasks.salesforce.UninstallPackagedIncremental
@@ -247,6 +251,12 @@ flows:
                 task: deploy
                 options:
                     path: unpackaged/config/offsetfiscal
+
+    config_multicurrency:
+        description: 'Configure a second currency'
+        steps:
+            1:
+                task: add_second_currency
 
     test_data_dev_org:
         description: 'WARNING: This flow deletes all data first, then loads the complete test data set based on 100 Contacts into the target org.'

--- a/tasks/multicurrency.py
+++ b/tasks/multicurrency.py
@@ -1,0 +1,12 @@
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
+
+class ConfigureCAD(BaseSalesforceApiTask):
+
+    def _run_task(self):
+        self.sf.CurrencyType.create({
+            'IsoCode': 'CAD',
+            'IsCorporate': False,
+            'IsActive': True,
+            'DecimalPlaces': 2,
+            'ConversionRate': 1.3,
+        })


### PR DESCRIPTION
Turns out we can insert CurrencyType using the REST API! This should let us run some multicurrency tests that currently do not run due to only having one currency configured in the beta_multicurrency scratch org.

Once this is approved, I need to add this flow to the beta_multicurrency plan in MetaCI before merging.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
