### PR TITLE
Org Telemetry Fixes

### DIFF
--- a/src/classes/UTIL_OrgTelemetry_BATCH.cls
+++ b/src/classes/UTIL_OrgTelemetry_BATCH.cls
@@ -87,6 +87,9 @@ public without sharing class UTIL_OrgTelemetry_BATCH implements Database.Batchab
         if (cnt == 1) {
             Database.executeBatch(new UTIL_OrgTelemetry_SObject_BATCH(
                     UTIL_OrgTelemetry_SObject_BATCH.TelemetryBatchJobMode.RECURRING_DONATIONS), 2000);
+        } else {
+            System.FeatureManagement.setPackageIntegerValue(UTIL_OrgTelemetry_SVC.TelemetryParameterName.Data_CountRdOppsAll.name(), 0);
+            System.FeatureManagement.setPackageIntegerValue(UTIL_OrgTelemetry_SVC.TelemetryParameterName.Data_CountRdOppsOpenEnded.name(), 0);
         }
     }
 }

--- a/src/classes/UTIL_OrgTelemetry_SObject_BATCH.cls
+++ b/src/classes/UTIL_OrgTelemetry_SObject_BATCH.cls
@@ -35,6 +35,13 @@
 * is built to be generic enough to be executed in different configurations to count whatever large object requires
 * counting. Stateful is used to hold the count variables and an Enum is used to define the mode the batch job
 * is executing in.
+* *
+* Significant query tests were done in Oct/Nov 2018 to determine what query can run against a very very large
+* organization without timing out. The initial query tests used two different WHERE clauses against the
+* npe03__Recurring_Donation__c field. Both of those consistently failed with a query timeout error. The only query
+* that did run consistently is one without any filter at all. Technically we could use a filter with against an
+* indexed field, however in this case the goal was to use " != null" which would not use the index. As a result
+* this job will query and loop through all Opportunity records, but just count the recurring donation related ones.
 */
 public class UTIL_OrgTelemetry_SObject_BATCH implements Database.Batchable<SObject>, Database.Stateful {
 
@@ -53,8 +60,7 @@ public class UTIL_OrgTelemetry_SObject_BATCH implements Database.Batchable<SObje
     private Integer rdAllOppsCount = 0;
     private Integer rdOpenStatusOppsCount = 0;
 
-    private static final String recurringDonationOpenStatusValue = System.Label.npe03.RecurringDonationOpenStatus;
-
+    private final String recurringDonationOpenStatusValue = System.Label.npe03.RecurringDonationOpenStatus;
 
     /**
      * @description Constructor
@@ -69,10 +75,8 @@ public class UTIL_OrgTelemetry_SObject_BATCH implements Database.Batchable<SObje
     public Database.QueryLocator start(Database.BatchableContext context) {
         switch on (jobMode) {
             when RECURRING_DONATIONS {
-                return Database.getQueryLocator(
-                        [SELECT Id, npe03__Recurring_Donation__r.npe03__Open_Ended_Status__c
-                        FROM Opportunity
-                        WHERE npe03__Recurring_Donation__c != null]);
+                String soql = 'SELECT Id, npe03__Recurring_Donation__r.npe03__Open_Ended_Status__c FROM Opportunity';
+                return Database.getQueryLocator(soql);
             }
         }
         // If no conditions are met, this returns an empty query to avoid an NPE

--- a/src/classes/UTIL_OrgTelemetry_SVC.cls
+++ b/src/classes/UTIL_OrgTelemetry_SVC.cls
@@ -231,15 +231,18 @@ public without sharing class UTIL_OrgTelemetry_SVC {
      */
     private void handleMaxNumRelatedOpps() {
         try {
-            Account acct = [SELECT npo02__NumberOfClosedOpps__c
+            Integer cnt = 0;
+            List<Account> accts = [SELECT npo02__NumberOfClosedOpps__c
                 FROM Account
                 WHERE npo02__NumberOfClosedOpps__c > 0
                 ORDER BY npo02__NumberOfClosedOpps__c DESC
                 LIMIT 1];
-            if (acct != null) {
-                System.FeatureManagement.setPackageIntegerValue(TelemetryParameterName.Data_MaxNumRelatedOpps.name(),
-                        acct.npo02__NumberOfClosedOpps__c.intValue());
+            if (!accts.isEmpty()) {
+                cnt = accts[0].npo02__NumberOfClosedOpps__c.intValue();
             }
-        } catch (Exception ex) {}
+            System.FeatureManagement.setPackageIntegerValue(TelemetryParameterName.Data_MaxNumRelatedOpps.name(), cnt);
+        } catch (Exception ex) {
+            System.FeatureManagement.setPackageIntegerValue(TelemetryParameterName.Data_MaxNumRelatedOpps.name(), -1);
+        }
     }
 }


### PR DESCRIPTION
Fix two issues:
* Integer Telemetry data was returning -1 for orgs that had no records to return. The intent is for -1 to represent an error querying data as opposed no data to query. The root issue here was that queries that returned 0 records would not return 0 for the telemetry, instead leaving the default value of -1. 
* Very large organization were still getting Query Timeout errors in the `UTIL_OrgTelemetry_SObject_BATCH` job after push upgrades. This PR changes the query to remove the non-selective filter against the Opportunity object. Significant query tests were done in to determine what query can run against a very very large organization without timing out. The initial query tests used two different WHERE clauses against the npe03__Recurring_Donation__c field. Both of those consistently failed with a query timeout error. The only query that did run consistently is one without any filter at all. Technically we could use a filter with against an indexed field, however in this case the goal was to use " != null" which would not use the index. As a result this job will query and loop through all Opportunity records, but just count the recurring donation related ones. Tests show that even with 16M Opportunities, this batch job will complete in under two hours (and is read-only, without any DML on any objects).

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
