### PR TITLE
Feedback for FLS in BGE

### DIFF
--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -103,9 +103,31 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     * @return void Throws an exception if user lacks permissions on any field
     */
     private static void handleMissingPermissions(List<String> missingPermissions) {
+
         if (!missingPermissions.isEmpty()) {
-            throw new AuraHandledException(Label.bgeFLSError + ' - ' + String.join(missingPermissions, ', ') );
+            throw new AuraHandledException(
+                Label.bgeFLSError + ' [' + truncateList(missingPermissions, 3) + ']'
+            );
         }
+    }
+
+    /*******************************************************************************************************
+    * @description Takes a list of strings and converts it to a string of a subset of the original list
+    * @param items list of Strings
+    * @param maxItems the maximum number of Strings from the list to retain
+    * @return String the truncated list of strings, separated by a comma
+    * @example truncateList(new List<String>{ 'apple', 'orange', 'banana', 'pear' }, 2); // returns 'apple, orange ...'
+    */
+    private static String truncateList(List<String> items, Integer maxItems) {
+        Integer totalItems = items.size();
+
+        if (totalItems >= maxItems) {
+            for (Integer i = maxItems; i < totalItems; i++) {
+                items.remove(i);
+            }
+        }
+
+        return String.join(items, ', ') + (totalItems > maxItems ? ' ...' : '');
     }
 
     /*******************************************************************************************************

--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -93,7 +93,7 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
 
             DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
 
-            if (!fieldResults.contains(fieldResult)) {
+            if (fieldName != 'Id' && !fieldResults.contains(fieldResult)) {
                 fieldResults.add(fieldResult);
             }
         }

--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -91,7 +91,8 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
                 fieldName = fieldName.substringBefore('__r') + '__c';
             }
 
-            DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
+            DescribeFieldResult fieldResult =
+                UTIL_Describe.getFieldDescribe(UTIL_Namespace.StrAllNSPrefix(objectName), UTIL_Namespace.StrAllNSPrefix(fieldName));
 
             if (fieldName != 'Id' && !fieldResults.contains(fieldResult)) {
                 fieldResults.add(fieldResult);

--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -84,6 +84,22 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
 
     }
 
+    public static void checkFieldPermissions(String objectName, List<String> fieldNamesToCheck) {
+        List<DescribeFieldResult> fieldResults = new List<DescribeFieldResult>();
+        for (String fieldName : fieldNamesToCheck) {
+            if (fieldName.contains('__r')) {
+                fieldName = fieldName.substringBefore('__r') + '__c';
+            }
+
+            DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
+
+            if (!fieldResults.contains(fieldResult)) {
+                fieldResults.add(fieldResult);
+            }
+        }
+        checkFieldPermissions(fieldResults);
+    }
+
     /*******************************************************************************************************
     * @description Handles missing field permissions
     * @param missingPermissions list of DescribeFieldResult records for which permissions are lacking
@@ -118,16 +134,16 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     * @return String the truncated list of strings, separated by a comma
     * @example truncateList(new List<String>{ 'apple', 'orange', 'banana', 'pear' }, 2); // returns 'apple, orange ...'
     */
+    @TestVisible
     private static String truncateList(List<String> items, Integer maxItems) {
         Integer totalItems = items.size();
+        List<String> limitedItems = new List<String>();
 
-        if (totalItems >= maxItems) {
-            for (Integer i = maxItems; i < totalItems; i++) {
-                items.remove(i);
-            }
+        for (Integer i = 0; i < maxItems && i < items.size(); i++) {
+            limitedItems.add(items[i]);
         }
 
-        return String.join(items, ', ') + (totalItems > maxItems ? ' ...' : '');
+        return String.join(limitedItems, ', ') + (totalItems > maxItems ? ' ...' : '');
     }
 
     /*******************************************************************************************************

--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -37,6 +37,78 @@
 public with sharing class BGE_BatchGiftEntry_UTIL {
 
     /*******************************************************************************************************
+    * @description Returns the relevant Batch fields for soql
+    * @return list of field API names
+    */
+    public static List<String> getBatchFieldNames() {
+        return new List<String>{
+            'Id',
+            'Name',
+            'Active_Fields__c',
+            'Batch_Description__c',
+            'Batch_Process_Size__c',
+            'Contact_Matching_Rule__c',
+            'Donation_Matching_Behavior__c',
+            'Donation_Matching_Implementing_Class__c',
+            'Donation_Matching_Rule__c',
+            'Donation_Date_Range__c',
+            'Expected_Count_of_Gifts__c',
+            'Expected_Total_Batch_Amount__c',
+            'Post_Process_Implementing_Class__c',
+            'Process_Using_Scheduled_Job__c',
+            'RequireTotalMatch__c',
+            'Run_Opportunity_Rollups_while_Processing__c'
+
+        };
+    }
+
+    /*******************************************************************************************************
+    * @description Checks to see whether the running user has permission to edit a given list of fields
+    * @param fieldsToCheck list of DescribeFieldResult records to check
+    * @return void Throws an exception if user lacks edit permissions on any field
+    */
+    public static void checkFieldPermissions(List<DescribeFieldResult> fieldsToCheck) {
+        Boolean hasPermission = true;
+        List<String> fieldsWithoutPermission = new List<String>();
+
+        for (DescribeFieldResult dfr : fieldsToCheck) {
+            if (!UTIL_Permissions.canUpdate(dfr, false)) {
+                hasPermission = false;
+                fieldsWithoutPermission.add(dfr.getLabel());
+            }
+        }
+
+        if (!hasPermission) {
+            handleMissingPermissions(fieldsWithoutPermission);
+        }
+
+    }
+
+    /*******************************************************************************************************
+    * @description Handles missing field permissions
+    * @param missingPermissions list of DescribeFieldResult records for which permissions are lacking
+    * @return void Throws an exception if user lacks permissions on any field
+    */
+    public static void handleMissingPermissions(List<DescribeFieldResult> missingPermissions) {
+        List<String> fieldNames = new List<String>();
+        for (DescribeFieldResult fieldResult : missingPermissions) {
+            fieldNames.add(fieldResult.getLabel());
+        }
+        handleMissingPermissions(fieldNames);
+    }
+
+    /*******************************************************************************************************
+    * @description Handles missing field permissions
+    * @param missingPermissions list of Strings identifying the fields with missing permissions
+    * @return void Throws an exception if user lacks permissions on any field
+    */
+    private static void handleMissingPermissions(List<String> missingPermissions) {
+        if (!missingPermissions.isEmpty()) {
+            throw new AuraHandledException(Label.bgeFLSError + ' - ' + String.join(missingPermissions, ', ') );
+        }
+    }
+
+    /*******************************************************************************************************
     * @description Checks for field permissions needed to create a new Batch
     * User must have fields on DataImportBatch__c that appear in the config wizard
     * as well as Donation_Amount__c on DataImport__c because it is locked as a required field in config wizard
@@ -50,9 +122,7 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
 
         for (String field : batchFieldNames) {
             if (field != 'Id') {
-                if (field.contains('__c')) {
-                    field = UTIL_Namespace.StrTokenNSPrefix(field);
-                }
+                field = UTIL_Namespace.StrAllNSPrefix(field);
                 fieldsToCheck.add(UTIL_Describe.getFieldDescribe(UTIL_Namespace.StrTokenNSPrefix('DataImportBatch__c'), field));
             }
         }
@@ -60,46 +130,9 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
         // Donation Amount is also required
         fieldsToCheck.add(UTIL_Describe.getFieldDescribe(UTIL_Namespace.StrTokenNSPrefix('DataImport__c'), UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c')));
 
-        for (DescribeFieldResult dfr : fieldsToCheck) {
-            if (!canUpdateField(dfr)) {
-                throw new AuraHandledException(Label.bgeFLSError);
-            }
-        }
+        checkFieldPermissions(fieldsToCheck);
     }
 
-    /*******************************************************************************************************
-    * @description checks for read, create, and edit FLS for a given field
-    * @param dfr DescribeFieldResult of the field to check
-    * @return Boolean
-    */
-    public static Boolean canUpdateField(DescribeFieldResult dfr) {
-        return dfr.isCreateable() && dfr.isUpdateable();
-    }
 
-    /*******************************************************************************************************
-    * @description Returns the relevant Batch fields for soql
-    * @return list of field API names
-    */
-    public static List<String> getBatchFieldNames() {
-        return new List<String>{
-                'Id',
-                'Name',
-                'Active_Fields__c',
-                'Batch_Description__c',
-                'Batch_Process_Size__c',
-                'Contact_Matching_Rule__c',
-                'Donation_Matching_Behavior__c',
-                'Donation_Matching_Implementing_Class__c',
-                'Donation_Matching_Rule__c',
-                'Donation_Date_Range__c',
-                'Expected_Count_of_Gifts__c',
-                'Expected_Total_Batch_Amount__c',
-                'Post_Process_Implementing_Class__c',
-                'Process_Using_Scheduled_Job__c',
-                'RequireTotalMatch__c',
-                'Run_Opportunity_Rollups_while_Processing__c'
-
-        };
-    }
 
 }

