### PR TITLE
Changed "create" to "manage"

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4585,8 +4585,8 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <categories>Payment Wizard</categories>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Message displayed when the user has no permission to create payments</shortDescription>
-        <value>You do not have permissions to create Payments.</value>
+        <shortDescription>Message displayed when the user has no permission to manage payments</shortDescription>
+        <value>You do not have permissions to manage Payments.</value>
     </labels>
     <labels>
         <fullName>pmtWizardSectionTitle</fullName>


### PR DESCRIPTION
A user must have Create, Edit, and Delete permissions to access Manage Soft Credits. This change clarifies this point.

# Critical Changes

# Changes

# Issues Closed

Fixes #3790 

# New Metadata

# Deleted Metadata
