### PR TITLE
BDI: Prevent multiple process clicks on Data Import page

### DIFF
--- a/src/pages/BDI_DataImport.page
+++ b/src/pages/BDI_DataImport.page
@@ -38,11 +38,6 @@
             dominant-baseline: middle;
             fill: #00396B;
         }
-
-        .slds-button_extension-disabled {
-            pointer-events: none;
-            cursor: default;
-        }
     </style>
 
     <script>

--- a/src/pages/BDI_DataImport.page
+++ b/src/pages/BDI_DataImport.page
@@ -38,26 +38,20 @@
             dominant-baseline: middle;
             fill: #00396B;
         }
+
+        .slds-button_extension-disabled {
+            pointer-events: none;
+            cursor: default;
+        }
     </style>
 
     <script>
-        function buttonsEnabled(enabled) {
+        function enableButton(enabled) {
             let targetButton = document.getElementById('{!$Component.idForm.idDataImportProcessButton}');
             let enableProcessButton = targetButton.setAttribute('disabled', null);
             let disableProcessButton = targetButton.setAttribute('disabled', 'disabled');
 
             enabled === true ? enableProcessButton : disableProcessButton;
-        }
-
-        function tryImportData() {
-            // Call action function to post form
-            importDataActionFunction();
-
-            // Disable button to prevent spam saving
-            buttonsEnabled(false);
-
-            // Return false to prevent the click from posting the form a second time
-            return false;
         }
     </script>
 
@@ -104,18 +98,14 @@
                                 <div class="slds-form slds-form_stacked slds-m-left_large">
                                     <div class="slds-form-element">
                                         <div class="slds-form-element__control">
-                                            <apex:actionFunction name="importDataActionFunction"
-                                                                 action="{!importData}"
-                                                                 oncomplete="buttonsEnabled(true);"
-                                                                 rerender="idForm">
-                                            </apex:actionFunction>
-
                                             <apex:commandButton value="{!$Label.bdiRunBtn}"
+                                                                action="{!importData}"
                                                                 immediate="false"
                                                                 styleClass="slds-button slds-button_brand"
                                                                 rerender="idForm"
                                                                 id="idDataImportProcessButton"
-                                                                onclick="return tryImportData();"/>
+                                                                onclick="enableButton(false)"
+                                                                oncomplete="enableButton(true)"/>
 
                                             <apex:commandButton value="{!$Label.bdiDryRunBeginButton}" action="{!startDryRun}" immediate="false" styleClass="slds-button slds-button_neutral" rendered="{!NOT(isGiftBatch)}" rerender="idForm"/>
                                             <apex:commandButton value="{!$Label.stgBtnCancel}" action="{!close}" immediate="true" styleClass="slds-button slds-button_neutral" />

--- a/src/pages/BDI_DataImport.page
+++ b/src/pages/BDI_DataImport.page
@@ -111,7 +111,6 @@
                                             </apex:actionFunction>
 
                                             <apex:commandButton value="{!$Label.bdiRunBtn}"
-                                                                action="{!importData}"
                                                                 immediate="false"
                                                                 styleClass="slds-button slds-button_brand"
                                                                 rerender="idForm"

--- a/src/pages/BDI_DataImport.page
+++ b/src/pages/BDI_DataImport.page
@@ -40,6 +40,27 @@
         }
     </style>
 
+    <script>
+        function buttonsEnabled(enabled) {
+            let targetButton = document.getElementById('{!$Component.idForm.idDataImportProcessButton}');
+            let enableProcessButton = targetButton.setAttribute('disabled', null);
+            let disableProcessButton = targetButton.setAttribute('disabled', 'disabled');
+
+            enabled === true ? enableProcessButton : disableProcessButton;
+        }
+
+        function tryImportData() {
+            // Call action function to post form
+            importDataActionFunction();
+
+            // Disable button to prevent spam saving
+            buttonsEnabled(false);
+
+            // Return false to prevent the click from posting the form a second time
+            return false;
+        }
+    </script>
+
     <div class="slds-scope slds-p-bottom_x-large">
         <apex:form id="idForm" html-novalidate="novalidate" styleClass="slds-p-bottom_x-large">
 
@@ -83,7 +104,20 @@
                                 <div class="slds-form slds-form_stacked slds-m-left_large">
                                     <div class="slds-form-element">
                                         <div class="slds-form-element__control">
-                                            <apex:commandButton value="{!$Label.bdiRunBtn}" action="{!importData}" immediate="false" styleClass="slds-button slds-button_brand" rerender="idForm"/>
+                                            <apex:actionFunction name="importDataActionFunction"
+                                                                 action="{!importData}"
+                                                                 oncomplete="buttonsEnabled(true);"
+                                                                 rerender="idForm">
+                                            </apex:actionFunction>
+
+                                            <apex:commandButton value="{!$Label.bdiRunBtn}"
+                                                                action="{!importData}"
+                                                                immediate="false"
+                                                                styleClass="slds-button slds-button_brand"
+                                                                rerender="idForm"
+                                                                id="idDataImportProcessButton"
+                                                                onclick="return tryImportData();"/>
+
                                             <apex:commandButton value="{!$Label.bdiDryRunBeginButton}" action="{!startDryRun}" immediate="false" styleClass="slds-button slds-button_neutral" rendered="{!NOT(isGiftBatch)}" rerender="idForm"/>
                                             <apex:commandButton value="{!$Label.stgBtnCancel}" action="{!close}" immediate="true" styleClass="slds-button slds-button_neutral" />
                                         </div>


### PR DESCRIPTION
- Bug Fix: Add Action and JS functions to handle 'Process Button' disable and form post

# Critical Changes

# Changes
- 'Begin Data Import Process' button will grey out and be disabled while form is posting.

# Issues Closed

# New Metadata

# Deleted Metadata