--- a/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls
@@ -1,0 +1,18 @@
+/**
+ * Created by lmeerkatz on 12/27/18.
+ */
+
+@isTest
+private with sharing class BGE_BatchGiftEntry_UTIL_TEST {
+
+    @isTest
+    static void testTruncateList() {
+        List<String> fruits = new List<String> { 'apple', 'banana', 'pear', 'orange' };
+        System.assertEquals('apple, banana, pear, orange', BGE_BatchGiftEntry_UTIL.truncateList(fruits, 5));
+        System.assertEquals('apple, banana, pear, orange', BGE_BatchGiftEntry_UTIL.truncateList(fruits, 4));
+        System.assertEquals('apple, banana, pear ...', BGE_BatchGiftEntry_UTIL.truncateList(fruits, 3));
+        System.assertEquals('apple, banana ...', BGE_BatchGiftEntry_UTIL.truncateList(fruits, 2));
+        System.assertEquals('apple ...', BGE_BatchGiftEntry_UTIL.truncateList(fruits, 1));
+    }
+
+}

--- a/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls-meta.xml
+++ b/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BGE_ConfigurationWizard_CTRL.cls
+++ b/src/classes/BGE_ConfigurationWizard_CTRL.cls
@@ -211,7 +211,7 @@ public with sharing class BGE_ConfigurationWizard_CTRL {
             'PICKLIST'
         };
 
-        // looping through the fields on DataImport__c
+        // looping through the fields on DataImport__c and remove unsupported data types
         for (String fieldName : sortedFieldNames) {
             DescribeFieldResult dfr = fieldMap.get(fieldName);
             String dataImportFieldApiName = UTIL_Namespace.StrTokenRemoveNSPrefix(dfr.getName());
@@ -220,13 +220,14 @@ public with sharing class BGE_ConfigurationWizard_CTRL {
             Boolean fieldAllowed = allowedObjects.contains(dataImportFieldMappedObject)
                 && allowedDataTypes.contains(dfr.getType().name())
                 && !bannedFields.contains(dataImportFieldApiName)
-                && dfr.getInlineHelpText() != null
-                && BGE_BatchGiftEntry_UTIL.canUpdateField(dfr);
+                && dfr.getInlineHelpText() != null;
 
             if (fieldAllowed) {
                 dfrs.add(dfr);
             }
         }
+
+        BGE_BatchGiftEntry_UTIL.checkFieldPermissions(dfrs);
 
         return dfrs;
     }

--- a/src/classes/BGE_DataImportBatchEntry_CTRL.cls
+++ b/src/classes/BGE_DataImportBatchEntry_CTRL.cls
@@ -257,43 +257,54 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
             List<BGE_ConfigurationWizard_CTRL.BGEField> activeFields = (List<BGE_ConfigurationWizard_CTRL.BGEField>)JSON.deserialize(activeFieldsJSON, List<BGE_ConfigurationWizard_CTRL.BGEField>.class);
 
             Map<String, Schema.DescribeFieldResult> fieldMap = UTIL_Describe.getAllFieldsDescribe(UTIL_Namespace.StrTokenNSPrefix('DataImport__c'));
+
+            List<DescribeFieldResult> unpermittedFields = new List<DescribeFieldResult>();
+
             for (BGE_ConfigurationWizard_CTRL.BGEField field : activeFields) {
                 Schema.DescribeFieldResult dataImportDFR = fieldMap.get(field.name.toLowerCase());
                 if (dataImportDFR != null) {
 
-                    checkFLS(dataImportDFR);
+                    if (UTIL_Permissions.canUpdate(dataImportDFR, false)) {
+                        Column col = new Column();
+                        col.label = dataImportDFR.getLabel();
+                        col.fieldName = dataImportDFR.getName();
+                        col.readOnly = false;
+                        col.defaultValue = field.defaultValue;
+                        col.required = field.required;
+                        col.hide = field.hide;
+                        col.type = dataImportDFR.getType().name().toLowerCase();
+                        if (col.type == 'date') {
+                            col.type = 'date-local';
+                        }
+                        if (col.type == 'double') {
+                            col.type = 'number';
+                        }
+                        col.typeAttributes = '{}';
 
-                    Column col = new Column();
-                    col.label = dataImportDFR.getLabel();
-                    col.fieldName = dataImportDFR.getName();
-                    col.readOnly = false;
-                    col.defaultValue = field.defaultValue;
-                    col.required = field.required;
-                    col.hide = field.hide;
-                    col.type = dataImportDFR.getType().name().toLowerCase();
-                    if (col.type == 'date') {
-                        col.type = 'date-local';
+                        col.options = BGE_ConfigurationWizard_CTRL.getPicklistOptions(col.fieldName);
+
+                        columns.add(col);
+
+                        String targetObject = BDI_DataImportService.getTargetObject(col.fieldName);
+                        if (targetObject == 'Payment') {
+                            targetObject = 'npe01__OppPayment__c';
+                        }
+                        String targetField = BDI_DataImportService.getTargetField(col.fieldName);
+                        DescribeFieldResult targetDFR = UTIL_Describe.getFieldDescribe(targetObject,targetField);
+
+
+                        if (!UTIL_Permissions.canUpdate(targetDFR, false)) {
+                            unpermittedFields.add(targetDFR);
+                        }
+                    } else {
+                        unpermittedFields.add(dataImportDFR);
                     }
-                    if (col.type == 'double') {
-                        col.type = 'number';
-                    }
-                    col.typeAttributes = '{}';
-
-                    col.options = BGE_ConfigurationWizard_CTRL.getPicklistOptions(col.fieldName);
-
-                    columns.add(col);
-
-                    String targetObject = BDI_DataImportService.getTargetObject(col.fieldName);
-                    if (targetObject == 'Payment') {
-                        targetObject = 'npe01__OppPayment__c';
-                    }
-                    String targetField = BDI_DataImportService.getTargetField(col.fieldName);
-                    DescribeFieldResult targetDFR = UTIL_Describe.getFieldDescribe(targetObject,targetField);
-
-                    checkFLS(targetDFR);
 
                 }
             }
+
+            BGE_BatchGiftEntry_UTIL.handleMissingPermissions(unpermittedFields);
+
         }
 
         return columns;
