### PR TITLE
CRLP Timezone Date filter fix (attempt #3)

### DIFF
--- a/src/classes/CMT_FilterRule.cls
+++ b/src/classes/CMT_FilterRule.cls
@@ -296,14 +296,20 @@ public class CMT_FilterRule {
     }
 
     /**
-     * @description Compare implementation for a DateTime data type
+     * @description Compare implementation for a DateTime data type. The UI will format a DateTime entered value as
+     * '2018-11-02T22:00:00.000Z' (i.e., GMT), however DateTime.valueOfGMT() requires that the string not include the
+     * "T" and "Z" letters.
      */
     public class CompareDateTimes implements ICompare {
         public Boolean isIncluded(SObject record, CMT_FilterRule rule) {
             DateTime fieldValue = (record.get(rule.field) != null ? (DateTime)record.get(rule.field) : null);
             String dateConstant = (String.isNotEmpty(rule.constant) && CMT_FilterRule.validDateConstants.contains(rule.constant) ?
                     rule.constant : null);
-            DateTime compareValue = (String.isNotEmpty(rule.constant) && dateConstant == null ? DateTime.valueOf(rule.constant) : null);
+            DateTime compareValue;
+
+            if (String.isNotEmpty(rule.constant) && dateConstant == null) {
+                compareValue = DateTime.valueOf(rule.constant.replace('T',' ').replace('Z', ''));
+            }
 
             if (fieldValue == null && compareValue == null) {
                 // A null to null comparison is either Equals (true) or false for any other operation

--- a/src/classes/CMT_FilterRule.cls
+++ b/src/classes/CMT_FilterRule.cls
@@ -104,6 +104,7 @@ public class CMT_FilterRule {
     protected Schema.SObjectType objectType;
     protected Schema.SObjectField field;
     protected FilterOperation operation;
+    protected SoapType fieldType;
     protected String constant;
     public String objectName;
     public Id ruleId;
@@ -120,8 +121,9 @@ public class CMT_FilterRule {
         this.field = UTIL_Describe.getFieldDescribe(filterRule.Object__r.QualifiedApiName, filterRule.Field__r.QualifiedApiName).getSObjectField();
         this.constant = filterRule.Constant__c;
         this.operation = CMT_FilterRuleUI_SVC.getFilterOperationFromString(filterRule.Operator__c);
+        this.fieldType = field.getDescribe().getSoapType();
 
-        if (field.getDescribe().getSOAPType() == SoapType.DATETIME && constant != null &&
+        if (fieldType == SoapType.DATETIME && constant != null &&
                 constant.length() == 10 && !CMT_FilterRule.validDateConstants.contains(constant)) {
             // If the field is a datetime type, and the constant is a date format (YYYY-DD-MM) then use
             // DATE comparison class rather than the date time comparison class
@@ -134,7 +136,7 @@ public class CMT_FilterRule {
             this.compare = (ICompare) converters.get(SoapType.STRING).newInstance();
 
         } else {
-            this.compare = (ICompare) converters.get(field.getDescribe().getSOAPType()).newInstance();
+            this.compare = (ICompare) converters.get(fieldType).newInstance();
         }
     }
 
@@ -253,9 +255,16 @@ public class CMT_FilterRule {
                     rule.constant : null);
             Date compareValue = (String.isNotEmpty(rule.constant) && dateConstant == null ? Date.valueOf(rule.constant) : null);
 
-            // Just in case the field value has a time portion, reconstruct the date from scratch
-            if (fieldValue != null) {
-                fieldValue = Date.newInstance(fieldValue.year(), fieldValue.month(), fieldValue.day());
+            // Because Date.valueOf() returns a DateTime field in GMT, it's necessary to attempt to cast as a
+            // DateTime and then use .Date() to get the local date portion. It's wrapped in a Try/Catch to handle
+            // any unexpected conversion scenarios
+            if (fieldValue != null && rule.fieldType == SoapType.DATETIME) {
+                try {
+                    Datetime dtmValue = (DateTime)record.get(rule.field);
+                    fieldValue = dtmValue.date();
+                } catch (Exception ex) {
+                    fieldValue = Date.newInstance(fieldValue.year(), fieldValue.month(), fieldValue.day());
+                }
             }
 
             if (fieldValue == null && compareValue == null) {

--- a/src/classes/CMT_FilterRule.cls
+++ b/src/classes/CMT_FilterRule.cls
@@ -308,7 +308,7 @@ public class CMT_FilterRule {
             DateTime compareValue;
 
             if (String.isNotEmpty(rule.constant) && dateConstant == null) {
-                compareValue = DateTime.valueOf(rule.constant.replace('T',' ').replace('Z', ''));
+                compareValue = DateTime.valueOfGMT(rule.constant.replace('T',' ').replace('Z', ''));
             }
 
             if (fieldValue == null && compareValue == null) {

--- a/src/classes/CMT_FilterRuleEvaluation_TEST.cls
+++ b/src/classes/CMT_FilterRuleEvaluation_TEST.cls
@@ -69,7 +69,7 @@ private class CMT_FilterRuleEvaluation_TEST {
                 CMT_UnitTestData_TEST.createFilterGroupRecord(filterGroupId7, 'Test Group 7') +
             ']';
 
-        String dtValue = Datetime.newInstance(closeDate, Time.newInstance(12,0,0,0)).format('YYYY-MM-dd');
+        String closeDateString = Datetime.newInstance(closeDate, Time.newInstance(12,0,0,0)).format('YYYY-MM-dd');
 
         String filterRulesJSON = '[' +
                 /*  FILTER RULES FOR FILTER GROUPS 1-3 -- Opportunity only String, Boolean and Date fields */
@@ -81,7 +81,7 @@ private class CMT_FilterRuleEvaluation_TEST {
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId1, 'Group1.Rule6', 'Opportunity', 'NextStep', 'Contains', 'TEST') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId1, 'Group1.Rule7', 'Opportunity', 'NextStep', 'Does_Not_Contain', 'NothingAtAll') + ',' +
 
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule1a', 'Opportunity', 'CloseDate', 'Equals', dtValue) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule1a', 'Opportunity', 'CloseDate', 'Equals', closeDateString) + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule1b', 'Opportunity', 'CloseDate', 'Equals', 'THIS_YEAR') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule2', 'Opportunity', 'CloseDate', 'Equals', 'THIS_MONTH') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule3', 'Opportunity', 'CloseDate', 'Not_Equals', 'LAST_YEAR') + ',' +
@@ -91,7 +91,7 @@ private class CMT_FilterRuleEvaluation_TEST {
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule1', 'Opportunity', 'CreatedDate', 'Equals', DateTime.Now().format('YYYY-MM-dd')) + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule2', 'Opportunity', 'CreatedDate', 'Greater_Or_Equal', DateTime.Now().addDays(-1).format('YYYY-MM-dd')) + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule3', 'Opportunity', 'CreatedDate', 'Less_Or_Equal', DateTime.Now().addDays(1).format('YYYY-MM-dd')) + ',' +
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule4', 'Opportunity', 'CreatedDate', 'Greater', DateTime.Now().addDays(-2).format('YYYY-MM-dd')) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule4', 'Opportunity', 'CreatedDate', 'Greater', DateTime.Now().addDays(-2).formatGmt('YYYY-MM-dd hh:mm:ss.SSS')) + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule5', 'Opportunity', 'CreatedDate', 'Less', DateTime.Now().addDays(2).format('YYYY-MM-dd')) + ',' +
 
                 /*  FILTER RULES FOR FILTER GROUP 4-7 -- Opportunity with RecordTypeId, RecordType.DeveloperName, StageName, OCR.Role, Amount */

--- a/src/classes/CMT_FilterRuleEvaluation_TEST.cls
+++ b/src/classes/CMT_FilterRuleEvaluation_TEST.cls
@@ -37,6 +37,7 @@
 private class CMT_FilterRuleEvaluation_TEST {
 
     private static Id filterGroupId1, filterGroupId2, filterGroupId3, filterGroupId4, filterGroupId5, filterGroupId6, filterGroupId7;
+    private static Date closeDate = Date.Today().toStartOfMonth().addDays(1);
 
     /**
      * @description Because unit tests cannot actually insert Custom Metadata Types and there's no real way to know
@@ -68,6 +69,8 @@ private class CMT_FilterRuleEvaluation_TEST {
                 CMT_UnitTestData_TEST.createFilterGroupRecord(filterGroupId7, 'Test Group 7') +
             ']';
 
+        String dtValue = Datetime.newInstance(closeDate, Time.newInstance(12,0,0,0)).format('YYYY-MM-dd');
+
         String filterRulesJSON = '[' +
                 /*  FILTER RULES FOR FILTER GROUPS 1-3 -- Opportunity only String, Boolean and Date fields */
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId1, 'Group1.Rule1', 'Opportunity', 'IsWon', 'Equals', 'True') + ',' +
@@ -78,7 +81,8 @@ private class CMT_FilterRuleEvaluation_TEST {
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId1, 'Group1.Rule6', 'Opportunity', 'NextStep', 'Contains', 'TEST') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId1, 'Group1.Rule7', 'Opportunity', 'NextStep', 'Does_Not_Contain', 'NothingAtAll') + ',' +
 
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule1', 'Opportunity', 'CloseDate', 'Equals', 'THIS_YEAR') + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule1a', 'Opportunity', 'CloseDate', 'Equals', dtValue) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule1b', 'Opportunity', 'CloseDate', 'Equals', 'THIS_YEAR') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule2', 'Opportunity', 'CloseDate', 'Equals', 'THIS_MONTH') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule3', 'Opportunity', 'CloseDate', 'Not_Equals', 'LAST_YEAR') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule4', 'Opportunity', 'CreatedDate', 'Equals', 'TODAY') + ',' +
@@ -139,7 +143,7 @@ private class CMT_FilterRuleEvaluation_TEST {
         Opportunity o = new Opportunity (
                 Name = 'Test Opp ' + c.FirstName + c.LastName,
                 Amount = 1000,
-                CloseDate = Date.Today().toStartOfMonth().addDays(1),
+                CloseDate = closeDate,
                 StageName = UTIL_UnitTestData_TEST.getClosedWonStage(),
                 Primary_Contact__c = c.Id,
                 RecordTypeId = UTIL_RecordTypes.getRecordTypeIdForGiftsTests(Opportunity.sObjectType),


### PR DESCRIPTION
Turns out that my fix the other night to the CRLP Filter Rule unit test to address the timezone issue (i.e., what caused all the builds run after 8PM ET to fail) did not actually work. When I retested again last night, the builds (and my local test still failed). After a bunch of research and testing I figured out what the issue is.
* The root cause is that the FilterRule is evaluating a DateTime field (CreatedDate) against a date-only string. Basically something like CreatedDate > 2017-06-01. This should be fine, except that Salesforce does not do a good job documenting what timezone values are returned in.
* The FilterRule evaluation class uses the compareDates method to do this work (vs. compareDateTimes) because one side of the equation is a date-only.
* The method gets the date from the field using valueOf: Date fieldValue = Date.valueOf(record('CreatedDate')). I would expect that to return the Date of the field in "my" (i.e., local) timezone.
* That is not the case. Instead, Salesforce returns the date in GMT (note that it should be date, not dateTime). So, if the record was created on "11/1/2018 9PM ET" you would expect the date to be 11/1/18. However, Salesforce actually returns 11/2/18 because 9PM ET is actually 1AM GMT the next day.
* To fix this, I added code to the method to first get the DateTime value of the field, then use the .date() method to get the date portion in the local timezone. ((DateTime)record.get('CreatedDate')).date().
* What was a little more interesting is that I originally had code similar to this in the method (which was the root cause of the bug I was trying to fix). The issue there was that the code to re-cast the Date as a DateTime field ran on every single compare, whether it was a Date or DateTime field. Apparently, Salesforce is not quite consistent on what it returns based on the type of field.
* To get this working in all cases, the key was only doing that recast to a DateTime if the field is actually a DateTime type. Basically, I put this code within an if (rule.fieldType == SoapType.DATETIME) block so it only casts the field to a DateTime if it's actually a DateTime field.

This PR also changes how the compareDateTimes method converts the DateTime string that the CRLP Settings UI creates into a DateTime. The UI adds "T" and "Z" to the dateTime string, which does not work when valueOf() is used to convert the string. It appears that this was never actually tested manually because the conversion would fail. 

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
