### PR TITLE
Adding TDTM Trigger for Cascade delete of Payment Allocations

### DIFF
--- a/src/classes/CMT_FilterRuleEvaluation_TEST.cls
+++ b/src/classes/CMT_FilterRuleEvaluation_TEST.cls
@@ -88,11 +88,11 @@ private class CMT_FilterRuleEvaluation_TEST {
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule4', 'Opportunity', 'CreatedDate', 'Equals', 'TODAY') + ',' +
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId2, 'Group2.Rule5', 'Opportunity', 'CreatedDate', 'Greater', 'YESTERDAY') + ',' +
 
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule1', 'Opportunity', 'CreatedDate', 'Equals', DateTime.Now().format('YYYY-MM-dd')) + ',' +
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule2', 'Opportunity', 'CreatedDate', 'Greater_Or_Equal', DateTime.Now().addDays(-1).format('YYYY-MM-dd')) + ',' +
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule3', 'Opportunity', 'CreatedDate', 'Less_Or_Equal', DateTime.Now().addDays(1).format('YYYY-MM-dd')) + ',' +
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule4', 'Opportunity', 'CreatedDate', 'Greater', DateTime.Now().addDays(-2).formatGmt('YYYY-MM-dd hh:mm:ss.SSS')) + ',' +
-                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule5', 'Opportunity', 'CreatedDate', 'Less', DateTime.Now().addDays(2).format('YYYY-MM-dd')) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule1', 'Opportunity', 'CreatedDate', 'Equals', DateTime.Now().format('yyyy-MM-dd')) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule2', 'Opportunity', 'CreatedDate', 'Greater_Or_Equal', DateTime.Now().addDays(-1).format('yyyy-MM-dd')) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule3', 'Opportunity', 'CreatedDate', 'Less_Or_Equal', DateTime.Now().addDays(1).format('yyyy-MM-dd')) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule4', 'Opportunity', 'CreatedDate', 'Greater', DateTime.Now().addDays(-2).formatGmt('yyyy-MM-dd hh:mm:ss.SSS')) + ',' +
+                CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId3, 'Group3.Rule5', 'Opportunity', 'CreatedDate', 'Less', DateTime.Now().addDays(2).format('yyyy-MM-dd')) + ',' +
 
                 /*  FILTER RULES FOR FILTER GROUP 4-7 -- Opportunity with RecordTypeId, RecordType.DeveloperName, StageName, OCR.Role, Amount */
                 CMT_UnitTestData_TEST.createFilterRuleRecord(null, filterGroupId4, 'Group4.Rule1', 'Opportunity', 'IsWon', 'Not_Equals', 'False') + ',' +

--- a/src/classes/PMT_CascadeDeleteLookups_TDTM.cls
+++ b/src/classes/PMT_CascadeDeleteLookups_TDTM.cls
@@ -1,0 +1,102 @@
+/*
+    Copyright (c) 2018, Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author Salesforce.org
+ * @date 2018
+ * @group Cascade Delete
+ * @description Cascade deletion extension for Payment object.
+ */
+public with sharing class PMT_CascadeDeleteLookups_TDTM extends CDL_CascadeDeleteLookups_TDTM {
+
+    /*******************************************************************************************************
+    * @description Gets the deleted Payments CascadeDeleteLoader Object. 
+    * @return CDL_CascadeDeleteLookups.CascadeDeleteLoader.
+    ********************************************************************************************************/
+    protected override CDL_CascadeDeleteLookups.CascadeDeleteLoader getCascadeDeleteLoader() {
+        return new CascadeDeleteLoader();
+    }
+
+    /*******************************************************************************************************
+    * @description Gets the undeleted Payments CascadeUndeleteLoader Object.
+    * @return CDL_CascadeDeleteLookups.CascadeUndeleteLoader.
+    ********************************************************************************************************/
+    protected override CDL_CascadeDeleteLookups.CascadeUndeleteLoader getCascadeUndeleteLoader() {
+        return new CascadeUndeleteLoader();
+    }
+
+    /*******************************************************************************************************
+    * @description Class that retrieves the children of the deleted Payments.
+    ********************************************************************************************************/
+    class CascadeDeleteLoader implements CDL_CascadeDeleteLookups.CascadeDeleteLoader {
+        
+        /*******************************************************************************************************
+        * @description Retrieves the related Allocations of the deleted Payments.
+        * @param Set<Id> The Ids of the deleted Payments.
+        * @return List<Allocation__c> Deleted Payments' Allocations.
+        ********************************************************************************************************/
+        public List<Allocation__c> load(Set<Id> paymentIds) {
+            return [
+                SELECT Payment__c  
+                FROM Allocation__c
+                WHERE Payment__c IN :paymentIds
+            ];
+        }
+    }
+
+    /*******************************************************************************************************
+    * @description Class that retrieves the children of the undeleted Payments.
+    ********************************************************************************************************/
+    class CascadeUndeleteLoader implements CDL_CascadeDeleteLookups.CascadeUndeleteLoader {
+
+        /*******************************************************************************************************
+        * @description Retrieves the related Allocations of the undeleted Payments.
+        * @param Set<Id> The Ids of the undeleted Payments.
+        * @return List<Allocation__c> Undeleted Payments' Allocations.
+        ********************************************************************************************************/
+        public List<Allocation__c> load(Set<Id> paymentIds) {
+            return [
+                SELECT Payment__c 
+                FROM Allocation__c
+                WHERE Payment__c IN :paymentIds
+                AND IsDeleted = TRUE
+                ALL ROWS
+            ];
+        }
+
+        /*******************************************************************************************************
+        * @description Retrieves the next children records group to be undeleted. In this case, there is no other
+        * group of children records to undelete after Allocations undeletion.
+        * @return CDL_CascadeDeleteLookups.CascadeUndeleteLoader.
+        ********************************************************************************************************/
+        public CDL_CascadeDeleteLookups.CascadeUndeleteLoader next() {
+            return null;
+        }
+    }
+}

