### PR TITLE
Reverting change to ignore Household naming when ADV is installed

### DIFF
--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -68,8 +68,7 @@ public without sharing class HH_HouseholdNaming {
     public void UpdateNames(list<id> hhids){
 
         // Skip automatic naming during Batch Data Import to improve performance
-        // Similarily, if Advancement is installed, we want to rely on HEDA naming settings
-        if (isHouseholdNamingDisabled || ADV_PackageInfo_SVC.useAdv()) {
+        if (isHouseholdNamingDisabled) {
             return;
         }
 


### PR DESCRIPTION
- To fix NPSP Unit Tests when ADV is installed, we are reverting the change to ignore Household Naming when ADV is installed

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
