### PR TITLE
Attempt to fix time-based test failures in CRLP_RollupAccount_TEST

### DIFF
--- a/src/classes/CRLP_RollupAccount_TEST.cls
+++ b/src/classes/CRLP_RollupAccount_TEST.cls
@@ -67,7 +67,9 @@ private class CRLP_RollupAccount_TEST {
         String filterGroupId1 = CMT_UnitTestData_TEST.getNewRecordId();
         String filterGroupId2 = CMT_UnitTestData_TEST.getNewRecordId();
 
-        String dtValue = DateTime.now().addMonths(-100).addDays(-1).format('yyyy-MM-dd');
+        DateTime dt = DateTime.now().addMonths(-100).addDays(-1);
+        String dtValue = dt.format('yyyy-MM-dd', UserInfo.getTimezone().toString());
+
         // Simple testing filters for IsWon, RecordType, and Paid/Written Off
         String filterGroupsJSON = '[' +
                 CMT_UnitTestData_TEST.createFilterGroupRecord(filterGroupId1, 'TestFilterGroup1-IsWon+Paid') + ',' +

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -349,7 +349,8 @@ private class CRLP_RollupContact_TEST {
                 Type = 'New'
         ));
         if (tt == TestType.TestWithAlwaysRollupToPrimary) {
-            donationYears.add(orgDonationDate.year().format());
+            String donationYr = UTIL_String.removeNonNumericCharacters(orgDonationDate.year().format());
+            donationYears.add(donationYr);
         }
 
         // create 4 opps for con4 to test single result opp edge cases

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -336,7 +336,7 @@ private class CRLP_RollupContact_TEST {
 
         // create one closed won Organization opportunity to ensure it's not included in the Contact Hard Credit rollups
         Decimal orgDonationAmt = 50000;
-        Date orgDonationDate = Date.Today().addDays(-30);
+        Date orgDonationDate = Date.today().addDays(-30);
         opps.add(new Opportunity (
                 Name = 'Test Org Opp ' + c.FirstName + ' ' + c.LastName,
                 AccountId = orgAcct.Id,
@@ -348,6 +348,9 @@ private class CRLP_RollupContact_TEST {
                 npe01__Do_Not_Automatically_Create_Payment__c = true,
                 Type = 'New'
         ));
+        if (tt == TestType.TestWithAlwaysRollupToPrimary) {
+            donationYears.add(orgDonationDate.year().format());
+        }
 
         // create 4 opps for con4 to test single result opp edge cases
         Date earlyLastYear = Date.newInstance(Date.today().year()-1,1,1);

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -348,6 +348,9 @@ private class CRLP_RollupContact_TEST {
                 npe01__Do_Not_Automatically_Create_Payment__c = true,
                 Type = 'New'
         ));
+
+        // This opp will roll up to the Contact only in this test context. So only in this context, we need to ensure
+        // its year is part of the donationYears set that we assert against the Contact's Donor Streak and Years Donated.
         if (tt == TestType.TestWithAlwaysRollupToPrimary) {
             String donationYr = UTIL_String.removeNonNumericCharacters(orgDonationDate.year().format());
             donationYears.add(donationYr);


### PR DESCRIPTION
This is a speculative change that may fix some tests that were failing yesterday. Fortunately/unfortunately those tests are not failing today, which makes it difficult to know if this change is doing anything useful.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
