### PR TITLE
Fix robot library initialization to be able to generate keyword documentation

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -66,12 +66,6 @@ tasks:
         options:
             path: unpackaged/config/delete
 
-    robot_documentation:
-        options:
-            files:
-              - tests/NPSP.py
-              - tests/NPSP.robot
-
     robot_libdoc:
         class_path: cumulusci.tasks.robotframework.RobotLibDoc
         options:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -66,6 +66,12 @@ tasks:
         options:
             path: unpackaged/config/delete
 
+    robot_documentation:
+        options:
+            files:
+              - tests/NPSP.py
+              - tests/NPSP.robot
+
     robot_libdoc:
         class_path: cumulusci.tasks.robotframework.RobotLibDoc
         options:

--- a/tests/NPSP.py
+++ b/tests/NPSP.py
@@ -755,8 +755,6 @@ class NPSP(object):
 
     def page_scroll_to_locator(self, path, *args, **kwargs):
         locator = self.get_npsp_locator(path, *args, **kwargs)
-        import sys; sys.stdout=sys.__stdout__
-        import pdb; pdb.set_trace()
         self.selenium.scroll_element_into_view(locator)
     
     def return_locator_value(self, path, *args, **kwargs): 


### PR DESCRIPTION
This includes a fix for NPSP.py; it was failing to be instantiated
when robot tries to import it when generating documentation. That is
because the __init__ tries to get a variable from a running test,
and no test is running when we generate the documentation.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
