### PR TITLE
Reverting ADV-specific test results

### DIFF
--- a/src/classes/BDI_DataImport_TEST.cls
+++ b/src/classes/BDI_DataImport_TEST.cls
@@ -357,29 +357,18 @@ public with sharing class BDI_DataImport_TEST {
         ID ApexJobId = Database.executeBatch(bdi, 10);
         Test.stopTest();
     
-        Boolean usingAdv = ADV_PackageInfo_SVC.useAdv();
         // verify expected results
         List<Contact> listCon = getContacts();
-        Integer numCons = usingAdv ? 2 : 1;
-        System.assertEquals(numCons, listCon.size());
+        System.assertEquals(1, listCon.size());
         System.assertEquals('TestFirstname00 TestLastname00', listCon[0].Name);
 
         listDI = getDIs();
         System.assertEquals(1, listDI.size());
-        // the outcome will be different if Advancement is installed because non-household Accounts CAN be donors
-        if (usingAdv){
-            System.assertEquals(listCon[0].Id, listDI[0].Contact1Imported__c);
-            System.assertEquals(listCon[1].Id, listDI[0].Contact2Imported__c);
-            System.assertEquals(listCon[0].AccountId, listDI[0].HouseholdAccountImported__c);
-            System.assertEquals(label.bdiMatched, listDI[0].Contact1ImportStatus__c);
-            System.assertEquals(label.bdiCreated, listDI[0].Contact2ImportStatus__c);   
-        } else {
-            System.assertEquals(null, listDI[0].Contact1Imported__c);
-            System.assertEquals(null, listDI[0].Contact2Imported__c);
-            System.assertEquals(null, listDI[0].HouseholdAccountImported__c);
-            System.assertEquals(label.bdiErrorNonHHAccountContact, listDI[0].Contact1ImportStatus__c);
-            System.assertEquals(null, listDI[0].Contact2ImportStatus__c);   
-        }
+        System.assertEquals(null, listDI[0].Contact1Imported__c);
+        System.assertEquals(null, listDI[0].Contact2Imported__c);
+        System.assertEquals(null, listDI[0].HouseholdAccountImported__c);
+        System.assertEquals(label.bdiErrorNonHHAccountContact, listDI[0].Contact1ImportStatus__c);
+        System.assertEquals(null, listDI[0].Contact2ImportStatus__c);
         List<Address__c> listAddr = getAddresses();   
         System.assertEquals(0, listAddr.size());
     }

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -1498,23 +1498,14 @@ private with sharing class BDI_DataImport_TEST2 {
         List<DataImport__c> listDI = new List<DataImport__c>();
         listDI.add(BDI_DataImport_TEST.newDI('c1', 'C1'));
         insert listDI;
-        
-        Boolean usingAdv = ADV_PackageInfo_SVC.useAdv();
+
         //run batch data import
         Test.StartTest();
         try {
             BDI_DataImport_API.importData();
-            if (usingAdv){
-                System.assert(true, 'importData should NOT have thrown exception');
-            } else {
-                System.assert(false, 'importData should have thrown exception');
-            }
+            System.assert(false, 'importData should have thrown exception');
         } catch (exception ex) {
-            if (usingAdv){
-                System.assert(false, 'importData should NOT have thrown exception');
-            } else {
-                System.assert(ex.getMessage().contains('Household Account model'));
-            }
+            System.assert(ex.getMessage().contains('Household Account model'));
         }
         Test.stopTest();
     }

