### PR TITLE
donation matching rule fields stored in lowercase

### DIFF
--- a/src/classes/BGE_ConfigurationWizard_CTRL.cls
+++ b/src/classes/BGE_ConfigurationWizard_CTRL.cls
@@ -444,7 +444,7 @@ public with sharing class BGE_ConfigurationWizard_CTRL {
 
         for (DescribeFieldResult donationField: dfrs) {
             Map<String, String> option = new Map<String, String>();
-            option.put('value', donationField.Name);
+            option.put('value', donationField.Name.toLowerCase());
             option.put('label', donationField.Label);
             donationMatchingOptions.add(option);
         }


### PR DESCRIPTION
# Critical Changes

# Changes
- Always store donation matching rule fields in lowercase

# Issues Closed

# New Metadata

# Deleted Metadata
