### PR TITLE
Configure default relationships for managed flows

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -262,6 +262,8 @@ flows:
                 task: update_admin_profile
                 options:
                     managed: true
+            5:
+                task: test_data_relationships
 
     config_offsetfiscal:
         description: 'Configure an offset fiscal year'


### PR DESCRIPTION
This ensures that default relationship settings are configured for flows like install_prod that install managed NPSP. 

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