--- a/src/classes/PMT_CascadeDeleteLookups_TDTM.cls-meta.xml
+++ b/src/classes/PMT_CascadeDeleteLookups_TDTM.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/PMT_CascadeDeleteLookups_TEST.cls
+++ b/src/classes/PMT_CascadeDeleteLookups_TEST.cls
@@ -67,19 +67,24 @@ private class PMT_CascadeDeleteLookups_TEST {
         List<npe01__OppPayment__c> payments = [SELECT Id FROM npe01__OppPayment__c WHERE IsDeleted = false];
         System.assertEquals(maxRecords, payments.size(), 'A Payment should have been created for each Closed Won Opportunity');
 
-        List<Allocation__c> totalAllocations = CDL_CascadeDeleteLookups_TEST.getNonDeletedAllocations();
-        System.assertEquals(maxRecords*2, totalAllocations.size(), 'Each Payment should have the same Allocation ratio as its Opportunity');
+        List<Allocation__c> paymentAllocations = [SELECT Id FROM Allocation__c WHERE Payment__c != null AND IsDeleted = false];
+        System.assertEquals(maxRecords, paymentAllocations.size(), 'Each Payment should have the same Allocation ratio as its Opportunity');
+
+        Set<Id> allocationIds = new Set<Id>();
+        for(Allocation__c allo : paymentAllocations){
+          allocationIds.add(allo.Id);
+        }
 
         Test.startTest();
         delete payments;
         Test.stopTest();
 
-        List<Allocation__c> deletedAllocations = CDL_CascadeDeleteLookups_TEST.getDeletedAllocations();
-        System.assertEquals(maxRecords, deletedAllocations.size(), 'Allocations should be cascade deleted when the Payment is deleted.');
+        List<Allocation__c> deletedAllocations = [SELECT Id FROM Allocation__c WHERE Id in :allocationIds AND IsDeleted = true ALL ROWS];
+        System.assertEquals(paymentAllocations.size(), deletedAllocations.size(), 'Allocations should be cascade deleted when the Payment is deleted.');
 
         undelete payments;
 
         List<Allocation__c> undeletedAllocations = CDL_CascadeDeleteLookups_TEST.getNonDeletedAllocations();
-        System.assertEquals(maxRecords*2, undeletedAllocations.size(), 'Allocations should be cascade undeleted when the Payment is deleted.');
+        System.assertEquals(maxRecords*2, undeletedAllocations.size(), 'Allocations should be cascade undeleted when the Payment is undeleted.');
     }
 }

