### PR TITLE
CRLP: ExecuteRollups Api Placeholder

### DIFF
--- a/src/classes/CRLP_ApiService.cls
+++ b/src/classes/CRLP_ApiService.cls
@@ -37,6 +37,7 @@
 public inherited sharing class CRLP_ApiService {
 
     public static final String PARAM_ROLLUPTYPE = 'RollupType';
+    public static final String PARAM_ROLLUPDEFS = 'RollupDefinitions';
 
 
     /**

--- a/src/classes/Callable_API.cls
+++ b/src/classes/Callable_API.cls
@@ -64,6 +64,9 @@ global with sharing class Callable_API implements System.Callable {
                 List<CRLP_Rollup> response = crlpApiSvc.getRollupDefinitions((String) params.get(CRLP_ApiService.PARAM_ROLLUPTYPE));
                 return JSON.serialize(response, true);
 
+            } when 'crlp.executerollups' {  // PLACEHOLDER CODE ONLY
+                return params.get(CRLP_ApiService.PARAM_ROLLUPDEFS);
+
             } when else {
                 throw new MalformedMethodInvocationException(
                     String.format(System.Label.CallableApiMethodNotImplemented, new List<String> { action })


### PR DESCRIPTION
Create a placeholder api action for `CRLP.ExecuteRollups` that the DSO Bridge Rollup Engine work item can use as a reference point. This will be merged into master so that the NPSP Beta includes the new api. Actual work on this api will begin in the current sprint. No release notes necessary for this.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
