### PR TITLE
Make trial page layouts use the button overrides

### DIFF
--- a/unpackaged/config/trial/layouts/Contact-Contact Lightning Layout.layout
+++ b/unpackaged/config/trial/layouts/Contact-Contact Lightning Layout.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <customButtons>%%%NAMESPACE%%%Recalculate_Rollups</customButtons>
-    <customButtons>npe4__Relationships_Viewer</customButtons>
+    <customButtons>Relationships_Viewer</customButtons>
     <excludeButtons>Clone</excludeButtons>
     <excludeButtons>DisableCustomerPortal</excludeButtons>
     <excludeButtons>DisablePartnerPortal</excludeButtons>
@@ -552,7 +552,7 @@
             <sortOrder>14</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>npe4__Relationships_Viewer</actionName>
+            <actionName>Relationships_Viewer</actionName>
             <actionType>CustomButton</actionType>
             <sortOrder>15</sortOrder>
         </platformActionListItems>

--- a/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Donation Layout.layout
+++ b/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Donation Layout.layout
@@ -374,8 +374,8 @@
         <relatedList>%%%NAMESPACE%%%Account_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
-        <customButtons>npe01__Schedule_Payments</customButtons>
-        <customButtons>npe01__Writeoff_Payments</customButtons>
+        <customButtons>Schedule_Payments</customButtons>
+        <customButtons>Writeoff_Payments</customButtons>
         <fields>NAME</fields>
         <fields>npe01__Payment_Amount__c</fields>
         <fields>Payment_Status__c</fields>

--- a/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Grant Layout.layout
+++ b/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Grant Layout.layout
@@ -250,8 +250,8 @@
         <relatedList>%%%NAMESPACE%%%Account_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
-        <customButtons>npe01__Schedule_Payments</customButtons>
-        <customButtons>npe01__Writeoff_Payments</customButtons>
+        <customButtons>Schedule_Payments</customButtons>
+        <customButtons>Writeoff_Payments</customButtons>
         <fields>NAME</fields>
         <fields>npe01__Payment_Amount__c</fields>
         <fields>Payment_Status__c</fields>

--- a/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Major Gift Layout.layout
+++ b/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Major Gift Layout.layout
@@ -250,8 +250,8 @@
         <relatedList>%%%NAMESPACE%%%Account_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
-        <customButtons>npe01__Schedule_Payments</customButtons>
-        <customButtons>npe01__Writeoff_Payments</customButtons>
+        <customButtons>Schedule_Payments</customButtons>
+        <customButtons>Writeoff_Payments</customButtons>
         <fields>NAME</fields>
         <fields>npe01__Payment_Amount__c</fields>
         <fields>Payment_Status__c</fields>

--- a/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Matching Gift Layout.layout
+++ b/unpackaged/config/trial/layouts/Opportunity-___NAMESPACE___Matching Gift Layout.layout
@@ -243,8 +243,8 @@
         <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
-        <customButtons>npe01__Schedule_Payments</customButtons>
-        <customButtons>npe01__Writeoff_Payments</customButtons>
+        <customButtons>Schedule_Payments</customButtons>
+        <customButtons>Writeoff_Payments</customButtons>
         <fields>NAME</fields>
         <fields>npe01__Payment_Amount__c</fields>
         <fields>Payment_Status__c</fields>

--- a/unpackaged/config/trial/layouts/npe03__Recurring_Donation__c-npe03__Recurring Donation Layout.layout
+++ b/unpackaged/config/trial/layouts/npe03__Recurring_Donation__c-npe03__Recurring Donation Layout.layout
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
-    <customButtons>npe03__Refresh_Opportunities</customButtons>
+    <customButtons>Refresh_Opportunities</customButtons>
     <customButtons>%%%NAMESPACE%%%Recalculate_Rollups</customButtons>
     <excludeButtons>Share</excludeButtons>
     <excludeButtons>Submit</excludeButtons>


### PR DESCRIPTION
When I added the page layouts from the trial, I intended to make them refer to our button overrides so that the buttons work with unmanaged NPSP, but I missed this part.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
