### PR TITLE
Making the BGE Donation Selector global

### DIFF
--- a/src/aura/BGE_DonationSelector/BGE_DonationSelector.cmp
+++ b/src/aura/BGE_DonationSelector/BGE_DonationSelector.cmp
@@ -35,7 +35,8 @@
   @description Component used to select an open donation for a given donor in Batch Gift Entry.
 -->
 
-<aura:component controller="BGE_DataImportBatchEntry_CTRL">
+<aura:component controller="BGE_DataImportBatchEntry_CTRL"
+                access="global">
     <!--Public Attributes-->
     <aura:attribute name="selectedDonation" type="SObject" description="Stored selected open donation object. Can also be null or empty." access="public" />
     <aura:attribute name="unpaidPayments" type="List" description="List of unpaid Payments" access="public" />


### PR DESCRIPTION
- Making the BGE Donation Selector component global so GEM can access it from Single Gift Entry.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
