### PR TITLE
BGE: order data import records by createddate instead of id

### DIFF
--- a/src/classes/BGE_DataImportBatchEntry_CTRL.cls
+++ b/src/classes/BGE_DataImportBatchEntry_CTRL.cls
@@ -348,7 +348,7 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
         String query = 'SELECT ' + String.join(dataImportFields,', ') +
             ' FROM DataImport__c' +
             ' WHERE NPSP_Data_Import_Batch__c = :batchId' +
-            ' ORDER BY Id ASC';
+            ' ORDER BY CreatedDate ASC';
 
         return Database.query(query);
     }
@@ -365,7 +365,7 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
         String query = 'SELECT ' + String.join(dataImportFields,', ') +
             ' FROM DataImport__c' +
             ' WHERE Id IN :dataImportIds' +
-            ' ORDER BY Id ASC';
+            ' ORDER BY CreatedDate ASC';
 
         return Database.query(query);
     }


### PR DESCRIPTION
Explicitly order the data import rows in the BGE grid by CreatedDate, not Id.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
