### PR TITLE
Move add button from each row in list to bottom of the list

### DIFF
--- a/src/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/src/classes/ALLO_ManageAllocations_CTRL.cls
@@ -268,12 +268,9 @@ public with sharing class ALLO_ManageAllocations_CTRL {
         else if (payment!=null)
             allo.Payment__c = parentId;
 
-        //enable adding to the last row
-        if (rowNumber == null || rowNumber >= listAllo.size()-1)
-            listAllo.add(allo);
-        else
-            listAllo.add(rowNumber+1, allo);
-
+        // always add to last row
+        listAllo.add(allo);
+        
         return null;
     }
 

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -168,7 +168,7 @@
                             <th scope="col"><span class="slds-truncate">{!$ObjectType.Allocation__c.Fields.General_Accounting_Unit__c.Label}</span></th>
                             <th scope="col" width="250px"><span class="slds-truncate">{!$ObjectType.Allocation__c.Fields.Amount__c.Label}</span></th>
                             <th scope="col" width="150px"><span class="slds-truncate">{!$ObjectType.Allocation__c.Fields.Percent__c.Label}</span></th>
-                            <th scope="col" width="200px"></th>
+                            <th scope="col" width="100px"></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -206,10 +206,6 @@
                                         <span class="slds-form-element__label slds-assistive-text">Delete Row {!cnt}</span>
                                         <apex:param name="rowForDel" value="{!cnt}" assignTo="{!rowNumber}"/>
                                     </apex:commandButton>
-                                    <apex:commandButton styleClass="slds-button slds-button_neutral" value="{!$Label.alloAddRow}" id="addRowBTN" title="{!$Label.alloAddRow}" action="{!addRow}" reRender="theTable" immediate="true">
-                                        <span class="slds-form-element__label slds-assistive-text"><apex:outputText value="{!$Label.alloAddRowAtPosition}"/> {!cnt}</span>
-                                        <apex:param name="rowForNew" value="{!cnt}" assignTo="{!rowNumber}"/>
-                                    </apex:commandButton>
                                 </td>
                             </tr>
                             <apex:variable var="cnt" value="{!cnt+1}"/>
@@ -226,17 +222,16 @@
                                     </div>
                                 </div>
                             </td>
-                            <td>
-                            </td>
-                            <td>
-                                <apex:commandButton styleClass="slds-button slds-button_neutral slds-button_small" value="{!$Label.alloAddRow}" id="addRowBTN" title="{!$Label.alloAddRow}" action="{!addRow}" reRender="theTable" immediate="true" rendered="{!listAlloSize==0}">
-                                    <span class="slds-form-element__label slds-assistive-text"><apex:outputText value="{!$Label.alloAddRowAtPosition}"/> {!cnt}</span>
-                                    <apex:param name="rowForNew" value="{!cnt}" assignTo="{!rowNumber}"/>
-                                </apex:commandButton>
-                            </td>
+                            <td colspan="2"></td>
                         </tr>
                    </tbody>
                 </table>
+
+                 <!-- Add Row -->
+                <div class="slds-p-around_medium">
+                        <apex:commandLink action="{!addRow}" immediate="true" reRender="theTable" 
+                            value="{!$Label.alloAddRow}" title="{!$Label.alloAddRow}" />
+                </div>
                 <script>
                     window.initOrReload();
                 </script>

--- a/src/pages/ALLO_ManageAllocations.page
+++ b/src/pages/ALLO_ManageAllocations.page
@@ -159,7 +159,7 @@
                 parentAction="javascript:window.urlHome();" parentRecordName="{!objectName}" parentRecordAction="/{!parentId}"
                 header="{!pageTitle}" icon="custom" iconCategory="standard" cancelAction="{!cancel}"
                 saveAction="{!saveClose}" saveReRender="theForm" saveDisabled="{!OR(NOT(isSupportedObject),(opp!=null&&parentAmount==0))}"/>
-            <c:UTIL_PageMessages />
+            <c:UTIL_PageMessages id="messages"/>
             <div>
                 <apex:outputPanel id="theTable">
                 <table class="slds-table slds-table_bordered slds-table_cell-buffer" >
@@ -202,7 +202,9 @@
                                     </div>
                                 </td>
                                 <td>
-                                    <apex:commandButton styleClass="slds-button slds-button_destructive" value="{!$Label.alloDeleteRow}" id="delRowBTN" title="{!$Label.alloDeleteRow}" action="{!delRow}" reRender="theForm" immediate="true">
+                                    <apex:commandButton 
+                                        styleClass="slds-button slds-button_destructive" value="{!$Label.alloDeleteRow}" id="delRowBTN" title="{!$Label.alloDeleteRow}" 
+                                        action="{!delRow}" reRender="theTable,messages" immediate="false">
                                         <span class="slds-form-element__label slds-assistive-text">Delete Row {!cnt}</span>
                                         <apex:param name="rowForDel" value="{!cnt}" assignTo="{!rowNumber}"/>
                                     </apex:commandButton>
@@ -229,7 +231,7 @@
 
                  <!-- Add Row -->
                 <div class="slds-p-around_medium">
-                        <apex:commandLink action="{!addRow}" immediate="true" reRender="theTable" 
+                        <apex:commandLink action="{!addRow}" immediate="true" reRender="theTable, messages" 
                             value="{!$Label.alloAddRow}" title="{!$Label.alloAddRow}" />
                 </div>
                 <script>


### PR DESCRIPTION
Removed the add allocation button on each row.  Moved it to the bottom of the list and converted it to a link action instead - to be consistent with the Manage Soft Credits UX.

# Critical Changes

# Changes
- The Add Row button on the Manage Allocations page has been moved to below the list of Allocation records.

# Issues Closed
Fixes #4101

# New Metadata

# Deleted Metadata