@@ -399,17 +410,6 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
         fields.addAll(activeFieldNames);
 
         return fields;
-    }
-
-    /*******************************************************************************************************
-    * @description checks for read, create, and edit FLS for a given field
-    * @param dfr DescribeFieldResult of the field to check
-    * @return void, throws AuraHandledException to display UI error
-    */
-    private static void checkFLS(DescribeFieldResult dfr) {
-        if (!dfr.isCreateable() || !dfr.isUpdateable()) {
-            throw new AuraHandledException(label.bgeFLSError);
-        }
     }
 
     /*******************************************************************************************************

--- a/src/classes/BGE_DataImportBatchEntry_CTRL.cls
+++ b/src/classes/BGE_DataImportBatchEntry_CTRL.cls
@@ -78,6 +78,9 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
         dataImportModel.labels = getBatchDataImportLabels();
         dataImportModel.isNamespaced = String.isNotBlank(UTIL_Namespace.getNamespace());
 
+        // check permissions on hard coded fields
+        BGE_BatchGiftEntry_UTIL.checkFieldPermissions(UTIL_Namespace.StrTokenNSPrefix('DataImport__c'), getDataImportFields());
+
         return JSON.serialize(dataImportModel);
     }
 
@@ -254,7 +257,8 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
         DataImportBatch__c batch = [SELECT Active_Fields__c FROM DataImportBatch__c WHERE Id = :batchId];
         String activeFieldsJSON = batch.Active_Fields__c;
         if (activeFieldsJSON != null) {
-            List<BGE_ConfigurationWizard_CTRL.BGEField> activeFields = (List<BGE_ConfigurationWizard_CTRL.BGEField>)JSON.deserialize(activeFieldsJSON, List<BGE_ConfigurationWizard_CTRL.BGEField>.class);
+            List<BGE_ConfigurationWizard_CTRL.BGEField> activeFields =
+                (List<BGE_ConfigurationWizard_CTRL.BGEField>)JSON.deserialize(activeFieldsJSON, List<BGE_ConfigurationWizard_CTRL.BGEField>.class);
 
             Map<String, Schema.DescribeFieldResult> fieldMap = UTIL_Describe.getAllFieldsDescribe(UTIL_Namespace.StrTokenNSPrefix('DataImport__c'));
 
@@ -382,14 +386,11 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
     }
 
     /*******************************************************************************************************
-    * @description returns a list of DataImport__c fields the Batch Gift Entry UI needs in SOQL
+    * @description returns the subset of DataImport__c fields that are part of every batch
     * @return List<String> list of DataImport__c field api names
     */
