### PR TITLE
Customizable Rollups: API to Retrieve Rollup Definitions - serialization fix

### DIFF
--- a/src/classes/Callable_API.cls
+++ b/src/classes/Callable_API.cls
@@ -61,7 +61,8 @@ global with sharing class Callable_API implements System.Callable {
 
             } when 'crlp.getdefinitionsforrolluptype' {
                 CRLP_ApiService crlpApiSvc = new CRLP_ApiService();
-                return crlpApiSvc.getRollupDefinitions((String) params.get(CRLP_ApiService.PARAM_ROLLUPTYPE));
+                List<CRLP_Rollup> response = crlpApiSvc.getRollupDefinitions((String) params.get(CRLP_ApiService.PARAM_ROLLUPTYPE));
+                return JSON.serialize(response, true);
 
             } when else {
                 throw new MalformedMethodInvocationException(


### PR DESCRIPTION
After testing with the bata package, it's not possible to serialize the response when it's returned as an object that is not global. As a result, the api needs to return a serialized string rather than List<CRLP_Rollup> so that the contents can be maintained stateful in the bridge as well as written into the Big Object for persistent storage of the summaries.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