--- a/src/classes/PMT_CascadeDeleteLookups_TEST.cls
+++ b/src/classes/PMT_CascadeDeleteLookups_TEST.cls
@@ -1,0 +1,85 @@
+/*
+    Copyright (c) 2018, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2018
+* @group Cascade Delete
+* @description Tests for cascade delete of Payments
+*/
+@isTest
+private class PMT_CascadeDeleteLookups_TEST {
+
+    /*********************************************************************************************************
+    * @description Deletes the Opportunities which deletes the related Allocations. 
+    * Then undeletes the Opportunities, which undeletes the Allocations.
+    * Verifies results: All the Allocations should be deleted after the Opportunities are deleted.
+    * Then the Allocations will be undeleted after the Opportunities are undeleted.
+    */
+    static testMethod void testPaymentCascade() {
+        General_Accounting_Unit__c defaultAccountingUnit = 
+          new General_Accounting_Unit__c(Name = 'DEFAULT_GAU');
+        insert defaultAccountingUnit;
+        
+        // Setup Default GAU and Payment allocations
+        Allocations_Settings__c alloSettings = UTIL_CustomSettingsFacade.getOrgAllocationsSettings();
+        alloSettings.Default__c = defaultAccountingUnit.Id;
+        alloSettings.Default_Allocations_Enabled__c = true;
+        alloSettings.Payment_Allocations_Enabled__c = true;
+        UTIL_CustomSettingsFacade.getAllocationsSettingsForTests(alloSettings);
+
+        Integer maxRecords = 2;
+
+        List<Account> accounts = CDL_CascadeDeleteLookups_TEST.buildAccounts(maxRecords);
+        insert accounts;
+
+        List<Opportunity> opportunities = CDL_CascadeDeleteLookups_TEST.buildOpportunities(accounts);
+        opportunities[0].StageName = UTIL_UnitTestData_TEST.getClosedWonStage();
+        opportunities[1].StageName = UTIL_UnitTestData_TEST.getClosedWonStage();
+        insert opportunities;
+
+        List<npe01__OppPayment__c> payments = [SELECT Id FROM npe01__OppPayment__c WHERE IsDeleted = false];
+        System.assertEquals(maxRecords, payments.size(), 'A Payment should have been created for each Closed Won Opportunity');
+
+        List<Allocation__c> totalAllocations = CDL_CascadeDeleteLookups_TEST.getNonDeletedAllocations();
+        System.assertEquals(maxRecords*2, totalAllocations.size(), 'Each Payment should have the same Allocation ratio as its Opportunity');
+
+        Test.startTest();
+        delete payments;
+        Test.stopTest();
+
+        List<Allocation__c> deletedAllocations = CDL_CascadeDeleteLookups_TEST.getDeletedAllocations();
+        System.assertEquals(maxRecords, deletedAllocations.size(), 'Allocations should be cascade deleted when the Payment is deleted.');
+
+        undelete payments;
+
+        List<Allocation__c> undeletedAllocations = CDL_CascadeDeleteLookups_TEST.getNonDeletedAllocations();
+        System.assertEquals(maxRecords*2, undeletedAllocations.size(), 'Allocations should be cascade undeleted when the Payment is deleted.');
+    }
+}

--- a/src/classes/PMT_CascadeDeleteLookups_TEST.cls-meta.xml
+++ b/src/classes/PMT_CascadeDeleteLookups_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -330,6 +330,10 @@ public without sharing class TDTM_DefaultConfig {
               Trigger_Action__c = 'BeforeDelete;AfterDelete;AfterUndelete'));
 
         handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
+              Class__c = 'PMT_CascadeDeleteLookups_TDTM', Load_Order__c = 1, Object__c = 'npe01__OppPayment__c',
+              Trigger_Action__c = 'BeforeDelete;AfterDelete;AfterUndelete'));
+
+        handlers.add(new Trigger_Handler__c(Active__c = true, Asynchronous__c = false,
               Class__c = 'RD_CascadeDeleteLookups_TDTM', Load_Order__c = 1, Object__c = 'npe03__Recurring_Donation__c',
               Trigger_Action__c = 'BeforeDelete;AfterDelete;AfterUndelete'));
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -268,6 +268,8 @@
         <members>OPP_PrimaryContact_TEST</members>
         <members>OPP_SendAcknowledgmentBTN_CTRL</members>
         <members>OPP_SendAcknowledgmentBTN_TEST</members>
+        <members>PMT_CascadeDeleteLookups_TDTM</members>
+        <members>PMT_CascadeDeleteLookups_TEST</members>
         <members>PMT_PaymentCreator</members>
         <members>PMT_PaymentCreator_BATCH</members>
         <members>PMT_PaymentCreator_TEST</members>


### PR DESCRIPTION
# Critical Changes

# Changes

- We have added a TDTM trigger that deletes all related Payment Allocations when a Payment is deleted.

# Issues Closed

- Fixes #3949

# New Metadata

- PMT_CascadeDeleteLookups_TDTM.cls
- PMT_CascadeDeleteLookups_TEST.cls

# Deleted Metadata