--- a/src/classes/CRLP_RollupSoftCredit_TEST.cls
+++ b/src/classes/CRLP_RollupSoftCredit_TEST.cls
@@ -171,8 +171,6 @@ private class CRLP_RollupSoftCredit_TEST {
      */
     private static void testRollupsServices(TestType tt) {
 
-        Boolean usingAdv = ADV_PackageInfo_SVC.useAdv();
-
         // Start by enabling Customizable Rollups (which disables all legacy rollup operations)
         UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
                 Customizable_Rollups_Enabled__c = true,
@@ -296,26 +294,18 @@ private class CRLP_RollupSoftCredit_TEST {
         orgOCR.Role = label.npo02.Household_Member_Contact_Role;
         update orgOCR;
 
-        // Because HEDA defaults to One-to-one Accounts, OCR values are different for these test Opps
-        Integer ocrCount = cnt;
-        Boolean isPrimaryTest = true;
-        if(!usingAdv){
-            isPrimaryTest = false;
-            ocrCount = (cnt * 3);
-        }
-
         //Create duplicate Non Primary OCRs to test the Rollup for duplicate OCRs.
         List<OpportunityContactRole> duplicateNonPrimaryOCRs = [
             SELECT OpportunityId, ContactId, Role, IsPrimary 
             FROM OpportunityContactRole 
-            WHERE IsPrimary = :isPrimaryTest 
+            WHERE IsPrimary = false 
             AND Opportunity.IsWon = true
         ].deepClone();
         insert duplicateNonPrimaryOCRs;
 
         Test.startTest();
 
-        system.assertEquals(ocrCount + duplicateNonPrimaryOCRs.size() + 1, [SELECT Count() FROM OpportunityContactRole WHERE Opportunity.IsWon = true],
+        system.assertEquals((cnt * 3) + duplicateNonPrimaryOCRs.size() + 1, [SELECT Count() FROM OpportunityContactRole WHERE Opportunity.IsWon = true],
                 'There should be 301 OCR records on closed won opps');
 
         List<Id> contactIds = new List<Id>{ c1.Id, c2.Id, c3.Id, c4.Id };
@@ -339,24 +329,13 @@ private class CRLP_RollupSoftCredit_TEST {
             String conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :c2Id LIMIT 1';
             c2 = database.query(conQuery);
 
-            if(usingAdv){
-                // Because the default HEDA Account model is Administrative (One-to-one),
-                // these results differ when Advancement is installed
-                System.assertEquals(null, c2.npo02__Soft_Credit_Total__c);
-                System.assertEquals(null, c2.Number_of_Soft_Credits__c);
-                System.assertEquals(null, c2.First_Soft_Credit_Date__c);
-                System.assertEquals(null, c2.Largest_Soft_Credit_Date__c);
-                System.assertEquals(null, c2.Last_Soft_Credit_Amount__c);
-                System.assertEquals(null, c2.Largest_Soft_Credit_Amount__c);
-            } else {
-                // Basic rollup asserts using existing NPSP rollup fields.
-                System.assertEquals(totalDonations, c2.npo02__Soft_Credit_Total__c);
-                System.assertEquals(cnt, c2.Number_of_Soft_Credits__c);
-                System.assertEquals(firstCloseDate, c2.First_Soft_Credit_Date__c);
-                System.assertEquals(largestGiftDate, c2.Largest_Soft_Credit_Date__c);
-                System.assertEquals(baseAmt, c2.Last_Soft_Credit_Amount__c);
-                System.assertEquals(maxAmt, c2.Largest_Soft_Credit_Amount__c);
-            }
+            // Basic rollup asserts using existing NPSP rollup fields.
+            System.assertEquals(totalDonations, c2.npo02__Soft_Credit_Total__c);
+            System.assertEquals(cnt, c2.Number_of_Soft_Credits__c);
+            System.assertEquals(firstCloseDate, c2.First_Soft_Credit_Date__c);
+            System.assertEquals(largestGiftDate, c2.Largest_Soft_Credit_Date__c);
+            System.assertEquals(baseAmt, c2.Last_Soft_Credit_Amount__c);
+            System.assertEquals(maxAmt, c2.Largest_Soft_Credit_Amount__c);
 
             // Query the Primary Contact (should have NO Soft Credit)
             conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :conId LIMIT 1';
@@ -384,21 +363,11 @@ private class CRLP_RollupSoftCredit_TEST {
             String acctQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Account.SObjectType) + ' WHERE Id = :acctId LIMIT 1';
             Account a = database.query(acctQuery);
 
-            // Because the default HEDA Account model is Administrative (One-to-one),
-            // these results differ when Advancement is installed
-            if(usingAdv){
-                System.assertEquals(0, a.npo02__TotalOppAmount__c);
-                System.assertEquals(0, a.npo02__NumberOfClosedOpps__c);
-                System.assertEquals(null, a.npo02__FirstCloseDate__c);
-                System.assertEquals(0, a.npo02__LastOppAmount__c);
-                System.assertEquals(0, a.npo02__LargestAmount__c);
-            } else {
-                System.assertEquals(totalDonations, a.npo02__TotalOppAmount__c);
-                System.assertEquals(cnt, a.npo02__NumberOfClosedOpps__c);
-                System.assertEquals(firstCloseDate, a.npo02__FirstCloseDate__c);
-                System.assertEquals(baseAmt, a.npo02__LastOppAmount__c);
-                System.assertEquals(maxAmt, a.npo02__LargestAmount__c);
-            }
+            System.assertEquals(totalDonations, a.npo02__TotalOppAmount__c);
+            System.assertEquals(cnt, a.npo02__NumberOfClosedOpps__c);
+            System.assertEquals(firstCloseDate, a.npo02__FirstCloseDate__c);
+            System.assertEquals(baseAmt, a.npo02__LastOppAmount__c);
+            System.assertEquals(maxAmt, a.npo02__LargestAmount__c);
 
         }
     }

--- a/src/classes/LD_LeadConvertOverride_TEST.cls
+++ b/src/classes/LD_LeadConvertOverride_TEST.cls
@@ -211,16 +211,12 @@ private class LD_LeadConvertOverride_TEST {
     * @description Runs newLeadConversionNewNameCompany with the 1x1 account model
     */
     static testMethod void newLeadConversionNewNamedCompany_TestOne2One(){
-        // Because HEDA Account model settings overwrite NPSP settings, this test fails with ADV installed
-        if (ADV_PackageInfo_SVC.useAdv()) return;
         newLeadConversionNewNamedCompany_Test(CAO_Constants.ONE_TO_ONE_PROCESSOR);
     }
     /*******************************************************************************************************
     * @description Runs newLeadConversionNewNameCompany with the Household account model
     */
     static testMethod void newLeadConversionNewNamedCompany_TestHHAccount(){
-        // Because HEDA Account model settings overwrite NPSP settings, this test fails with ADV installed
-        if (ADV_PackageInfo_SVC.useAdv()) return;
         newLeadConversionNewNamedCompany_Test(CAO_Constants.HH_ACCOUNT_PROCESSOR);
     }
     /*******************************************************************************************************


### PR DESCRIPTION
- Reverting ADV specific test results, since HEDA Account model syncing will now be turned off by default

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