-    public static List<String> getDataImportFields(Id batchId) {
-
-        List<String> activeFieldNames = getActiveFieldNamesFromBatch(batchId);
-
-        List<String> fields = new List<String> {
+    private static List<String> getDataImportFields() {
+        return new List<String> {
             'Id',
             'Account1Imported__c',
             'Account1Imported__r.Name',
@@ -406,8 +407,16 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
             'PaymentImportStatus__c',
             'Status__c'
         };
+    }
 
-        fields.addAll(activeFieldNames);
+    /*******************************************************************************************************
+    * @description returns a list of DataImport__c fields the Batch Gift Entry UI needs in SOQL
+    * @return List<String> list of DataImport__c field api names
+    */
+    public static List<String> getDataImportFields(Id batchId) {
+
+        List<String> fields = getDataImportFields();
+        fields.addAll(getActiveFieldNamesFromBatch(batchId));
 
         return fields;
     }

--- a/src/classes/UTIL_Permissions.cls
+++ b/src/classes/UTIL_Permissions.cls
@@ -37,16 +37,18 @@ public with sharing class UTIL_Permissions {
 
     private final static String INSUFFICIENT_PERMISSION_MESSAGE = System.Label.flsError;
 
+    /*** Object Level Security ***/
+
     public static Boolean canRead(String obj) {
         return canRead(obj, true);
     }
 
-    public static Boolean canWrite(String obj) {
-        return canWrite(obj, true);
-    }
-
     public static Boolean canCreate(String obj) {
         return canCreate(obj, true);
+    }
+
+    public static Boolean canUpdate(String obj) {
+        return canUpdate(obj, true);
     }
 
     public static Boolean canDelete(String obj) {
@@ -55,17 +57,6 @@ public with sharing class UTIL_Permissions {
 
     public static Boolean canRead(String obj, Boolean throwException) {
         if (!UTIL_Describe.getObjectDescribe(obj).isAccessible()) {
-            if (throwException) {
-                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
-            } else {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    public static Boolean canWrite(String obj, Boolean throwException) {
-        if (!UTIL_Describe.getObjectDescribe(obj).isUpdateable()) {
             if (throwException) {
                 throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
             } else {
@@ -86,6 +77,17 @@ public with sharing class UTIL_Permissions {
         return true;
     }
 
+    public static Boolean canUpdate(String obj, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(obj).isUpdateable()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static Boolean canDelete(String obj, Boolean throwException) {
         if (!UTIL_Describe.getObjectDescribe(obj).isDeletable()) {
             if (throwException) {
@@ -97,30 +99,59 @@ public with sharing class UTIL_Permissions {
         return true;
     }
 
-    public static Boolean canRead(String obj, String field, Boolean throwException) {
-        if (!UTIL_Describe.getFieldDescribe(obj, field).isAccessible()) {
-            if (throwException) {
-                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
-            } else {
-                return false;
-            }
-        }
-        return true;
-    }
+    /*** Field Level Security ***/
 
-    public static Boolean canWrite(String obj, String field, Boolean throwException) {
-        if (!UTIL_Describe.getFieldDescribe(obj, field).isUpdateable()) {
-            if (throwException) {
-                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
-            } else {
-                return false;
-            }
-        }
-        return true;
+    public static Boolean canRead(String obj, String field, Boolean throwException) {
+        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(obj, field);
+        return canRead(fieldResult, throwException);
     }
 
     public static Boolean canCreate(String obj, String field, Boolean throwException) {
-        if (!UTIL_Describe.getFieldDescribe(obj, field).isCreateable()) {
+        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(obj, field);
+        return canCreate(fieldResult, throwException);
+    }
+
+    public static Boolean canUpdate(String obj, String field, Boolean throwException) {
+        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(obj, field);
+        return canUpdate(fieldResult, throwException);
+    }
+
+    public static Boolean canRead(DescribeFieldResult fieldResult) {
+        return canRead(fieldResult, true);
+    }
+
+    public static Boolean canCreate(DescribeFieldResult fieldResult) {
+        return canCreate(fieldResult, true);
+    }
+
+    public static Boolean canUpdate(DescribeFieldResult fieldResult) {
+        return canUpdate(fieldResult, true);
+    }
+
+    public static Boolean canRead(DescribeFieldResult fieldResult, Boolean throwException) {
+        if (!fieldResult.isAccessible()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canCreate(DescribeFieldResult fieldResult, Boolean throwException) {
+        if (!fieldResult.isCreateable()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canUpdate(DescribeFieldResult fieldResult, Boolean throwException) {
+        if (!fieldResult.isUpdateable()) {
             if (throwException) {
                 throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
             } else {
@@ -134,8 +165,8 @@ public with sharing class UTIL_Permissions {
         return canRead(obj, field, true);
     }
 
-    public static Boolean canWrite(String obj, String field) {
-        return canWrite(obj, field, true);
+    public static Boolean canUpdate(String obj, String field) {
+        return canUpdate(obj, field, true);
     }
 
     public static Boolean canCreate(String obj, String field) {

--- a/src/classes/UTIL_Permissions.cls
+++ b/src/classes/UTIL_Permissions.cls
@@ -39,24 +39,50 @@ public with sharing class UTIL_Permissions {
 
     /*** Object Level Security ***/
 
-    public static Boolean canRead(String obj) {
-        return canRead(obj, true);
+    /**
+    * @description Determines whether the running user has read permissions on the given object
+    * @param objectName the name of the object
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
+    public static Boolean canRead(String objectName) {
+        return canRead(objectName);
     }
 
-    public static Boolean canCreate(String obj) {
-        return canCreate(obj, true);
+    /**
+    * @description Determines whether the running user has create permissions on the given object
+    * @param objectName the name of the object
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
+    public static Boolean canCreate(String objectName) {
+        return canCreate(objectName);
     }
 
-    public static Boolean canUpdate(String obj) {
-        return canUpdate(obj, true);
+    /**
+    * @description Determines whether the running user has update permissions on the given object
+    * @param objectName the name of the object
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
+    public static Boolean canUpdate(String objectName) {
+        return canUpdate(objectName);
     }
 
-    public static Boolean canDelete(String obj) {
-        return canDelete(obj, true);
+    /**
+    * @description Determines whether the running user has delete permissions on the given object
+    * @param objectName the name of the object
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
+    public static Boolean canDelete(String objectName) {
+        return canDelete(objectName);
     }
 
-    public static Boolean canRead(String obj, Boolean throwException) {
-        if (!UTIL_Describe.getObjectDescribe(obj).isAccessible()) {
+    /**
+    * @description Determines whether the running user has read permissions on the given object
+    * @param objectName the name of the object
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
+    public static Boolean canRead(String objectName, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(objectName).isAccessible()) {
             if (throwException) {
                 throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
             } else {
@@ -66,8 +92,14 @@ public with sharing class UTIL_Permissions {
         return true;
     }
 
-    public static Boolean canCreate(String obj, Boolean throwException) {
-        if (!UTIL_Describe.getObjectDescribe(obj).isCreateable()) {
+    /**
+    * @description Determines whether the running user has create permissions on the given object
+    * @param objectName the name of the object
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
+    public static Boolean canCreate(String objectName, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(objectName).isCreateable()) {
             if (throwException) {
                 throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
             } else {
@@ -77,8 +109,14 @@ public with sharing class UTIL_Permissions {
         return true;
     }
 
-    public static Boolean canUpdate(String obj, Boolean throwException) {
-        if (!UTIL_Describe.getObjectDescribe(obj).isUpdateable()) {
+    /**
+    * @description Determines whether the running user has update permissions on the given object
+    * @param objectName the name of the object
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
+    public static Boolean canUpdate(String objectName, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(objectName).isUpdateable()) {
             if (throwException) {
                 throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
             } else {
@@ -88,8 +126,14 @@ public with sharing class UTIL_Permissions {
         return true;
     }
 
-    public static Boolean canDelete(String obj, Boolean throwException) {
-        if (!UTIL_Describe.getObjectDescribe(obj).isDeletable()) {
+    /**
+    * @description Determines whether the running user has delete permissions on the given object
+    * @param objectName the name of the object
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
+    public static Boolean canDelete(String objectName, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(objectName).isDeletable()) {
             if (throwException) {
                 throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
             } else {
@@ -101,33 +145,105 @@ public with sharing class UTIL_Permissions {
 
     /*** Field Level Security ***/
 
-    public static Boolean canRead(String obj, String field, Boolean throwException) {
-        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(obj, field);
+    /**
+    * @description Determines whether the running user has read permissions on the given object and field
+    * @param objectName the name of the object
+    * @param fieldName the name of the field
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
+    public static Boolean canRead(String objectName, String fieldName) {
+        return canRead(objectName, fieldName, true);
+    }
+
+    /**
+    * @description Determines whether the running user has update permissions on the given object and field
+    * @param objectName the name of the object
+    * @param fieldName the name of the field
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
+    public static Boolean canUpdate(String objectName, String fieldName) {
+        return canUpdate(objectName, fieldName, true);
+    }
+
+    /**
+    * @description Determines whether the running user has create permissions on the given object and field
+    * @param objectName the name of the object
+    * @param fieldName the name of the field
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
+    public static Boolean canCreate(String objectName, String fieldName) {
+        return canCreate(objectName, fieldName, true);
+    }
+
+    /**
+    * @description Determines whether the running user has read permissions on the given object and field
+    * @param objectName the name of the object
+    * @param fieldName the name of the field
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
+    public static Boolean canRead(String objectName, String fieldName, Boolean throwException) {
+        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
         return canRead(fieldResult, throwException);
     }
 
-    public static Boolean canCreate(String obj, String field, Boolean throwException) {
-        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(obj, field);
+    /**
+    * @description Determines whether the running user has create permissions on the given object and field
+    * @param objectName the name of the object
+    * @param fieldName the name of the field
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
+    public static Boolean canCreate(String objectName, String fieldName, Boolean throwException) {
+        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
         return canCreate(fieldResult, throwException);
     }
 
-    public static Boolean canUpdate(String obj, String field, Boolean throwException) {
-        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(obj, field);
+    /**
+    * @description Determines whether the running user has update permissions on the given object and field
+    * @param objectName the name of the object
+    * @param fieldName the name of the field
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
+    public static Boolean canUpdate(String objectName, String fieldName, Boolean throwException) {
+        DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
         return canUpdate(fieldResult, throwException);
     }
 
+    /**
+    * @description Determines whether the running user has read permissions on the DescribeFieldResult
+    * @param fieldResult the DescribeFieldResult of the field to check
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
     public static Boolean canRead(DescribeFieldResult fieldResult) {
         return canRead(fieldResult, true);
     }
 
+    /**
+    * @description Determines whether the running user has create permissions on the DescribeFieldResult
+    * @param fieldResult the DescribeFieldResult of the field to check
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
     public static Boolean canCreate(DescribeFieldResult fieldResult) {
         return canCreate(fieldResult, true);
     }
 
+    /**
+    * @description Determines whether the running user has update permissions on the DescribeFieldResult
+    * @param fieldResult the DescribeFieldResult of the field to check
+    * @return returns true if the user has permission; throws an exception if they don't
+    */
     public static Boolean canUpdate(DescribeFieldResult fieldResult) {
         return canUpdate(fieldResult, true);
     }
 
+    /**
+    * @description Determines whether the running user has read permissions on the given field
+    * @param fieldResult the DescribeFieldResult of the field to check
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
     public static Boolean canRead(DescribeFieldResult fieldResult, Boolean throwException) {
         if (!fieldResult.isAccessible()) {
             if (throwException) {
@@ -139,6 +255,12 @@ public with sharing class UTIL_Permissions {
         return true;
     }
 
+    /**
+    * @description Determines whether the running user has create permissions on the given field
+    * @param fieldResult the DescribeFieldResult of the field to check
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
     public static Boolean canCreate(DescribeFieldResult fieldResult, Boolean throwException) {
         if (!fieldResult.isCreateable()) {
             if (throwException) {
@@ -150,6 +272,12 @@ public with sharing class UTIL_Permissions {
         return true;
     }
 
+    /**
+    * @description Determines whether the running user has update permissions on the given field
+    * @param fieldResult the DescribeFieldResult of the field to check
+    * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    */
     public static Boolean canUpdate(DescribeFieldResult fieldResult, Boolean throwException) {
         if (!fieldResult.isUpdateable()) {
             if (throwException) {
@@ -159,18 +287,6 @@ public with sharing class UTIL_Permissions {
             }
         }
         return true;
-    }
-
-    public static Boolean canRead(String obj, String field) {
-        return canRead(obj, field, true);
-    }
-
-    public static Boolean canUpdate(String obj, String field) {
-        return canUpdate(obj, field, true);
-    }
-
-    public static Boolean canCreate(String obj, String field) {
-        return canCreate(obj, field, true);
     }
 
     public class InsufficientPermissionException extends Exception {}

--- a/src/classes/UTIL_Permissions.cls
+++ b/src/classes/UTIL_Permissions.cls
@@ -45,7 +45,7 @@ public with sharing class UTIL_Permissions {
     * @return returns true if the user has permission; throws an exception if they don't
     */
     public static Boolean canRead(String objectName) {
-        return canRead(objectName);
+        return canRead(objectName, true);
     }
 
     /**
@@ -54,7 +54,7 @@ public with sharing class UTIL_Permissions {
     * @return returns true if the user has permission; throws an exception if they don't
     */
     public static Boolean canCreate(String objectName) {
-        return canCreate(objectName);
+        return canCreate(objectName, true);
     }
 
     /**
@@ -63,7 +63,7 @@ public with sharing class UTIL_Permissions {
     * @return returns true if the user has permission; throws an exception if they don't
     */
     public static Boolean canUpdate(String objectName) {
-        return canUpdate(objectName);
+        return canUpdate(objectName, true);
     }
 
     /**
@@ -72,7 +72,7 @@ public with sharing class UTIL_Permissions {
     * @return returns true if the user has permission; throws an exception if they don't
     */
     public static Boolean canDelete(String objectName) {
-        return canDelete(objectName);
+        return canDelete(objectName, true);
     }
 
     /**

--- a/src/classes/UTIL_Permissions.cls
+++ b/src/classes/UTIL_Permissions.cls
@@ -1,0 +1,147 @@
+/*
+    Copyright (c) 2017 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group Utilities
+* @description Object- and field-level security checks
+*/
+public with sharing class UTIL_Permissions {
+
+    private final static String INSUFFICIENT_PERMISSION_MESSAGE = System.Label.flsError;
+
+    public static Boolean canRead(String obj) {
+        return canRead(obj, true);
+    }
+
+    public static Boolean canWrite(String obj) {
+        return canWrite(obj, true);
+    }
+
+    public static Boolean canCreate(String obj) {
+        return canCreate(obj, true);
+    }
+
+    public static Boolean canDelete(String obj) {
+        return canDelete(obj, true);
+    }
+
+    public static Boolean canRead(String obj, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(obj).isAccessible()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canWrite(String obj, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(obj).isUpdateable()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canCreate(String obj, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(obj).isCreateable()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canDelete(String obj, Boolean throwException) {
+        if (!UTIL_Describe.getObjectDescribe(obj).isDeletable()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canRead(String obj, String field, Boolean throwException) {
+        if (!UTIL_Describe.getFieldDescribe(obj, field).isAccessible()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canWrite(String obj, String field, Boolean throwException) {
+        if (!UTIL_Describe.getFieldDescribe(obj, field).isUpdateable()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canCreate(String obj, String field, Boolean throwException) {
+        if (!UTIL_Describe.getFieldDescribe(obj, field).isCreateable()) {
+            if (throwException) {
+                throw new InsufficientPermissionException(INSUFFICIENT_PERMISSION_MESSAGE);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Boolean canRead(String obj, String field) {
+        return canRead(obj, field, true);
+    }
+
+    public static Boolean canWrite(String obj, String field) {
+        return canWrite(obj, field, true);
+    }
+
+    public static Boolean canCreate(String obj, String field) {
+        return canCreate(obj, field, true);
+    }
+
+    public class InsufficientPermissionException extends Exception {}
+
+}

--- a/src/classes/UTIL_Permissions.cls
+++ b/src/classes/UTIL_Permissions.cls
@@ -42,7 +42,7 @@ public with sharing class UTIL_Permissions {
     /**
     * @description Determines whether the running user has read permissions on the given object
     * @param objectName the name of the object
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canRead(String objectName) {
         return canRead(objectName, true);
@@ -51,7 +51,7 @@ public with sharing class UTIL_Permissions {
     /**
     * @description Determines whether the running user has create permissions on the given object
     * @param objectName the name of the object
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canCreate(String objectName) {
         return canCreate(objectName, true);
@@ -60,7 +60,7 @@ public with sharing class UTIL_Permissions {
     /**
     * @description Determines whether the running user has update permissions on the given object
     * @param objectName the name of the object
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canUpdate(String objectName) {
         return canUpdate(objectName, true);
@@ -69,7 +69,7 @@ public with sharing class UTIL_Permissions {
     /**
     * @description Determines whether the running user has delete permissions on the given object
     * @param objectName the name of the object
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canDelete(String objectName) {
         return canDelete(objectName, true);
@@ -79,7 +79,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has read permissions on the given object
     * @param objectName the name of the object
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canRead(String objectName, Boolean throwException) {
         if (!UTIL_Describe.getObjectDescribe(objectName).isAccessible()) {
@@ -96,7 +96,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has create permissions on the given object
     * @param objectName the name of the object
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canCreate(String objectName, Boolean throwException) {
         if (!UTIL_Describe.getObjectDescribe(objectName).isCreateable()) {
@@ -113,7 +113,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has update permissions on the given object
     * @param objectName the name of the object
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canUpdate(String objectName, Boolean throwException) {
         if (!UTIL_Describe.getObjectDescribe(objectName).isUpdateable()) {
@@ -130,7 +130,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has delete permissions on the given object
     * @param objectName the name of the object
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canDelete(String objectName, Boolean throwException) {
         if (!UTIL_Describe.getObjectDescribe(objectName).isDeletable()) {
@@ -149,7 +149,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has read permissions on the given object and field
     * @param objectName the name of the object
     * @param fieldName the name of the field
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canRead(String objectName, String fieldName) {
         return canRead(objectName, fieldName, true);
@@ -159,7 +159,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has update permissions on the given object and field
     * @param objectName the name of the object
     * @param fieldName the name of the field
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canUpdate(String objectName, String fieldName) {
         return canUpdate(objectName, fieldName, true);
@@ -169,7 +169,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has create permissions on the given object and field
     * @param objectName the name of the object
     * @param fieldName the name of the field
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canCreate(String objectName, String fieldName) {
         return canCreate(objectName, fieldName, true);
@@ -180,7 +180,7 @@ public with sharing class UTIL_Permissions {
     * @param objectName the name of the object
     * @param fieldName the name of the field
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canRead(String objectName, String fieldName, Boolean throwException) {
         DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
@@ -192,7 +192,7 @@ public with sharing class UTIL_Permissions {
     * @param objectName the name of the object
     * @param fieldName the name of the field
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canCreate(String objectName, String fieldName, Boolean throwException) {
         DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
@@ -204,7 +204,7 @@ public with sharing class UTIL_Permissions {
     * @param objectName the name of the object
     * @param fieldName the name of the field
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if not
     */
     public static Boolean canUpdate(String objectName, String fieldName, Boolean throwException) {
         DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
@@ -214,7 +214,7 @@ public with sharing class UTIL_Permissions {
     /**
     * @description Determines whether the running user has read permissions on the DescribeFieldResult
     * @param fieldResult the DescribeFieldResult of the field to check
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canRead(DescribeFieldResult fieldResult) {
         return canRead(fieldResult, true);
@@ -223,7 +223,7 @@ public with sharing class UTIL_Permissions {
     /**
     * @description Determines whether the running user has create permissions on the DescribeFieldResult
     * @param fieldResult the DescribeFieldResult of the field to check
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canCreate(DescribeFieldResult fieldResult) {
         return canCreate(fieldResult, true);
@@ -232,7 +232,7 @@ public with sharing class UTIL_Permissions {
     /**
     * @description Determines whether the running user has update permissions on the DescribeFieldResult
     * @param fieldResult the DescribeFieldResult of the field to check
-    * @return returns true if the user has permission; throws an exception if they don't
+    * @return returns true if the user has permission; throws an exception not
     */
     public static Boolean canUpdate(DescribeFieldResult fieldResult) {
         return canUpdate(fieldResult, true);
@@ -242,7 +242,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has read permissions on the given field
     * @param fieldResult the DescribeFieldResult of the field to check
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canRead(DescribeFieldResult fieldResult, Boolean throwException) {
         if (!fieldResult.isAccessible()) {
@@ -259,7 +259,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has create permissions on the given field
     * @param fieldResult the DescribeFieldResult of the field to check
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canCreate(DescribeFieldResult fieldResult, Boolean throwException) {
         if (!fieldResult.isCreateable()) {
@@ -276,7 +276,7 @@ public with sharing class UTIL_Permissions {
     * @description Determines whether the running user has update permissions on the given field
     * @param fieldResult the DescribeFieldResult of the field to check
     * @param throwException indicates whether an exception should be thrown if the user doesn't have permission
-    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception if they don't
+    * @return returns boolean to indicate whether the user has permission; conditionally throws an exception not
     */
     public static Boolean canUpdate(DescribeFieldResult fieldResult, Boolean throwException) {
         if (!fieldResult.isUpdateable()) {

--- a/src/classes/UTIL_Permissions.cls-meta.xml
+++ b/src/classes/UTIL_Permissions.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -157,13 +157,22 @@ private with sharing class UTIL_Permissions_TEST {
     @isTest
     static void readOnlyUserFieldCheckNoException() {
         System.runAs(getReadOnlyUser()) {
+            DescribeFieldResult customFieldResult = UTIL_Describe.getFieldDescribe(customObjectName, customFieldName);
+            DescribeFieldResult standardFieldResult = UTIL_Describe.getFieldDescribe(standardObjectName, standardFieldName);
+
             System.assert(!UTIL_Permissions.canRead(customObjectName, customFieldName, false));
             System.assert(!UTIL_Permissions.canCreate(customObjectName, customFieldName, false));
             System.assert(!UTIL_Permissions.canUpdate(customObjectName, customFieldName, false));
             System.assert(!UTIL_Permissions.canCreate(standardObjectName, standardFieldName, false));
             System.assert(!UTIL_Permissions.canUpdate(standardObjectName, standardFieldName, false));
-            // this one is positive!
+            System.assert(!UTIL_Permissions.canCreate(customFieldResult, false));
+            System.assert(!UTIL_Permissions.canUpdate(customFieldResult, false));
+            System.assert(!UTIL_Permissions.canCreate(standardFieldResult, false));
+            System.assert(!UTIL_Permissions.canUpdate(standardFieldResult, false));
+
+            // these two are positive!
             System.assert(UTIL_Permissions.canRead(standardObjectName, standardFieldName, false));
+            System.assert(UTIL_Permissions.canRead(standardFieldResult, false));
         }
     }
 
@@ -186,12 +195,21 @@ private with sharing class UTIL_Permissions_TEST {
     @isTest
     static void sysAdminFieldCheckNoException() {
         System.runAs(getSysAdmin()) {
+            DescribeFieldResult customFieldResult = UTIL_Describe.getFieldDescribe(customObjectName, customFieldName);
+            DescribeFieldResult standardFieldResult = UTIL_Describe.getFieldDescribe(standardObjectName, standardFieldName);
+
             System.assert(UTIL_Permissions.canRead(customObjectName, customFieldName, false));
             System.assert(UTIL_Permissions.canCreate(customObjectName, customFieldName, false));
             System.assert(UTIL_Permissions.canUpdate(customObjectName, customFieldName, false));
             System.assert(UTIL_Permissions.canRead(standardObjectName, standardFieldName, false));
             System.assert(UTIL_Permissions.canCreate(standardObjectName, standardFieldName, false));
             System.assert(UTIL_Permissions.canUpdate(standardObjectName, standardFieldName, false));
+            System.assert(UTIL_Permissions.canRead(customFieldResult, false));
+            System.assert(UTIL_Permissions.canCreate(customFieldResult, false));
+            System.assert(UTIL_Permissions.canUpdate(customFieldResult, false));
+            System.assert(UTIL_Permissions.canRead(standardFieldResult, false));
+            System.assert(UTIL_Permissions.canCreate(standardFieldResult, false));
+            System.assert(UTIL_Permissions.canUpdate(standardFieldResult, false));
         }
     }
 

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -122,82 +122,78 @@ private with sharing class UTIL_Permissions_TEST {
         }
     }
 
-//    @isTest
-//    static void readOnlyUserCannotReadCustomFieldException() {
-//        Boolean exceptionCaught = false;
-//
-//        System.runAs(getReadOnlyUser()) {
-//            try {
-//                System.assert(!UTIL_Permissions.canRead(customObjectName));
-//            } catch (Exception ex) {
-//                exceptionCaught = true;
-//                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
-//            }
-//        }
-//
-//        System.assert(exceptionCaught);
-//    }
+    @isTest
+    static void readOnlyUserCannotReadCustomFieldException() {
+        Boolean exceptionCaught = false;
 
-//    @isTest
-//    static void readOnlyUserCannotUpdateStandardFieldException() {
-//        Boolean exceptionCaught = false;
-//
-//        System.runAs(getReadOnlyUser()) {
-//            try {
-//                System.assert(!UTIL_Permissions.canUpdate(customObjectName));
-//            } catch (Exception ex) {
-//                exceptionCaught = true;
-//                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
-//            }
-//        }
-//
-//        System.assert(exceptionCaught);
-//    }
-//
-//    @isTest
-//    static void readOnlyUserFieldCheckNoException() {
-//        System.runAs(getReadOnlyUser()) {
-//            System.assert(!UTIL_Permissions.canRead(customObjectName, false));
-//            System.assert(!UTIL_Permissions.canCreate(customObjectName, false));
-//            System.assert(!UTIL_Permissions.canUpdate(customObjectName, false));
-//            System.assert(!UTIL_Permissions.canDelete(customObjectName, false));
-//            System.assert(!UTIL_Permissions.canCreate(standardObjectName, false));
-//            System.assert(!UTIL_Permissions.canUpdate(standardObjectName, false));
-//            System.assert(!UTIL_Permissions.canDelete(standardObjectName, false));
-//            // this one is positive!
-//            System.assert(UTIL_Permissions.canRead(standardObjectName, false));
-//        }
-//    }
-//
-//    @isTest
-//    static void sysAdminCanDeleteCustomFieldException() {
-//        Boolean exceptionCaught = false;
-//
-//        System.runAs(getSysAdmin()) {
-//            try {
-//                System.assert(UTIL_Permissions.canDelete(customObjectName));
-//            } catch (Exception ex) {
-//                exceptionCaught = true;
-//                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
-//            }
-//        }
-//
-//        System.assert(!exceptionCaught);
-//    }
-//
-//    @isTest
-//    static void sysAdminFieldCheckNoException() {
-//        System.runAs(getSysAdmin()) {
-//            System.assert(UTIL_Permissions.canRead(customObjectName, false));
-//            System.assert(UTIL_Permissions.canCreate(customObjectName, false));
-//            System.assert(UTIL_Permissions.canUpdate(customObjectName, false));
-//            System.assert(UTIL_Permissions.canDelete(customObjectName, false));
-//            System.assert(UTIL_Permissions.canRead(standardObjectName, false));
-//            System.assert(UTIL_Permissions.canCreate(standardObjectName, false));
-//            System.assert(UTIL_Permissions.canUpdate(standardObjectName, false));
-//            System.assert(UTIL_Permissions.canDelete(standardObjectName, false));
-//        }
-//    }
+        System.runAs(getReadOnlyUser()) {
+            try {
+                System.assert(!UTIL_Permissions.canRead(customObjectName, customFieldName));
+            } catch (Exception ex) {
+                exceptionCaught = true;
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+            }
+        }
+
+        System.assert(exceptionCaught);
+    }
+
+    @isTest
+    static void readOnlyUserCannotUpdateStandardFieldException() {
+        Boolean exceptionCaught = false;
+
+        System.runAs(getReadOnlyUser()) {
+            try {
+                System.assert(!UTIL_Permissions.canUpdate(customObjectName, customFieldName));
+            } catch (Exception ex) {
+                exceptionCaught = true;
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+            }
+        }
+
+        System.assert(exceptionCaught);
+    }
+
+    @isTest
+    static void readOnlyUserFieldCheckNoException() {
+        System.runAs(getReadOnlyUser()) {
+            System.assert(!UTIL_Permissions.canRead(customObjectName, customFieldName, false));
+            System.assert(!UTIL_Permissions.canCreate(customObjectName, customFieldName, false));
+            System.assert(!UTIL_Permissions.canUpdate(customObjectName, customFieldName, false));
+            System.assert(!UTIL_Permissions.canCreate(standardObjectName, standardFieldName, false));
+            System.assert(!UTIL_Permissions.canUpdate(standardObjectName, standardFieldName, false));
+            // this one is positive!
+            System.assert(UTIL_Permissions.canRead(standardObjectName, standardFieldName, false));
+        }
+    }
+
+    @isTest
+    static void sysAdminCanUpdateCustomFieldException() {
+        Boolean exceptionCaught = false;
+
+        System.runAs(getSysAdmin()) {
+            try {
+                System.assert(UTIL_Permissions.canUpdate(customObjectName, customFieldName));
+            } catch (Exception ex) {
+                exceptionCaught = true;
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+            }
+        }
+
+        System.assert(!exceptionCaught);
+    }
+
+    @isTest
+    static void sysAdminFieldCheckNoException() {
+        System.runAs(getSysAdmin()) {
+            System.assert(UTIL_Permissions.canRead(customObjectName, customFieldName, false));
+            System.assert(UTIL_Permissions.canCreate(customObjectName, customFieldName, false));
+            System.assert(UTIL_Permissions.canUpdate(customObjectName, customFieldName, false));
+            System.assert(UTIL_Permissions.canRead(standardObjectName, standardFieldName, false));
+            System.assert(UTIL_Permissions.canCreate(standardObjectName, standardFieldName, false));
+            System.assert(UTIL_Permissions.canUpdate(standardObjectName, standardFieldName, false));
+        }
+    }
 
 
 }

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -1,0 +1,203 @@
+/*
+    Copyright (c) 2018 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+@isTest
+private with sharing class UTIL_Permissions_TEST {
+
+    // Read Only users don't have access to custom objects or fields
+    private static User getReadOnlyUser() {
+        return UTIL_UnitTestData_TEST.createUserWithoutInsert('Read Only');
+    }
+
+    // System Administrators have read/write access to custom and standard fields
+    private static User getSysAdmin() {
+        return UTIL_UnitTestData_TEST.createUserWithoutInsert('System Administrator');
+    }
+
+    private static String customObjectName = UTIL_Namespace.StrAllNSPrefix('Address__c');
+    private static String customFieldName = UTIL_Namespace.StrAllNSPrefix('Address_Type__c');
+    private static String standardObjectName = 'Contact';
+    private static String standardFieldName = 'FirstName';
+
+    @isTest
+    static void readOnlyUserCannotReadCustomObjectException() {
+        Boolean exceptionCaught = false;
+
+        System.runAs(getReadOnlyUser()) {
+            try {
+                System.assert(!UTIL_Permissions.canRead(customObjectName));
+            } catch (Exception ex) {
+                exceptionCaught = true;
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+            }
+        }
+
+        System.assert(exceptionCaught);
+    }
+
+    @isTest
+    static void readOnlyUserCannotUpdateStandardObjectException() {
+        Boolean exceptionCaught = false;
+
+        System.runAs(getReadOnlyUser()) {
+            try {
+                System.assert(!UTIL_Permissions.canUpdate(customObjectName));
+            } catch (Exception ex) {
+                exceptionCaught = true;
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+            }
+        }
+
+        System.assert(exceptionCaught);
+    }
+
+    @isTest
+    static void readOnlyUserObjectCheckNoException() {
+        System.runAs(getReadOnlyUser()) {
+            System.assert(!UTIL_Permissions.canRead(customObjectName, false));
+            System.assert(!UTIL_Permissions.canCreate(customObjectName, false));
+            System.assert(!UTIL_Permissions.canUpdate(customObjectName, false));
+            System.assert(!UTIL_Permissions.canDelete(customObjectName, false));
+            System.assert(!UTIL_Permissions.canCreate(standardObjectName, false));
+            System.assert(!UTIL_Permissions.canUpdate(standardObjectName, false));
+            System.assert(!UTIL_Permissions.canDelete(standardObjectName, false));
+            // this one is positive!
+            System.assert(UTIL_Permissions.canRead(standardObjectName, false));
+        }
+    }
+
+    @isTest
+    static void sysAdminCanDeleteCustomObjectException() {
+        Boolean exceptionCaught = false;
+
+        System.runAs(getSysAdmin()) {
+            try {
+                System.assert(UTIL_Permissions.canDelete(customObjectName));
+            } catch (Exception ex) {
+                exceptionCaught = true;
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+            }
+        }
+
+        System.assert(!exceptionCaught);
+    }
+
+    @isTest
+    static void sysAdminObjectCheckNoException() {
+        System.runAs(getSysAdmin()) {
+            System.assert(UTIL_Permissions.canRead(customObjectName, false));
+            System.assert(UTIL_Permissions.canCreate(customObjectName, false));
+            System.assert(UTIL_Permissions.canUpdate(customObjectName, false));
+            System.assert(UTIL_Permissions.canDelete(customObjectName, false));
+            System.assert(UTIL_Permissions.canRead(standardObjectName, false));
+            System.assert(UTIL_Permissions.canCreate(standardObjectName, false));
+            System.assert(UTIL_Permissions.canUpdate(standardObjectName, false));
+            System.assert(UTIL_Permissions.canDelete(standardObjectName, false));
+        }
+    }
+
+//    @isTest
+//    static void readOnlyUserCannotReadCustomFieldException() {
+//        Boolean exceptionCaught = false;
+//
+//        System.runAs(getReadOnlyUser()) {
+//            try {
+//                System.assert(!UTIL_Permissions.canRead(customObjectName));
+//            } catch (Exception ex) {
+//                exceptionCaught = true;
+//                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+//            }
+//        }
+//
+//        System.assert(exceptionCaught);
+//    }
+
+//    @isTest
+//    static void readOnlyUserCannotUpdateStandardFieldException() {
+//        Boolean exceptionCaught = false;
+//
+//        System.runAs(getReadOnlyUser()) {
+//            try {
+//                System.assert(!UTIL_Permissions.canUpdate(customObjectName));
+//            } catch (Exception ex) {
+//                exceptionCaught = true;
+//                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+//            }
+//        }
+//
+//        System.assert(exceptionCaught);
+//    }
+//
+//    @isTest
+//    static void readOnlyUserFieldCheckNoException() {
+//        System.runAs(getReadOnlyUser()) {
+//            System.assert(!UTIL_Permissions.canRead(customObjectName, false));
+//            System.assert(!UTIL_Permissions.canCreate(customObjectName, false));
+//            System.assert(!UTIL_Permissions.canUpdate(customObjectName, false));
+//            System.assert(!UTIL_Permissions.canDelete(customObjectName, false));
+//            System.assert(!UTIL_Permissions.canCreate(standardObjectName, false));
+//            System.assert(!UTIL_Permissions.canUpdate(standardObjectName, false));
+//            System.assert(!UTIL_Permissions.canDelete(standardObjectName, false));
+//            // this one is positive!
+//            System.assert(UTIL_Permissions.canRead(standardObjectName, false));
+//        }
+//    }
+//
+//    @isTest
+//    static void sysAdminCanDeleteCustomFieldException() {
+//        Boolean exceptionCaught = false;
+//
+//        System.runAs(getSysAdmin()) {
+//            try {
+//                System.assert(UTIL_Permissions.canDelete(customObjectName));
+//            } catch (Exception ex) {
+//                exceptionCaught = true;
+//                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+//            }
+//        }
+//
+//        System.assert(!exceptionCaught);
+//    }
+//
+//    @isTest
+//    static void sysAdminFieldCheckNoException() {
+//        System.runAs(getSysAdmin()) {
+//            System.assert(UTIL_Permissions.canRead(customObjectName, false));
+//            System.assert(UTIL_Permissions.canCreate(customObjectName, false));
+//            System.assert(UTIL_Permissions.canUpdate(customObjectName, false));
+//            System.assert(UTIL_Permissions.canDelete(customObjectName, false));
+//            System.assert(UTIL_Permissions.canRead(standardObjectName, false));
+//            System.assert(UTIL_Permissions.canCreate(standardObjectName, false));
+//            System.assert(UTIL_Permissions.canUpdate(standardObjectName, false));
+//            System.assert(UTIL_Permissions.canDelete(standardObjectName, false));
+//        }
+//    }
+
+
+}

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -157,8 +157,10 @@ private with sharing class UTIL_Permissions_TEST {
     @isTest
     static void readOnlyUserFieldCheckNoException() {
         System.runAs(getReadOnlyUser()) {
-            DescribeFieldResult customFieldResult = UTIL_Describe.getFieldDescribe(customObjectName, customFieldName);
-            DescribeFieldResult standardFieldResult = UTIL_Describe.getFieldDescribe(standardObjectName, standardFieldName);
+            DescribeFieldResult customFieldResult =
+                UTIL_Describe.getFieldDescribe(customObjectName, customFieldName);
+            DescribeFieldResult standardFieldResult =
+                UTIL_Describe.getFieldDescribe(standardObjectName, standardFieldName);
 
             System.assert(!UTIL_Permissions.canRead(customObjectName, customFieldName, false));
             System.assert(!UTIL_Permissions.canCreate(customObjectName, customFieldName, false));
@@ -195,8 +197,10 @@ private with sharing class UTIL_Permissions_TEST {
     @isTest
     static void sysAdminFieldCheckNoException() {
         System.runAs(getSysAdmin()) {
-            DescribeFieldResult customFieldResult = UTIL_Describe.getFieldDescribe(customObjectName, customFieldName);
-            DescribeFieldResult standardFieldResult = UTIL_Describe.getFieldDescribe(standardObjectName, standardFieldName);
+            DescribeFieldResult customFieldResult =
+                UTIL_Describe.getFieldDescribe(customObjectName, customFieldName);
+            DescribeFieldResult standardFieldResult =
+                UTIL_Describe.getFieldDescribe(standardObjectName, standardFieldName);
 
             System.assert(UTIL_Permissions.canRead(customObjectName, customFieldName, false));
             System.assert(UTIL_Permissions.canCreate(customObjectName, customFieldName, false));

--- a/src/classes/UTIL_Permissions_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Permissions_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -422,10 +422,10 @@
         <members>UTIL_OrgTelemetry_SVC</members>
         <members>UTIL_OrgTelemetry_TEST</members>
         <members>UTIL_PageMessages_CTRL</members>
-        <members>UTIL_Permissions</members>
-        <members>UTIL_Permissions_TEST</members>
         <members>UTIL_PerfLogger</members>
         <members>UTIL_PerfLogger_TEST</members>
+        <members>UTIL_Permissions</members>
+        <members>UTIL_Permissions_TEST</members>
         <members>UTIL_PlatformCache</members>
         <members>UTIL_Profile</members>
         <members>UTIL_Profile_TEST</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -83,6 +83,7 @@
         <members>BDI_SettingsUI_CTRL</members>
         <members>BDI_SettingsUI_TEST</members>
         <members>BGE_BatchGiftEntry_UTIL</members>
+        <members>BGE_BatchGiftEntry_UTIL_TEST</members>
         <members>BGE_ConfigurationWizard_CTRL</members>
         <members>BGE_ConfigurationWizard_CTRL_TEST</members>
         <members>BGE_DataImportBatchEntry_CTRL</members>
@@ -421,6 +422,8 @@
         <members>UTIL_OrgTelemetry_SVC</members>
         <members>UTIL_OrgTelemetry_TEST</members>
         <members>UTIL_PageMessages_CTRL</members>
+        <members>UTIL_Permissions</members>
+        <members>UTIL_Permissions_TEST</members>
         <members>UTIL_PerfLogger</members>
         <members>UTIL_PerfLogger_TEST</members>
         <members>UTIL_PlatformCache</members>


### PR DESCRIPTION
Adds feedback about which fields the user needs permissions for. It would be nice to show object names here as well, but that would require some additional refactoring. 

<img width="1105" alt="screen shot 2018-12-27 at 4 01 25 pm" src="https://user-images.githubusercontent.com/2000501/50497891-bda4b580-09f0-11e9-9d71-96963f8297b9.png">

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
