### PR TITLE
Copy CurrencyIsoCode from Contact to Account.

### DIFF
--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -560,6 +560,8 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
                 a.Phone = c.Phone;
                 a.Fax = c.Fax;
                 a.OwnerId = c.OwnerId;
+                if (UTIL_Currency.getInstance().isMultiCurrencyOrganization())
+                    a.CurrencyIsoCode = c.CurrencyIsoCode;
                 // only set account's billing address if address management is off.
                 // otherwise, we'll let ADDR_Contact_TDTM push the new address into the account.
                 if (!CAO_Constants.isHHAccountModel() || UTIL_CustomSettingsFacade.getContactsSettings().Household_Account_Addresses_Disabled__c) {


### PR DESCRIPTION
Hi there...

I created [an issue](https://powerofus.force.com/_ui/core/userprofile/UserProfilePage?u=0058000000BjCKl&tab=sfdc.ProfilePlatformFeed&fId=0D58000003X5b0M) on the Hub a while back, but while it got some generally positive comments it never saw any action. This is still causing me and my team pain on a regular basis, so I'd love to get it fixed.

Like [last time](https://github.com/SalesforceFoundation/Cumulus/pull/2604), I have looked through the source and had a crack at a fix, but I still don't know how to actually test this, so I haven't, I'm just looking to start a discussion and hopefully this points you in the right direction.

Basically, when a Household Account is automatically created from a Contact creation, I think the currency of the Contact should be copied to the Account. Currently when we create a Contact with (eg) AUD, the Account is created as USD (which is our org-wide default).

Thanks!