### PR TITLE
Add configuration for MetaDeploy installation plans

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -370,6 +370,9 @@ plans:
                 task: install_managed
             3:
                 task: deploy_post
+                ui_options:
+                    first:
+                        name: NPSP Config for Salesforce Mobile App
     new_org:
         slug: trial
         title: Install NPSP Trial

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -352,3 +352,40 @@ orgs:
         enterprise:
             config_file: orgs/enterprise.json
 
+plans:
+    existing_org:
+        slug: install
+        title: Install NPSP
+        tier: primary
+        steps:
+            1:
+                flow: dependencies
+                ui_options:
+                    deploy_pre:
+                        account_record_types:
+                            name: Account Record Types
+                        opportunity_record_types:
+                            name: Opportunity Record Types
+            2:
+                task: install_managed
+            3:
+                task: deploy_post
+    new_org:
+        slug: trial
+        title: Install NPSP Trial
+        # This will be tier: unlisted once that is an option.
+        tier: additional
+        is_listed: False
+        steps:
+            1:
+                flow: dependencies
+                ui_options:
+                    deploy_pre:
+                        account_record_types:
+                            name: Account Record Types
+                        opportunity_record_types:
+                            name: Opportunity Record Types
+            2:
+                task: install_managed
+            3:
+                flow: config_managed


### PR DESCRIPTION
This adds configuration for publishing two MetaDeploy installation plans:
- `existing_org` (equivalent to the existing installer, installs NPSP but does not configure)
- `new_org` (equivalent to running the `install_prod` flow, installs NPSP with trial configuration)

Note: Using this configuration requires changes to the metadeploy publish task which are pending in https://github.com/SFDO-Tooling/CumulusCI/pull/1020

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
