### PR TITLE
Error Notifier Job Fixes

### DIFF
--- a/src/classes/ERR_Handler.cls
+++ b/src/classes/ERR_Handler.cls
@@ -108,30 +108,37 @@ public class ERR_Handler {
     public static Errors getErrors(List<Object> dmlResults, List<SObject> sObjects) {
         Errors errors = new Errors();
 
-        if (dmlResults != null) {
-            for (Integer i=0; i<dmlResults.size(); i++) {
-                Boolean isSuccess = true;
-                if (dmlResults[i] instanceof Database.SaveResult) {
-                    isSuccess = ((Database.SaveResult)dmlResults[i]).isSuccess();
-                } else if (dmlResults[i] instanceof Database.DeleteResult) {
-                    isSuccess = ((Database.DeleteResult)dmlResults[i]).isSuccess();
-                } else if (dmlResults[i] instanceof Database.UndeleteResult) {
-                    isSuccess = ((Database.UndeleteResult)dmlResults[i]).isSuccess();
-                }
+        if (dmlResults == null || dmlResults.isEmpty()) {
+            return errors;
+        }
+        for (Integer i=0; i<dmlResults.size(); i++) {
+            Boolean isSuccess = true;
+            if (dmlResults[i] instanceof Database.SaveResult) {
+                isSuccess = ((Database.SaveResult)dmlResults[i]).isSuccess();
+            } else if (dmlResults[i] instanceof Database.DeleteResult) {
+                isSuccess = ((Database.DeleteResult)dmlResults[i]).isSuccess();
+            } else if (dmlResults[i] instanceof Database.UndeleteResult) {
+                isSuccess = ((Database.UndeleteResult)dmlResults[i]).isSuccess();
+            }
 
-                if (!isSuccess) {
-                    errors.errorsExist = true;
+            if (!isSuccess) {
+                errors.errorsExist = true;
 
-                    //Creating error object
-                    Error__c err = createError(dmlResults[i], sObjects[i].getSObjectType().getDescribe().getName(), sObjects[i].Id);
-                    errors.errorRecords.add(err);
+                //Creating error object
+                Error__c err = createError(
+                    dmlResults[i],
+                    sObjects[i].getSObjectType().getDescribe().getName(),
+                    sObjects[i].Id,
+                    null
+                );
+                errors.errorRecords.add(err);
 
-                    //We cannot use addError on the record here, because if we do, the whole transaction will be rolled back, and
-                    //no error record will be saved, or error notification sent.
+                //We cannot use addError on the record here, because if we do, the whole transaction will be rolled back, and
+                //no error record will be saved, or error notification sent.
 
-                    //Displaying an error message to the user
-                    if(ApexPages.currentPage() != null)
-                       ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, err.Full_Message__c));
+                //Displaying an error message to the user
+                if (ApexPages.currentPage() != null) {
+                    ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, err.Full_Message__c));
                 }
             }
         }
@@ -140,14 +147,14 @@ public class ERR_Handler {
 
     /*******************************************************************************************************
     * @description Processes the results of a group DML operations caused by a batch, future, or queued job and performed
-    * 				using the Database class to determine if errors occurred. It does not store errors or send error email
-    * 				notifications. These operations should be performed after the rollback.
+    * using the Database class to determine if errors occurred. It does not store errors or send error email
+    * notifications. These operations should be performed after the rollback.
     *
     * @param dmlResults The results of a DML batch operation performed using the Database class.
     * @param sObjects The records the DML operation was performed on.
     * @return Errors The errors with a single list that occurred during a batch DML operation performed using the Database class.
     */
-    public static Errors getJobErrors(List<Object> dmlResults, List<SObject> sObjects, string context) {
+    public static Errors getJobErrors(List<Object> dmlResults, List<SObject> sObjects, String context) {
         Errors errors = new Errors();
         List<String> errorsFound = new List<String>();
 
@@ -257,7 +264,7 @@ public class ERR_Handler {
     */
     public static void processError(Exception e, String context) {
         if (e != null) {
-            Error__c error = createError(e);
+            Error__c error = createError(e, context);
             processErrors(new Error__c[]{error}, context);
         }
     }
@@ -274,7 +281,7 @@ public class ERR_Handler {
     public static void processErrors(List<Exception> exceptions, ERR_Handler_API.Context context) {
         List<Error__c> errors = new List<Error__c>();
         for (Exception e : exceptions) {
-            errors.add(createError(e));
+            errors.add(createError(e, context.name()));
         }
         
         processErrors(errors, context.name());
@@ -297,6 +304,7 @@ public class ERR_Handler {
                 UTIL_Debug.debug('**** Storing errorRecords: ' + errorRecords);
                 Database.insert(errorRecords, false);
             }
+
             //ERR_Notifier takes care of checking the settings itself.
             ERR_Notifier.sendErrorNotifications(context);
         }
@@ -305,13 +313,15 @@ public class ERR_Handler {
     /*******************************************************************************************************
     * @description Creates an error record from an exception.
     * @param e Exception to create error record from.
+    * @param context The context the exception was raised on.
     * @return Error__c Error record.
     */
-    private static Error__c createError(Exception e) {
+    private static Error__c createError(Exception e, String context) {
         Error__c error = new Error__c();
         error.Datetime__c = System.now();
         error.Error_Type__c = e.getTypeName();
         error.Full_Message__c = e.getMessage();
+        error.Context_Type__c = context;
 
         //Putting it into a local string to see if that helps storing the stack trace when we
         //are in a managed package.
@@ -335,12 +345,14 @@ public class ERR_Handler {
     *               the different DML operations that the Database class can perform don't have a common parent.
     * @param objectType The name of the type of object that caused the error.
     * @param objId The id of the record that caused the error.
+    * @param context The context the exception was raised on.
     * @return The error record.
     */
-    private static Error__c createError(Object result, string objectType, id objId) {
+    private static Error__c createError(Object result, String objectType, Id objId, String context) {
         Error__c error = new Error__c();
         error.Datetime__c = System.now();
         error.Object_Type__c = objectType;
+        error.Context_Type__c = context;
 
         if (result instanceof Database.SaveResult) {
             Database.SaveResult saveResult = (Database.SaveResult) result;
@@ -365,6 +377,7 @@ public class ERR_Handler {
     /*******************************************************************************************************
     * @description Creates a single error record from a Database class DML operation in a batch, future or queued job.
     * @param message The full message of all the errors for a given job and compiled IDs.
+    * @param context The context the exception was raised on.
     * @param objectType The type of all records in the job, only to be passed in if they all match.
     * @return The error record.
     */
@@ -383,6 +396,7 @@ public class ERR_Handler {
     /*******************************************************************************************************
     * @description Creates a single error record from a Database class DML operation in a batch, future or queued job.
     * @param message The full message of all the errors for a given job and compiled IDs.
+    * @param context The context the exception was raised on.
     * @return The error record.
     */
     private static Error__c createJobError(String message, String context) {

--- a/src/classes/ERR_Handler_TEST.cls
+++ b/src/classes/ERR_Handler_TEST.cls
@@ -37,30 +37,31 @@
 public class ERR_Handler_TEST {
     
     private static Id chatterGroupId;
+
     /*******************************************************************************************************
     * @description test setup of error notifications via chatter
     */
     private static void setupWithChatterNotifications() {
-    	// all these tests are about testing our error handling, so we can't let the assert interfere
-    	TDTM_TriggerHandler.suppressDebugAssertAfterErrorLogging = true;        
-    	
-    	UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c(
+        // all these tests are about testing our error handling, so we can't let the assert interfere
+        TDTM_TriggerHandler.suppressDebugAssertAfterErrorLogging = true;
+
+        UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c(
             npe01__Account_Processor__c = CAO_Constants.HH_ACCOUNT_PROCESSOR));
-    	UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(new npo02__Households_Settings__c (
+        UTIL_CustomSettingsFacade.getHouseholdsSettingsForTests(new npo02__Households_Settings__c (
             npo02__Household_Rules__c = HH_Households.ALL_PROCESSOR, npo02__Enable_Opp_Rollup_Triggers__c = true));
-    	
-    	if(Schema.SObjectType.User.isFeedEnabled()) {
-	    	SObject chatterGroup = (SObject)System.Type.forName('CollaborationGroup').newInstance();
-	    	chatterGroup.put('Name', 'ChatterTestGroup');
-	    	chatterGroup.put('CollaborationType', 'Private');
-	    	insert chatterGroup;
-	    	chatterGroupId = chatterGroup.Id;
-	    	UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(Error_Notifications_On__c = true, 
+
+        if(Schema.SObjectType.User.isFeedEnabled()) {
+            SObject chatterGroup = (SObject)System.Type.forName('CollaborationGroup').newInstance();
+            chatterGroup.put('Name', 'ChatterTestGroup');
+            chatterGroup.put('CollaborationType', 'Private');
+            insert chatterGroup;
+            chatterGroupId = chatterGroup.Id;
+            UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(Error_Notifications_On__c = true,
             Error_Notifications_To__c = chatterGroup.Id, Store_Errors_On__c = true, Respect_Duplicate_Rule_Settings__c = true));
-    	} else {
-    		UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(Error_Notifications_On__c = true, 
+        } else {
+            UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(Error_Notifications_On__c = true,
             Error_Notifications_To__c = null, Store_Errors_On__c = true, Respect_Duplicate_Rule_Settings__c = true));
-    	}
+        }
     }
     /*******************************************************************************************************
     * @description test setup of error notifications via email
@@ -84,24 +85,24 @@ public class ERR_Handler_TEST {
      * ERR_Handler.processError() and verify that the error was posted to
      * Chatter.
      */
-    public testmethod static void errorsStoredInDbTdtmCustomConfigPostToChatter() {
-    	setupWithChatterNotifications();
-    	
+    private static testMethod void errorsStoredInDbTdtmCustomConfigPostToChatter() {
+        setupWithChatterNotifications();
+
         StringException testException = new StringException('Test Exception');
         ERR_Handler.processError(testException, ERR_Handler_API.Context.TDTM);
 
-        List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c, Posted_in_Chatter__c from Error__c];
+        List<Error__c> errors = [SELECT Id, Full_Message__c, Stack_Trace__c, Posted_in_Chatter__c FROM Error__c];
         System.assertEquals(1, errors.size());
         UTIL_Debug.debug('****Errors: ' + JSON.serializePretty(errors));
         
         //Verify error was posted to chatter group
         if(Schema.SObjectType.User.isFeedEnabled()) {
-	        List<SObject> chatterPosts = Database.query('select Title from FeedItem where ParentId = :chatterGroupId');
-	        System.assertEquals(1, chatterPosts.size());
-	        System.assertEquals('Salesforce Error', chatterPosts[0].get('Title'));
-	        for(Error__c error : errors) {
-	        	System.assertEquals(true, error.Posted_in_Chatter__c);
-	        }
+            List<SObject> chatterPosts = Database.query('SELECT Title FROM FeedItem where ParentId = :chatterGroupId');
+            System.assertEquals(1, chatterPosts.size());
+            System.assertEquals('Salesforce Error', chatterPosts[0].get('Title'));
+            for(Error__c error : errors) {
+                System.assertEquals(true, error.Posted_in_Chatter__c);
+            }
         }
     }
     
@@ -109,7 +110,7 @@ public class ERR_Handler_TEST {
      * @description Trigger error notification processing by calling
      * ERR_Handler.processError() and verify that the error was emailed
      */
-    public testmethod static void errorsStoredInDbTdtmCustomConfigEmailErrors() {
+    private static testMethod void errorsStoredInDbTdtmCustomConfigEmailErrors() {
         setupWithEmailNotifications();
 
         Test.startTest();
@@ -119,7 +120,7 @@ public class ERR_Handler_TEST {
 
         Test.stopTest();
 
-        List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c, Email_Sent__c from Error__c];
+        List<Error__c> errors = [SELECT Id, Full_Message__c, Stack_Trace__c, Email_Sent__c FROM Error__c];
         System.assertEquals(1, errors.size());
         
         //Verify error was emailed
@@ -132,7 +133,7 @@ public class ERR_Handler_TEST {
     * @description This is the same test called testErrorRecordCreation in the REL_Relationships_TEST class,
     * but using simple insert instead of Database.insert
     */
-    static testMethod void errorStoredInDatabaseFromInsert() {
+    private static testMethod void errorStoredInDatabaseFromInsert() {
         setupWithChatterNotifications();
         
         Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', Title = 'VP1');
@@ -146,30 +147,30 @@ public class ERR_Handler_TEST {
         } catch (exception ex) {
             ERR_Handler.processError(ex, ERR_Handler_API.Context.REL);
         }
-        //assert an error record was created - Required fields are missing: [npe4__Contact__c]
-        //npe4__Contact__c is missing from the reciprocal relationship that gets automatically created.
-        system.assertEquals(1, [select count() from Error__c]);
+        // assert an error record was created - Required fields are missing: [npe4__Contact__c]
+        // from the reciprocal relationship that gets automatically created.
+        System.assertEquals(1, [SELECT count() FROM Error__c]);
         
         //update relationship - this will create the missing npe4__Contact__c field
         relationships[0].npe4__RelatedContact__c = contact1.id;
         Database.SaveResult[] updateResults = Database.update(relationships, false);
-        system.assertNotEquals(null, relationships[0].npe4__Contact__c);
+        System.assertNotEquals(null, relationships[0].npe4__Contact__c);
         
         //get errors
         ERR_Handler.Errors errors = ERR_Handler.getErrors(updateResults, (List<SObject>)relationships);
         //we still get an error, because of the Related_Contact_Do_Not_Change validation rule on Relationship
-        system.assertEquals(true, errors.errorsExist);
-        system.assertEquals(1, errors.errorRecords.size());
+        System.assertEquals(true, errors.errorsExist);
+        System.assertEquals(1, errors.errorRecords.size());
 
         //assert no additional error record was created on update
-        system.assertEquals(1, [select count() from Error__c]);
+        System.assertEquals(1, [SELECT count() FROM Error__c]);
     }
 
     /*******************************************************************************************************
     * @description Testing that DML changes are properly rolled back in a controller that adheres to our
     * error-handling design, and that the error is properly stored.
     */
-    static testMethod void controllerWithManualRollback() {
+    private static testMethod void controllerWithManualRollback() {
         setupWithChatterNotifications();
         
         ERR_Handler_CTRL_TEST controller = new ERR_Handler_CTRL_TEST();
@@ -179,23 +180,27 @@ public class ERR_Handler_TEST {
         Test.stopTest();
         
         //assert contact record creation was rolled back
-        system.assertEquals(0, [select count() from Contact]);
+        System.assertEquals(0, [SELECT count() FROM Contact]);
         
         //assert relationship record was not stored
-        system.assertEquals(0, [select count() from npe4__Relationship__c]);
+        System.assertEquals(0, [SELECT count() FROM npe4__Relationship__c]);
          
         //assert an error record was created - Required fields are missing: [npe4__Contact__c]
-        system.assertEquals(1, [select count() from Error__c]);    
+        System.assertEquals(1, [SELECT count() FROM Error__c]);
     }
+
     /*******************************************************************************************************
-    * @description Test that an inactive user won't receive email as the primary error user 
+    * @description Test that error email are still sent to other system admins if the assigned user is not active 
     */
-    static testMethod void testInactiveUserEmailBehavior() {
+    private static testMethod void shouldStillSendEmailsForInactiveUser() {
         String un = System.now().getTime() + '@testerson.com';
         User u = UTIL_UnitTestData_TEST.createNewInactiveUserForTests(un);
 
-        UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(Error_Notifications_On__c = true, 
-            Error_Notifications_To__c = u.Id, Store_Errors_On__c = true, Respect_Duplicate_Rule_Settings__c = true));
+        UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(
+            Error_Notifications_On__c = true, 
+            Error_Notifications_To__c = u.Id, 
+            Store_Errors_On__c = true, 
+            Respect_Duplicate_Rule_Settings__c = true));
  
         Test.startTest();
 
@@ -204,12 +209,12 @@ public class ERR_Handler_TEST {
 
         Test.stopTest();
 
-        List<Error__c> errors = [select Id, Full_Message__c, Stack_Trace__c, Email_Sent__c from Error__c];
+        List<Error__c> errors = [SELECT Id, Full_Message__c, Stack_Trace__c, Email_Sent__c FROM Error__c];
         System.assertEquals(1, errors.size());
 
         //Verify error was NOT emailed
         for(Error__c error : errors) {
-            System.assertEquals(false, error.Email_Sent__c);
+            System.assertEquals(true, error.Email_Sent__c);
         }
     }
 }

--- a/src/classes/ERR_Handler_TEST.cls
+++ b/src/classes/ERR_Handler_TEST.cls
@@ -34,7 +34,7 @@
 * @group ErrorHandling
 */
 @isTest
-public class ERR_Handler_TEST {
+private class ERR_Handler_TEST {
     
     private static Id chatterGroupId;
 
@@ -63,6 +63,7 @@ public class ERR_Handler_TEST {
             Error_Notifications_To__c = null, Store_Errors_On__c = true, Respect_Duplicate_Rule_Settings__c = true));
         }
     }
+
     /*******************************************************************************************************
     * @description test setup of error notifications via email
     */
@@ -85,13 +86,15 @@ public class ERR_Handler_TEST {
      * ERR_Handler.processError() and verify that the error was posted to
      * Chatter.
      */
-    private static testMethod void errorsStoredInDbTdtmCustomConfigPostToChatter() {
+    @IsTest
+    private static void errorsStoredInDbTdtmCustomConfigPostToChatter() {
         setupWithChatterNotifications();
 
         StringException testException = new StringException('Test Exception');
         ERR_Handler.processError(testException, ERR_Handler_API.Context.TDTM);
 
-        List<Error__c> errors = [SELECT Id, Full_Message__c, Stack_Trace__c, Posted_in_Chatter__c FROM Error__c];
+        List<Error__c> errors = getErrors();
+
         System.assertEquals(1, errors.size());
         UTIL_Debug.debug('****Errors: ' + JSON.serializePretty(errors));
         
@@ -110,7 +113,8 @@ public class ERR_Handler_TEST {
      * @description Trigger error notification processing by calling
      * ERR_Handler.processError() and verify that the error was emailed
      */
-    private static testMethod void errorsStoredInDbTdtmCustomConfigEmailErrors() {
+    @IsTest
+    private static void errorsStoredInDbTdtmCustomConfigEmailErrors() {
         setupWithEmailNotifications();
 
         Test.startTest();
@@ -120,12 +124,13 @@ public class ERR_Handler_TEST {
 
         Test.stopTest();
 
-        List<Error__c> errors = [SELECT Id, Full_Message__c, Stack_Trace__c, Email_Sent__c FROM Error__c];
+        List<Error__c> errors = getErrors();
         System.assertEquals(1, errors.size());
         
         //Verify error was emailed
         for(Error__c error : errors) {
             System.assertEquals(true, error.Email_Sent__c);
+            System.assertEquals(ERR_Handler_API.Context.TDTM.name(), error.Context_Type__c);
         }
     }
 
@@ -133,7 +138,8 @@ public class ERR_Handler_TEST {
     * @description This is the same test called testErrorRecordCreation in the REL_Relationships_TEST class,
     * but using simple insert instead of Database.insert
     */
-    private static testMethod void errorStoredInDatabaseFromInsert() {
+    @IsTest
+    private static void errorStoredInDatabaseFromInsert() {
         setupWithChatterNotifications();
         
         Contact contact1 = new Contact(FirstName = 'test', LastName = 'testerson1', Title = 'VP1');
@@ -170,7 +176,8 @@ public class ERR_Handler_TEST {
     * @description Testing that DML changes are properly rolled back in a controller that adheres to our
     * error-handling design, and that the error is properly stored.
     */
-    private static testMethod void controllerWithManualRollback() {
+    @IsTest
+    private static void controllerWithManualRollback() {
         setupWithChatterNotifications();
         
         ERR_Handler_CTRL_TEST controller = new ERR_Handler_CTRL_TEST();
@@ -192,7 +199,8 @@ public class ERR_Handler_TEST {
     /*******************************************************************************************************
     * @description Test that error email are still sent to other system admins if the assigned user is not active 
     */
-    private static testMethod void shouldStillSendEmailsForInactiveUser() {
+    @IsTest
+    private static void shouldStillSendEmailsForInactiveUser() {
         String un = System.now().getTime() + '@testerson.com';
         User u = UTIL_UnitTestData_TEST.createNewInactiveUserForTests(un);
 
@@ -209,12 +217,30 @@ public class ERR_Handler_TEST {
 
         Test.stopTest();
 
-        List<Error__c> errors = [SELECT Id, Full_Message__c, Stack_Trace__c, Email_Sent__c FROM Error__c];
+        List<Error__c> errors = getErrors();
         System.assertEquals(1, errors.size());
 
         //Verify error was NOT emailed
         for(Error__c error : errors) {
             System.assertEquals(true, error.Email_Sent__c);
+            System.assertEquals(ERR_Handler_API.Context.TDTM.name(), error.Context_Type__c);
         }
+    }
+
+    // Helpers
+    ////////////
+
+    /**
+     * @description Helper method to retrieve all error records
+     */
+    private static List<Error__c> getErrors() {
+        return [SELECT Id,
+                Full_Message__c,
+                Stack_Trace__c,
+                Email_Sent__c,
+                Posted_in_Chatter__c,
+                Context_Type__c
+            FROM Error__c
+        ];
     }
 }

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -38,9 +38,19 @@ public class ERR_Notifier {
 
     /** @description Filtering options to reduce the number of records processed during the notify job */
     @TestVisible
-    private static Integer MAX_RECORDS = 5000;
+    private static Integer MAX_RECORDS = 500;
     @TestVisible
     private static Datetime MAX_AGE_FOR_ERRORS = System.now().addHours(-48);
+
+    /** @description Maximum Heap Storage that will be used to build the message/post body */
+    private Decimal MAX_HEAP_LIMIT {
+        get {
+            if (MAX_HEAP_LIMIT == null) {
+                MAX_HEAP_LIMIT = (Limits.getLimitHeapSize() * 0.95);
+            }
+            return MAX_HEAP_LIMIT;
+        } set;
+    }
 
     /** @description Global error notification settings used in NPSP Settings and here */
     public static final String ERROR_NOTIFICATION_USER_PREFIX = USER_UserService.OBJECT_ID_PREFIX_USER;
@@ -241,6 +251,9 @@ public class ERR_Notifier {
         bodyString += '\n\nErrors:';
         Integer i = 1;
         for (Error__c error : errorList) {
+            if (isNearHeapLimit()) {
+                break;
+            }
             bodyString += '\n\n----------\n Error #' + i + ': \n' + buildErrorMessageBody(error);
             i++;
         }
@@ -259,8 +272,8 @@ public class ERR_Notifier {
     }
 
     /**********************************************************************************************
-    * @description Post a message to Chatter with information about all the existing error records
-    * that were not already posted.
+    * @description Post one message per error to Chatter with all details on the error message.
+    * error records that were not already posted.
     * @param chatterGroupId The ID of the Chatter group to post to.
     * @return void
     */
@@ -281,6 +294,9 @@ public class ERR_Notifier {
 
             List<SObject> postsToInsert = new List<SObject>();
             for (Error__c error : errors) {
+                if (isNearHeapLimit()) {
+                    break;
+                }
                 postsToInsert.add(createChatterPost(error, collaborationGroup.Id));
                 error.Posted_in_Chatter__c = true;
             }
@@ -359,11 +375,27 @@ public class ERR_Notifier {
             ];
     }
 
+    /**
+     * @description Retrieve the specified email for the notification User. Returns NULL if the
+     * user is not active
+     * @param userId
+     * @return Email (or null)
+     */
     private String getUserEmail(Id userId) {
         List<User> users = [SELECT Email FROM User WHERE Id = :userId AND IsActive = TRUE LIMIT 1];
         if (!users.isEmpty()) {
             return users[0].Email;
         }
         return null;
+    }
+
+    /**
+    * @description Just in case the size of the Error__c records (LOB fields) plus the size of
+    * the created Email Message Body or Chatter Post Body is within 95% of the total heap available
+    * stop building the message/post body and send/post with the content as is. This avoids an
+    * untrappable limit exception.
+    */
+    private Boolean isNearHeapLimit() {
+        return (Limits.getHeapSize() >= MAX_HEAP_LIMIT);
     }
 }

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -246,8 +246,11 @@ public class ERR_Notifier {
         }
 
         if (errorNotifRecipient != ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS) {
-            bodyString += '\n\nNOTE: The specified Error Recipient UserId (' + errorNotifRecipient + ') is not an ' +
-                'active User in this Salesforce org';
+            String userEmail = getUserEmail(errorNotifRecipient);
+            if (userEmail == null) {
+                bodyString += '\n\nNOTE: The specified Error Recipient UserId (' + errorNotifRecipient + ') is not an ' +
+                    'active User in this Salesforce org';
+            }
         }
 
         mail.setPlainTextBody(bodyString);

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -106,22 +106,27 @@ public class ERR_Notifier {
 
     /**********************************************************************************************
      * @description Using the provided error notification user id (or 'All System Admins') or gets
-     * all system admin email addresses
+     * all system admin email addresses. If the specified user is inactive, send the notification
+     * to all System Admins
      * @param errorNotifRecipient Id or Null
      * @return List<Email>
      */
+    @TestVisible
     private List<String> getErrorEmailRecipients(String errorNotifRecipient) {
         List<String> recipientsList = new List<String>();
         Boolean isUserId = errorNotifRecipient instanceof Id
                 && errorNotifRecipient.startsWith(ERROR_NOTIFICATION_USER_PREFIX);
 
         if (isUserId) {
-            List<User> users = [SELECT Email FROM User WHERE Id = :errorNotifRecipient AND IsActive = TRUE LIMIT 1];
-            if (!users.isEmpty()) {
-                recipientsList.add(users[0].Email);
+            String userEmail = getUserEmail(errorNotifRecipient);
+            if (userEmail != null) {
+                recipientsList.add(userEmail);
+            } else {
+                errorNotifRecipient = ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS;
             }
+        }
 
-        } else if (errorNotifRecipient == ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS) {
+        if (errorNotifRecipient == ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS) {
             recipientsList.addAll(getSystemAdminEmails());
         }
 
@@ -212,7 +217,11 @@ public class ERR_Notifier {
     * @param recipientsList The list of email recipients.
     * @return 
     */
+    @TestVisible
     private Messaging.SingleEmailMessage createEmailMessage(String context, List<Error__c> errorList, List<String> recipientsList) {
+        Error_Settings__c errorSettings = UTIL_CustomSettingsFacade.getErrorSettings();
+        String errorNotifRecipient = errorSettings.Error_Notifications_To__c;
+
         Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
         mail.setUseSignature(false);
         mail.setReplyTo(EMAIL_REPLY_TO);
@@ -234,6 +243,11 @@ public class ERR_Notifier {
         for (Error__c error : errorList) {
             bodyString += '\n\n----------\n Error #' + i + ': \n' + buildErrorMessageBody(error);
             i++;
+        }
+
+        if (errorNotifRecipient != ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS) {
+            bodyString += '\n\nNOTE: The specified Error Recipient UserId (' + errorNotifRecipient + ') is not an ' +
+                'active User in this Salesforce org';
         }
 
         mail.setPlainTextBody(bodyString);
@@ -340,5 +354,13 @@ public class ERR_Notifier {
                 ORDER BY CreatedDate ASC
                 LIMIT :MAX_RECORDS
             ];
+    }
+
+    private String getUserEmail(Id userId) {
+        List<User> users = [SELECT Email FROM User WHERE Id = :userId AND IsActive = TRUE LIMIT 1];
+        if (!users.isEmpty()) {
+            return users[0].Email;
+        }
+        return null;
     }
 }

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -36,21 +36,36 @@
 */
 public class ERR_Notifier {
 
+    /** @description Filtering options to reduce the number of records processed during the notify job */
+    private static final Integer MAX_RECORDS = 5000;
+    private static final Datetime MAX_AGE_FOR_ERRORS = System.now().addHours(-48);
+
+    /** @description Global email constants used for all outbound (system) emails */
+    public static final String EMAIL_SYSTEM_ERRORS_TO = 'errors@salesforce.org';
+    public static final String EMAIL_REPLYTO = 'donotreply@salesforce.org';
+    public static final String EMAIL_SENDER_NAME = 'Nonprofit Success Pack';
+
+    /** @description the subject for errors sent out of this service only */
+    private static final String EMAIL_SUBJECT = 'Salesforce Error';
+
+    public static final String ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS = 'All Sys Admins';
+
     public static NotificationOptions notificationOptions = new NotificationOptions();
     
-    /*******************************************************************************************************
+    /*******************************************************ø************************************************
     * @description Inner class with the 3 types of notification options: user, chatter group, and all system
-    *              administrators.
+    * administrators.
     */
     public class NotificationOptions {
-        public final String sysAdmins = 'All Sys Admins';
-        public final String user = '005';  //specific user (should be a system admin)
-        public final String chatterGroup = '0F9'; //chatter group
+        public final String sysAdmins = ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS;
+        public final String userPrefix = USER_UserService.OBJECT_ID_PREFIX_USER;
+        public final String chatterGroup = CollaborationGroup.SObjectType.getDescribe().getKeyPrefix();
     }
 
     /*******************************************************************************************************
-    * @description Sends error notifications to the receivers specified in the settings, if error notifications are enabled, with
-    *              all the existing error records that have not been included in previous error notifications.
+    * @description Sends error notifications to the receivers specified in the settings, if error
+    * notifications are enabled, with all the existing error records that have not been included in
+    * previous error notifications.
     * @param context The context that triggered the error notification.
     * @return void
     */
@@ -61,25 +76,50 @@ public class ERR_Notifier {
 
         if (errorSettings.Error_Notifications_On__c == true && errorNotifRecipient != null) {
 
-            //We will post to chatter, if enabled
-            if(errorNotifRecipient instanceof id && errorNotifRecipient.startsWith(NotificationOptions.chatterGroup) 
-            && Schema.SObjectType.User.isFeedEnabled()) {
-                postErrorsToChatter(errorNotifRecipient);
-            //We will send email
-            } else {
-                List<String> sendList = new List<String>();
-                if (errorNotifRecipient instanceof id && errorNotifRecipient.startsWith(NotificationOptions.user)) {
-                    List<User> useremaillist = new List<User>();
-                    useremaillist = [SELECT email FROM User WHERE id = :errorNotifRecipient AND isActive = true];
-                    for (User u : useremaillist)
-                        sendList.add(u.email);
-                } else if(errorNotifRecipient == NotificationOptions.sysAdmins) {
-                    sendList.addAll(getSystemAdminEmails());
-                }
+            ERR_Notifier notifierService = new ERR_Notifier();
 
-                sendEmailNotifications(context, sendList);
+            Boolean isChatterGroup = errorNotifRecipient instanceof Id
+                    && errorNotifRecipient.startsWith(notificationOptions.chatterGroup);
+
+            if (isChatterGroup && Schema.SObjectType.User.isFeedEnabled()) {
+
+                notifierService.postErrorsToChatter(errorNotifRecipient);
+
+            } else {
+
+                notifierService.sendEmailNotifications(context,
+                        notifierService.getErrorEmailRecipients(errorNotifRecipient));
             }
         }
+    }
+
+    // ====================== HELPER METHODS FOR ERROR NOTIFICATION SERVICE =========================
+
+    /** @description Private constructor so the class cannot be instantiated outside of this class */
+    @TestVisible
+    private ERR_Notifier() {}
+
+    /**
+     * @description Using the provided error notification user id (or 'All System Admins') or gets
+     * all system admin email addresses
+     * @param errorNotifRecipient Id or Null
+     * @return List<Email>
+     */
+    private List<String> getErrorEmailRecipients(String errorNotifRecipient) {
+        List<String> recipientsList = new List<String>();
+        Boolean isUserId = errorNotifRecipient instanceof Id && errorNotifRecipient.startsWith(notificationOptions.userPrefix);
+
+        if (isUserId) {
+            List<User> users = [SELECT Email FROM User WHERE Id = :errorNotifRecipient AND IsActive = TRUE LIMIT 1];
+            if (!users.isEmpty()) {
+                recipientsList.add(users[0].Email);
+            }
+
+        } else if (errorNotifRecipient == notificationOptions.sysAdmins) {
+            recipientsList.addAll(getSystemAdminEmails());
+        }
+
+        return recipientsList;
     }
 
     /*******************************************************************************************************
@@ -87,7 +127,7 @@ public class ERR_Notifier {
     * @return List<String> Emails
     */
     @TestVisible
-    private static List<String> getSystemAdminEmails() {
+    private List<String> getSystemAdminEmails() {
         Set<String> emails = new Set<String>();
         List<Id> sysAdminProfileIds = UTIL_Profile.getInstance().getProfileIds(UTIL_Profile.SYSTEM_ADMINISTRATOR);
 
@@ -108,48 +148,53 @@ public class ERR_Notifier {
     /*******************************************************************************************************
     * @description Sends error email notifications.
     * @param context The context that triggered the error notification
-    * @param sendList The list of email addresses to send notifications to.
+    * @param recipientsList The list of email addresses to send notifications to.
     * @return void
     */
-    private static void sendEmailNotifications(String context, List<String> sendList) {
-        if (!system.isBatch() && !system.isFuture() && Limits.getAsyncCalls() < Limits.getLimitAsyncCalls()) {
-            //We cannot pass the context, because only primitive types can be passed to future methods.
-            sendErrorQueueEmailNotificationFuture(sendList);
-        } else if (system.isFuture()) {
-            sendErrorQueueEmailNotification(context, sendList);
+    private void sendEmailNotifications(String context, List<String> recipientsList) {
+
+        if (!System.isBatch() && !System.isFuture() && Limits.getAsyncCalls() < Limits.getLimitAsyncCalls()) {
+            sendErrorQueueEmailNotificationFuture(recipientsList);
+
+        } else if (System.isFuture()) {
+            sendErrorQueueEmailNotification(context, recipientsList);
         }
     }
 
     /*******************************************************************************************************
-    * @description Sends error email notifications in a future (asynchronously). It will send an email with all the 
-    *              existing error records not already sent in a notification.
+    * @description Sends error email notifications in a future (asynchronously). It will send an email
+    * with all the existing error records not already sent in a notification.
     * @param context The context that triggered the error notification.
-    * @param sendList The list of email addresses to send notifications to.
+    * @param recipientsList The list of email addresses to send notifications to.
     * @return void
     */
     @future
-    private static void sendErrorQueueEmailNotificationFuture(List<String> sendList) {
-        sendErrorQueueEmailNotification(null, sendList);
+    private static void sendErrorQueueEmailNotificationFuture(List<String> recipientsList) {
+        ERR_Notifier notifierService = new ERR_Notifier();
+        notifierService.sendErrorQueueEmailNotification(null, recipientsList);
     }
 
     /*******************************************************************************************************
-    * @description Sends error email notifications synchronously. It will send an email with all the existing error
-    *              records not already sent in a notification.
+    * @description Sends error email notifications synchronously. It will send an email with all the
+    * existing error records not already sent in a notification.
     * @param context The context that triggered the error notification.
-    * @param sendList The list of email addresses to send notifications to.
+    * @param recipientsList The list of email addresses to send notifications to.
     * @return void
     */
-    private static void sendErrorQueueEmailNotification(String context, List<String> sendList) {
-        List<Error__c> errors = [select Id, Error_Type__c, Datetime__c, Full_Message__c, Record_URL__c, Context_Type__c,
-                                        Stack_Trace__c from Error__c where Email_Sent__c = false];
+    private void sendErrorQueueEmailNotification(String context, List<String> recipientsList) {
+        List<Error__c> errors = getErrorsPendingNotification();
 
-        if (!errors.isEmpty() && !sendList.isEmpty()) {
-            Messaging.SingleEmailMessage sme = createEmailMessage(context, errors, sendList);
-            Messaging.sendEmail(new Messaging.SingleEmailMessage[]{sme});
+        if (!errors.isEmpty() && !recipientsList.isEmpty()) {
+            try {
+                Messaging.SingleEmailMessage email = createEmailMessage(context, errors, recipientsList);
+                Messaging.sendEmail(new Messaging.SingleEmailMessage[]{ email });
+            } catch (Exception ex) {
+                // Swallow any errors generating the email
+            }
 
-            for(Error__c error : errors)
+            for (Error__c error : errors) {
                 error.Email_Sent__c = true;
-
+            }
             update errors;
         }
     }
@@ -158,126 +203,136 @@ public class ERR_Notifier {
     * @description Creates the email message to send as error notification.
     * @param context The context that triggered the error notification.
     * @param errorList The list of errors to include in the email.
-    * @param sendList The list of email recipients.
+    * @param recipientsList The list of email recipients.
     * @return 
     */
-    private static Messaging.SingleEmailMessage createEmailMessage(String context, List<Error__c> errorList, List<String> sendList) {
+    private Messaging.SingleEmailMessage createEmailMessage(String context, List<Error__c> errorList, List<String> recipientsList) {
         Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
         mail.setUseSignature(false);
-        mail.setReplyTo('donotreply@salesforce.org');
-        mail.setSenderDisplayName('Nonprofit Success Pack');
-        mail.setSubject('Salesforce Error');
-        string bodyString = 'Organization: ' + UserInfo.getOrganizationName() + '(' + UserInfo.getOrganizationId() + ')\n';
-        bodyString += 'User: ' + UserInfo.getUserName() + '(' + UserInfo.getUserId() + ')\n\n';
-        bodyString += Label.ErrorEmailMessage + '\n';
-        if (context == ERR_Handler_API.Context.RD.name())
-            bodyString += system.label.npe03.RecurringDonationErrorEmailBody;
+        mail.setReplyTo(EMAIL_REPLYTO);
+        mail.setSenderDisplayName(EMAIL_SENDER_NAME);
+        mail.setSubject(EMAIL_SUBJECT);
+
+        String bodyStringTemplate = 'Organization: {0} ({1})\nUser: {2} ({3})\n\n';
+        String bodyString = String.format(bodyStringTemplate, new List<String>{
+                UserInfo.getOrganizationName(), UserInfo.getOrganizationId(), UserInfo.getUserName(), UserInfo.getUserId()
+        });
+
+        bodyString += System.Label.ErrorEmailMessage + '\n';
+        if (context == ERR_Handler_API.Context.RD.name()) {
+            bodyString += System.Label.npe03.RecurringDonationErrorEmailBody;
+        }
+
         bodyString += '\n\nErrors:';
         Integer i = 1;
-        for (Error__c error : errorList){
-            bodystring += '\n\n----------\n Error #' + i + ': \n' + getErrorMessageBody(error);
+        for (Error__c error : errorList) {
+            bodyString += '\n\n----------\n Error #' + i + ': \n' + buildErrorMessageBody(error);
             i++;
         }
+
         mail.setPlainTextBody(bodyString);
-        mail.setToAddresses(sendList); 
+        mail.setToAddresses(recipientsList); 
         return mail;        
     }
 
     /*******************************************************************************************************
-    * @description Post a message to Chatter with information about all the existing error records that were not already posted.
+    * @description Post a message to Chatter with information about all the existing error records
+    * that were not already posted.
     * @param chatterGroupId The ID of the Chatter group to post to.
     * @return void
     */
-    public static void postErrorsToChatter(String chatterGroupId) {
+    private void postErrorsToChatter(String chatterGroupId) {
 
-        if(chatterGroupId instanceof Id) {
-            SObject collaborationGroup = Database.query('select Id, Name from CollaborationGroup where id = :chatterGroupId');
-            List<Error__c> errors = [select Id, Error_Type__c, Datetime__c, Full_Message__c, Record_URL__c, Context_Type__c,
-                                        Stack_Trace__c from Error__c where Posted_in_Chatter__c = false];    
-
-            if (!errors.isEmpty()) {
-                List<SObject> postsToInsert = new List<SObject>();
-                for(Error__c error : errors) {
-                    SObject post = (SObject)System.Type.forName('FeedItem').newInstance();
-                    post.put('Title', 'Salesforce Error');
-                    String body = getErrorMessageBody(error);
-                    post.put('Body', body);
-                    post.put('ParentId', collaborationGroup.Id);
-                    postsToInsert.add(post);
-                    error.Posted_in_Chatter__c = true;
-                }
-                insert postsToInsert;
-                update errors; //we don't want to post the same errors again    
-            }
+        if (!(chatterGroupId instanceof Id)) {
+            return;
         }
+
+        SObject collaborationGroup = Database.query('SELECT Id, Name' +
+                ' FROM CollaborationGroup' +
+                ' WHERE Id = :chatterGroupId' +
+                ' LIMIT 1');
+
+        List<Error__c> errors = getErrorsPendingNotification();
+
+        if (!errors.isEmpty()) {
+
+            List<SObject> postsToInsert = new List<SObject>();
+            for (Error__c error : errors) {
+                postsToInsert.add(createChatterPost(error, collaborationGroup.Id));
+                error.Posted_in_Chatter__c = true;
+            }
+
+            try {
+                insert postsToInsert;
+            } catch (Exception ex) {
+                // swallow any errors posting the errors to chatter
+            }
+
+            update errors; //we don't want to post the same errors again
+        }
+    }
+
+    /**
+     * @description Create a chatter post for a specific Error__c log record
+     * @param error
+     * @param groupId
+     * @return FeedItem
+     */
+    private SObject createChatterPost(Error__c error, Id groupId) {
+        String body = buildErrorMessageBody(error);
+
+        SObject post = (SObject)System.Type.forName('FeedItem').newInstance();
+        post.put('Title', 'Salesforce Error');
+        post.put('Body', body);
+        post.put('ParentId', groupId);
+
+        return post;
     }
 
     /*******************************************************************************************************
     * @description Creates the body of the error message for a specific error record.
-    * @param error The error record to create the message string from.
-    * @return String The string representing the error record.
+    * @param error The error record to create the message String from.
+    * @return String The String representing the error record.
     */
-    private static String getErrorMessageBody(Error__c error) {
+    private String buildErrorMessageBody(Error__c error) {
+
         String body = '\nError Type: ' + error.Error_Type__c;
         body += '\nError Date: ' + error.Datetime__c;
         body += '\nMessage: "' + error.Full_Message__c + '"';
-        if(error.Record_URL__c != null)
+
+        if (error.Record_URL__c != null) {
             body += '\n' + error.Record_URL__c;
-        if(error.Context_Type__c != null)
+        }
+
+        if (error.Context_Type__c != null) {
             body += '\nContext: ' + error.Context_Type__c;
+        }
+
         body += '\n\nStack Trace:\n ' + error.Stack_Trace__c;
+
         return body;
     }
-     
-    /*******************************************************************************************************
-    * @description Verifies error settings are still valid.
-    * @param ctrl The controller that calls the method.
-    * @return void
-    */
-    public static void verifyErrorSettings(STG_PanelHealthCheck_CTRL ctrl) {
-        
-        Error_Settings__c es = UTIL_CustomSettingsFacade.getErrorSettings();
-        String errorNotifRecipient = es.Error_Notifications_To__c;
-        string strSetting;
-        strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Error_Settings__c'), UTIL_Namespace.StrTokenNSPrefix('Error_Notifications_To__c'));
 
-        if (es.Error_Notifications_On__c && errorNotifRecipient != null) {
-            if (errorNotifRecipient != NotificationOptions.sysAdmins) {
-                if (!(errorNotifRecipient instanceof id)) {
-                    ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError, label.healthDetailsInvalidErrorRecipient, 
-                        string.format(label.healthSolutionEditSetting, new string[]{strSetting, Label.stgNavSystem, Label.stgNavErrorNotify}));
-                    return;
-                }
-                if (errorNotifRecipient.startsWith(NotificationOptions.chatterGroup) && Schema.SObjectType.User.isFeedEnabled()) {
-                    // verify chatter group exists
-                    list<SObject> listCG = Database.query('select Id, Name from CollaborationGroup where id = :errorNotifRecipient');
-                    if (listCG.size() == 0) {
-                        ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError, 
-                            string.format(label.healthDetailsInvalidErrorChatterGroup, new string[]{errorNotifRecipient}),
-                            string.format(label.healthSolutionEditSetting, new string[]{strSetting, Label.stgNavSystem, Label.stgNavErrorNotify}));
-                        return;
-                    }
-                } else {
-                    if (errorNotifRecipient.startsWith(NotificationOptions.user)) {
-                        // verify user exists and is active
-                        list<User> listUser = [select name, email, isActive from User where id = :errorNotifRecipient and isActive = true];
-                        if (listUser.size() == 0) {
-                            ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError, 
-                                string.format(label.healthDetailsInvalidErrorUser, new string[]{errorNotifRecipient}),
-                                string.format(label.healthSolutionEditSetting, new string[]{strSetting, Label.stgNavSystem, Label.stgNavErrorNotify}));
-                            return;    
-                        }
-                        if (listUser[0].isActive == false) { 
-                            ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError, 
-                                string.format(label.healthDetailsInvalidErrorUser, new string[]{listUser[0].name}),
-                                string.format(label.healthSolutionEditSetting, new string[]{strSetting, Label.stgNavSystem, Label.stgNavErrorNotify}));
-                            return; 
-                        }
-                    }
-                }
-            }
-        // settings ok.
-        ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusSuccess, null, label.healthLabelErrorRecipientValid);
-        }
+    /**
+     * @description Return a list of errors pending notification (email or chatter). Limits the list to
+     * the defined maximum number of records, and only those created in the defined period of time
+     * @return List<Error__c>
+     */
+    @TestVisible
+    private List<Error__c> getErrorsPendingNotification() {
+        return [SELECT  Id, 
+                        Error_Type__c, 
+                        Datetime__c, 
+                        Full_Message__c,
+                        Record_URL__c, 
+                        Context_Type__c, 
+                        Stack_Trace__c
+                FROM Error__c
+                WHERE Email_Sent__c = FALSE
+                    AND Posted_in_Chatter__c = FALSE
+                    AND Datetime__c >= :MAX_AGE_FOR_ERRORS
+                ORDER BY CreatedDate ASC
+                LIMIT :MAX_RECORDS
+            ];
     }
 }

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -43,7 +43,8 @@ public class ERR_Notifier {
     private static Datetime MAX_AGE_FOR_ERRORS = System.now().addHours(-48);
 
     /** @description Maximum Heap Storage that will be used to build the message/post body */
-    private Decimal MAX_HEAP_LIMIT {
+    @TestVisible
+    private static Decimal MAX_HEAP_LIMIT {
         get {
             if (MAX_HEAP_LIMIT == null) {
                 MAX_HEAP_LIMIT = (Limits.getLimitHeapSize() * 0.95);
@@ -212,16 +213,13 @@ public class ERR_Notifier {
             } catch (Exception ex) {
                 // Swallow any errors generating the email
             }
-
-            for (Error__c error : errors) {
-                error.Email_Sent__c = true;
-            }
             update errors;
         }
     }
 
     /**********************************************************************************************
-    * @description Creates the email message to send as error notification.
+    * @description Creates the email message to send as error notification and marks each Error__c
+    * record with Email_Sent=true
     * @param context The context that triggered the error notification.
     * @param errorList The list of errors to include in the email.
     * @param recipientsList The list of email recipients.
@@ -249,13 +247,13 @@ public class ERR_Notifier {
         }
 
         bodyString += '\n\nErrors:';
-        Integer i = 1;
+        Integer i = 0;
         for (Error__c error : errorList) {
             if (isNearHeapLimit()) {
                 break;
             }
-            bodyString += '\n\n----------\n Error #' + i + ': \n' + buildErrorMessageBody(error);
-            i++;
+            bodyString += '\n\n----------\n Error #' + (++i) + ': \n' + buildErrorMessageBody(error);
+            error.Email_Sent__c = true;
         }
 
         if (errorNotifRecipient != ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS) {

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -49,7 +49,7 @@ public class ERR_Notifier {
 
     /** @description Global email constants used for all outbound (system) emails */
     public static final String EMAIL_SYSTEM_ERRORS_TO = 'errors@salesforce.org';
-    public static final String EMAIL_REPLYTO = 'donotreply@salesforce.org';
+    public static final String EMAIL_REPLY_TO = 'donotreply@salesforce.org';
     public static final String EMAIL_SENDER_NAME = 'Nonprofit Success Pack';
 
     /** @description the subject for errors sent out of this service only */
@@ -86,11 +86,11 @@ public class ERR_Notifier {
         }
     }
 
-    // ====================== HELPER METHODS FOR ERROR NOTIFICATION SERVICE =========================
-
     /** @description Private constructor so the class cannot be instantiated outside of this class */
     @TestVisible
     private ERR_Notifier() {}
+
+    // ====================== HELPER METHODS FOR ERROR NOTIFICATION SERVICE =========================
 
     /**********************************************************************************************
      * @description Using the provided error notification user id (or 'All System Admins') or gets
@@ -203,7 +203,7 @@ public class ERR_Notifier {
     private Messaging.SingleEmailMessage createEmailMessage(String context, List<Error__c> errorList, List<String> recipientsList) {
         Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
         mail.setUseSignature(false);
-        mail.setReplyTo(EMAIL_REPLYTO);
+        mail.setReplyTo(EMAIL_REPLY_TO);
         mail.setSenderDisplayName(EMAIL_SENDER_NAME);
         mail.setSubject(EMAIL_SUBJECT);
 

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -37,8 +37,15 @@
 public class ERR_Notifier {
 
     /** @description Filtering options to reduce the number of records processed during the notify job */
-    private static final Integer MAX_RECORDS = 5000;
-    private static final Datetime MAX_AGE_FOR_ERRORS = System.now().addHours(-48);
+    @TestVisible
+    private static Integer MAX_RECORDS = 5000;
+    @TestVisible
+    private static Datetime MAX_AGE_FOR_ERRORS = System.now().addHours(-48);
+
+    /** @description Global error notification settings used in NPSP Settings and here */
+    public static final String ERROR_NOTIFICATION_USER_PREFIX = USER_UserService.OBJECT_ID_PREFIX_USER;
+    public static final String ERROR_NOTIFICATION_CHATTER_PREFIX = CollaborationGroup.SObjectType.getDescribe().getKeyPrefix();
+    public static final String ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS = 'All Sys Admins';
 
     /** @description Global email constants used for all outbound (system) emails */
     public static final String EMAIL_SYSTEM_ERRORS_TO = 'errors@salesforce.org';
@@ -48,21 +55,7 @@ public class ERR_Notifier {
     /** @description the subject for errors sent out of this service only */
     private static final String EMAIL_SUBJECT = 'Salesforce Error';
 
-    public static final String ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS = 'All Sys Admins';
-
-    public static NotificationOptions notificationOptions = new NotificationOptions();
-    
-    /*******************************************************ø************************************************
-    * @description Inner class with the 3 types of notification options: user, chatter group, and all system
-    * administrators.
-    */
-    public class NotificationOptions {
-        public final String sysAdmins = ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS;
-        public final String userPrefix = USER_UserService.OBJECT_ID_PREFIX_USER;
-        public final String chatterGroup = CollaborationGroup.SObjectType.getDescribe().getKeyPrefix();
-    }
-
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Sends error notifications to the receivers specified in the settings, if error
     * notifications are enabled, with all the existing error records that have not been included in
     * previous error notifications.
@@ -79,7 +72,7 @@ public class ERR_Notifier {
             ERR_Notifier notifierService = new ERR_Notifier();
 
             Boolean isChatterGroup = errorNotifRecipient instanceof Id
-                    && errorNotifRecipient.startsWith(notificationOptions.chatterGroup);
+                    && errorNotifRecipient.startsWith(ERROR_NOTIFICATION_CHATTER_PREFIX);
 
             if (isChatterGroup && Schema.SObjectType.User.isFeedEnabled()) {
 
@@ -99,7 +92,7 @@ public class ERR_Notifier {
     @TestVisible
     private ERR_Notifier() {}
 
-    /**
+    /**********************************************************************************************
      * @description Using the provided error notification user id (or 'All System Admins') or gets
      * all system admin email addresses
      * @param errorNotifRecipient Id or Null
@@ -107,7 +100,8 @@ public class ERR_Notifier {
      */
     private List<String> getErrorEmailRecipients(String errorNotifRecipient) {
         List<String> recipientsList = new List<String>();
-        Boolean isUserId = errorNotifRecipient instanceof Id && errorNotifRecipient.startsWith(notificationOptions.userPrefix);
+        Boolean isUserId = errorNotifRecipient instanceof Id
+                && errorNotifRecipient.startsWith(ERROR_NOTIFICATION_USER_PREFIX);
 
         if (isUserId) {
             List<User> users = [SELECT Email FROM User WHERE Id = :errorNotifRecipient AND IsActive = TRUE LIMIT 1];
@@ -115,14 +109,14 @@ public class ERR_Notifier {
                 recipientsList.add(users[0].Email);
             }
 
-        } else if (errorNotifRecipient == notificationOptions.sysAdmins) {
+        } else if (errorNotifRecipient == ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS) {
             recipientsList.addAll(getSystemAdminEmails());
         }
 
         return recipientsList;
     }
 
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Get the active System Administrators' emails.
     * @return List<String> Emails
     */
@@ -145,7 +139,7 @@ public class ERR_Notifier {
         return new List<String>(emails);
     }
 
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Sends error email notifications.
     * @param context The context that triggered the error notification
     * @param recipientsList The list of email addresses to send notifications to.
@@ -161,7 +155,7 @@ public class ERR_Notifier {
         }
     }
 
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Sends error email notifications in a future (asynchronously). It will send an email
     * with all the existing error records not already sent in a notification.
     * @param context The context that triggered the error notification.
@@ -174,7 +168,7 @@ public class ERR_Notifier {
         notifierService.sendErrorQueueEmailNotification(null, recipientsList);
     }
 
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Sends error email notifications synchronously. It will send an email with all the
     * existing error records not already sent in a notification.
     * @param context The context that triggered the error notification.
@@ -199,7 +193,7 @@ public class ERR_Notifier {
         }
     }
 
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Creates the email message to send as error notification.
     * @param context The context that triggered the error notification.
     * @param errorList The list of errors to include in the email.
@@ -235,7 +229,7 @@ public class ERR_Notifier {
         return mail;        
     }
 
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Post a message to Chatter with information about all the existing error records
     * that were not already posted.
     * @param chatterGroupId The ID of the Chatter group to post to.
@@ -272,7 +266,7 @@ public class ERR_Notifier {
         }
     }
 
-    /**
+    /**********************************************************************************************
      * @description Create a chatter post for a specific Error__c log record
      * @param error
      * @param groupId
@@ -289,7 +283,7 @@ public class ERR_Notifier {
         return post;
     }
 
-    /*******************************************************************************************************
+    /**********************************************************************************************
     * @description Creates the body of the error message for a specific error record.
     * @param error The error record to create the message String from.
     * @return String The String representing the error record.
@@ -313,7 +307,7 @@ public class ERR_Notifier {
         return body;
     }
 
-    /**
+    /**********************************************************************************************
      * @description Return a list of errors pending notification (email or chatter). Limits the list to
      * the defined maximum number of records, and only those created in the defined period of time
      * @return List<Error__c>

--- a/src/classes/ERR_Notifier.cls
+++ b/src/classes/ERR_Notifier.cls
@@ -44,7 +44,19 @@ public class ERR_Notifier {
 
     /** @description Global error notification settings used in NPSP Settings and here */
     public static final String ERROR_NOTIFICATION_USER_PREFIX = USER_UserService.OBJECT_ID_PREFIX_USER;
-    public static final String ERROR_NOTIFICATION_CHATTER_PREFIX = CollaborationGroup.SObjectType.getDescribe().getKeyPrefix();
+    public static final String ERROR_NOTIFICATION_CHATTER_PREFIX {
+        get {
+            if (ERROR_NOTIFICATION_CHATTER_PREFIX == null) {
+                try {
+                    ERROR_NOTIFICATION_CHATTER_PREFIX =
+                            UTIL_Describe.getObjectDescribe('CollaborationGroup').getKeyPrefix();
+                } catch (Exception ex) {
+                    ERROR_NOTIFICATION_CHATTER_PREFIX = '0F9';
+                }
+            }
+            return ERROR_NOTIFICATION_CHATTER_PREFIX;
+        } private set;
+    }
     public static final String ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS = 'All Sys Admins';
 
     /** @description Global email constants used for all outbound (system) emails */

--- a/src/classes/ERR_Notifier_TEST.cls
+++ b/src/classes/ERR_Notifier_TEST.cls
@@ -65,9 +65,9 @@ private class ERR_Notifier_TEST {
 
         List<Error__c> errors = new List<Error__c>();
         // The oldest error will be 80 days old
-        Datetime dt=Datetime.now().addDays(80).addHours(-1);
+        Datetime dt = Datetime.now().addDays(80).addHours(-1);
         // Create one error per day for up to 100 total records.
-        for (Integer n=0; n<100; n++) {
+        for (Integer n = 0; n < 100; n++) {
             errors.add(createError(dt));
             dt = dt.addDays(1);
         }
@@ -98,7 +98,7 @@ private class ERR_Notifier_TEST {
         ));
 
         List<Error__c> errors = new List<Error__c>();
-        for (Integer n=0; n<100; n++) {
+        for (Integer n = 0; n < 100; n++) {
             errors.add(createError(Datetime.now()));
         }
         insert errors;
@@ -112,6 +112,62 @@ private class ERR_Notifier_TEST {
             System.assert(err.Email_Sent__c,
                     'All emails pending notification should be marked as having an email sent');
         }
+    }
+
+    /**********************************************************************************************
+    * @description Verify that if the specified Error Notification User is inactive (or doesn't exist), that the
+    * returned list of email recipients consists of all System Admin users
+    */
+    @IsTest
+    private static void shouldReturnAllSystemAdminsEmailsIfErrorUserIsInactive() {
+        // Create a System Admin User
+        User tempUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
+        tempUser.IsActive = true;
+        insert tempUser;
+
+        Id fakeUserId = UTIL_UnitTestData_TEST.mockId(User.SObjectType);
+        Error_Settings__c errorSettings = UTIL_CustomSettingsFacade.getErrorSettingsForTests(
+            new Error_Settings__c(
+                Error_Notifications_On__c = True,
+                Error_Notifications_To__c = fakeUserId
+            )
+        );
+        String errorNotifRecipient = errorSettings.Error_Notifications_To__c;
+
+        Set<String> expectedEmails = getSystemAdminEmails();
+
+        Test.startTest();
+        ERR_Notifier notifierService = new ERR_Notifier();
+        List<String> errorRecipients = notifierService.getErrorEmailRecipients(errorNotifRecipient);
+        Test.stopTest();
+
+        System.assert(errorRecipients.size() > 1, 'There should be more than one System Admin user listed');
+        System.assert(expectedEmails.containsAll(errorRecipients), 'All System Admins should be set as recipients');
+    }
+
+    /**********************************************************************************************
+    * @description Verify that if the specified Error Notification User is inactive (or doesn't exist), that the
+    * generated email includes a note about it.
+    */
+    @IsTest
+    private static void shouldIncludeNoteAboutInactiveNotificationUserInEmail() {
+        Id fakeUserId = UTIL_UnitTestData_TEST.mockId(User.SObjectType);
+        Error_Settings__c errorSettings = UTIL_CustomSettingsFacade.getErrorSettingsForTests(
+            new Error_Settings__c(
+                Error_Notifications_On__c = True,
+                Error_Notifications_To__c = fakeUserId
+            )
+        );
+        String errorNotifRecipient = errorSettings.Error_Notifications_To__c;
+
+        Test.startTest();
+        ERR_Notifier notifierService = new ERR_Notifier();
+        List<String> errorRecipients = notifierService.getErrorEmailRecipients(errorNotifRecipient);
+        Messaging.SingleEmailMessage emailMessage = notifierService.createEmailMessage(null, new List<Error__c>(), errorRecipients);
+        Test.stopTest();
+
+        System.assert(emailMessage.getPlainTextBody().containsIgnoreCase('not an active user'));
+        System.assert(emailMessage.getPlainTextBody().containsIgnoreCase(errorNotifRecipient));
     }
 
     /**********************************************************************************************
@@ -136,7 +192,7 @@ private class ERR_Notifier_TEST {
         ));
 
         List<Error__c> errors = new List<Error__c>();
-        for (Integer n=0; n<100; n++) {
+        for (Integer n = 0; n < 100; n++) {
             errors.add(createError(Datetime.now()));
         }
         insert errors;

--- a/src/classes/ERR_Notifier_TEST.cls
+++ b/src/classes/ERR_Notifier_TEST.cls
@@ -270,7 +270,7 @@ private class ERR_Notifier_TEST {
     }
 
     /**********************************************************************************************
-    * @description Confirm that errors are not posted to Chatter if the heap size limit has been reached
+    * @description Confirm that errors are not emailed if the heap size limit has been reached
     */
     @IsTest
     private static void shouldNotEmailErrorsWithHeapLimit() {

--- a/src/classes/ERR_Notifier_TEST.cls
+++ b/src/classes/ERR_Notifier_TEST.cls
@@ -108,7 +108,7 @@ private class ERR_Notifier_TEST {
         Test.stopTest();
 
         ERR_Notifier notifierService = new ERR_Notifier();
-        for (Error__c err : notifierService.getErrorsPendingNotification()) {
+        for (Error__c err : getErrors()) {
             System.assert(err.Email_Sent__c,
                     'All emails pending notification should be marked as having an email sent');
         }
@@ -198,7 +198,7 @@ private class ERR_Notifier_TEST {
     * that meet the criteria and sends an email for them.
     */
     @IsTest
-    private static void shouldPostEmailsToChatter() {
+    private static void shouldPostErrorsToChatter() {
 
         if (!Schema.SObjectType.User.isFeedEnabled()) {
             return;
@@ -225,14 +225,95 @@ private class ERR_Notifier_TEST {
         Test.stopTest();
 
         ERR_Notifier notifierService = new ERR_Notifier();
-        for (Error__c err : notifierService.getErrorsPendingNotification()) {
+        for (Error__c err : getErrors()) {
             System.assert(err.Posted_in_Chatter__c,
-                    'All emails pending notification should be marked as being posted to chatter');
+                    'All errors pending notification should be marked as being posted to chatter');
         }
     }
 
+    /**********************************************************************************************
+    * @description Confirm that errors are not posted to Chatter if the heap size limit has been reached
+    */
+    @IsTest
+    private static void shouldNotPostErrorsToChatterWithHeapLimit() {
+
+        if (!Schema.SObjectType.User.isFeedEnabled()) {
+            return;
+        }
+
+        SObject chatterGroup = (SObject)System.Type.forName('CollaborationGroup').newInstance();
+        chatterGroup.put('Name', 'ChatterTestGroup');
+        chatterGroup.put('CollaborationType', 'Private');
+        insert chatterGroup;
+
+        UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(
+            Error_Notifications_On__c = True,
+            Error_Notifications_To__c = chatterGroup.Id
+        ));
+
+        List<Error__c> errors = new List<Error__c>();
+        for (Integer n = 0; n < 100; n++) {
+            errors.add(createError(Datetime.now()));
+        }
+        insert errors;
+
+        Test.startTest();
+        ERR_Notifier.MAX_HEAP_LIMIT = Limits.getHeapSize()+1;
+        ERR_Notifier.sendErrorNotifications(null);
+        Test.stopTest();
+
+        ERR_Notifier notifierService = new ERR_Notifier();
+        for (Error__c err : getErrors()) {
+            System.assertEquals(false, err.Posted_in_Chatter__c,
+                'All errors pending notification should NOT have been posted to chatter because over heap size limit');
+        }
+    }
+
+    /**********************************************************************************************
+    * @description Confirm that errors are not posted to Chatter if the heap size limit has been reached
+    */
+    @IsTest
+    private static void shouldNotEmailErrorsWithHeapLimit() {
+        UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(
+            Error_Notifications_On__c = True,
+            Error_Notifications_To__c = UserInfo.getUserId()
+        ));
+
+        List<Error__c> errors = new List<Error__c>();
+        for (Integer n = 0; n < 100; n++) {
+            errors.add(createError(Datetime.now()));
+        }
+        insert errors;
+
+        Test.startTest();
+        ERR_Notifier.MAX_HEAP_LIMIT = Limits.getHeapSize()+1;
+        ERR_Notifier.sendErrorNotifications(null);
+        Test.stopTest();
+
+        ERR_Notifier notifierService = new ERR_Notifier();
+        for (Error__c err : getErrors()) {
+            System.assertEquals(false, err.Email_Sent__c,
+                'All errors pending notification should NOT have been emailed because over heap size limit');
+        }
+    }
+
+
     // Helpers
     ////////////
+
+    /**
+     * @description Helper method to retrieve all error records
+     */
+    private static List<Error__c> getErrors() {
+        return [SELECT Id,
+            Full_Message__c,
+            Stack_Trace__c,
+            Email_Sent__c,
+            Posted_in_Chatter__c,
+            Context_Type__c
+        FROM Error__c
+        ];
+    }
 
     /**********************************************************************************************
     * @description Get System Administrator User emails

--- a/src/classes/ERR_Notifier_TEST.cls
+++ b/src/classes/ERR_Notifier_TEST.cls
@@ -42,7 +42,8 @@ private class ERR_Notifier_TEST {
     ***************************************************************************************************************************/   
     private static testMethod void testGetSystemAdminEmails() {
         Test.startTest();
-        Set<String> recipientEmails = new Set<String>(ERR_Notifier.getSystemAdminEmails());
+        ERR_Notifier notifierService = new ERR_Notifier();
+        Set<String> recipientEmails = new Set<String>(notifierService.getSystemAdminEmails());
         Test.stopTest();
 
         Set<String> expectedEmails = getSystemAdminEmails();

--- a/src/classes/ERR_Notifier_TEST.cls
+++ b/src/classes/ERR_Notifier_TEST.cls
@@ -35,12 +35,13 @@
 */
 @isTest
 private class ERR_Notifier_TEST {
-	
-    /**************************************************************************************************************************
-    @description Test retrieval of System Administrator Users' Emails
-    verify: Emails of System Administrator Users are retrieved
-    ***************************************************************************************************************************/   
-    private static testMethod void testGetSystemAdminEmails() {
+
+    /**********************************************************************************************
+    * @description Test retrieval of System Administrator Users' Emails
+    * verify: Emails of System Administrator Users are retrieved
+    */
+    @IsTest
+    private static void shouldMatchSystemAdminEmailList() {
         Test.startTest();
         ERR_Notifier notifierService = new ERR_Notifier();
         Set<String> recipientEmails = new Set<String>(notifierService.getSystemAdminEmails());
@@ -52,10 +53,109 @@ private class ERR_Notifier_TEST {
         System.assert(expectedEmails.containsAll(recipientEmails), 'Expected and retrieved emails should be the same');
     }
 
+    /**********************************************************************************************
+    * @description Confirm that the method to retrieve Error log record pending notification
+    * only retrieve records created in the last 48 hours.
+    */
+    @IsTest
+    private static void shouldOnlyRetrieveRecentErrorLogEntries() {
+
+        ERR_Notifier.MAX_AGE_FOR_ERRORS = Datetime.now().addDays(-3);
+        ERR_Notifier.MAX_RECORDS = 10;
+
+        List<Error__c> errors = new List<Error__c>();
+        // The oldest error will be 80 days old
+        Datetime dt=Datetime.now().addDays(80).addHours(-1);
+        // Create one error per day for up to 100 total records.
+        for (Integer n=0; n<100; n++) {
+            errors.add(createError(dt));
+            dt = dt.addDays(1);
+        }
+        insert errors;
+
+        Test.startTest();
+        ERR_Notifier notifierService = new ERR_Notifier();
+        errors = notifierService.getErrorsPendingNotification();
+        Test.stopTest();
+
+        System.assertEquals(ERR_Notifier.MAX_RECORDS, errors.size(), 'There should only be ten errors returned.');
+
+        for (Error__c err : errors) {
+            System.assert(err.Datetime__c >= ERR_Notifier.MAX_AGE_FOR_ERRORS,
+                'All returned errors should be newer than one day');
+        }
+    }
+
+    /**********************************************************************************************
+    * @description Confirm that send error notification process retrieves all errors created
+    * that meet the criteria and sends an email for them.
+    */
+    @IsTest
+    private static void shouldSendEmailsToCurrentUser() {
+        UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(
+                Error_Notifications_On__c = True,
+                Error_Notifications_To__c = UserInfo.getUserId()
+        ));
+
+        List<Error__c> errors = new List<Error__c>();
+        for (Integer n=0; n<100; n++) {
+            errors.add(createError(Datetime.now()));
+        }
+        insert errors;
+
+        Test.startTest();
+        ERR_Notifier.sendErrorNotifications(null);
+        Test.stopTest();
+
+        ERR_Notifier notifierService = new ERR_Notifier();
+        for (Error__c err : notifierService.getErrorsPendingNotification()) {
+            System.assert(err.Email_Sent__c,
+                    'All emails pending notification should be marked as having an email sent');
+        }
+    }
+
+    /**********************************************************************************************
+    * @description Confirm that send error notification process retrieves all errors created
+    * that meet the criteria and sends an email for them.
+    */
+    @IsTest
+    private static void shouldPostEmailsToChatter() {
+
+        if (!Schema.SObjectType.User.isFeedEnabled()) {
+            return;
+        }
+
+        SObject chatterGroup = (SObject)System.Type.forName('CollaborationGroup').newInstance();
+        chatterGroup.put('Name', 'ChatterTestGroup');
+        chatterGroup.put('CollaborationType', 'Private');
+        insert chatterGroup;
+
+        UTIL_CustomSettingsFacade.getErrorSettingsForTests(new Error_Settings__c(
+            Error_Notifications_On__c = True,
+            Error_Notifications_To__c = chatterGroup.Id
+        ));
+
+        List<Error__c> errors = new List<Error__c>();
+        for (Integer n=0; n<100; n++) {
+            errors.add(createError(Datetime.now()));
+        }
+        insert errors;
+
+        Test.startTest();
+        ERR_Notifier.sendErrorNotifications(null);
+        Test.stopTest();
+
+        ERR_Notifier notifierService = new ERR_Notifier();
+        for (Error__c err : notifierService.getErrorsPendingNotification()) {
+            System.assert(err.Posted_in_Chatter__c,
+                    'All emails pending notification should be marked as being posted to chatter');
+        }
+    }
+
     // Helpers
     ////////////
 
-    /*********************************************************************************************************
+    /**********************************************************************************************
     * @description Get System Administrator User emails
     * @return Set<String> Emails
     */
@@ -66,11 +166,27 @@ private class ERR_Notifier_TEST {
                 SELECT Email
                 FROM User
                 WHERE Profile.Name = :UTIL_Profile.SYSTEM_ADMINISTRATOR
-                AND IsActive = true
+                AND IsActive = TRUE
         ]) {
             result.add(usr.Email);
         }
 
         return result;
+    }
+
+    /**********************************************************************************************
+    * @description Create an instance of an Error__c record
+    * @return Error__c instance
+    */
+    private static Error__c createError(Datetime dt) {
+        return new Error__c(
+            Error_Type__c = 'TEST',
+            Datetime__c = dt,
+            Full_Message__c = 'TEST',
+            Context_Type__c = 'TEST',
+            Stack_Trace__c = 'TEST',
+            Posted_in_Chatter__c = False,
+            Email_Sent__c = False
+        );
     }
 }

--- a/src/classes/ERR_Notifier_TEST.cls
+++ b/src/classes/ERR_Notifier_TEST.cls
@@ -171,6 +171,30 @@ private class ERR_Notifier_TEST {
     }
 
     /**********************************************************************************************
+    * @description Verify that if the specified Error Notification User is inactive (or doesn't exist), that the
+    * generated email includes a note about it.
+    */
+    @IsTest
+    private static void shouldNotIncludeNoteAboutInactiveNotificationUserInEmail() {
+        Id fakeUserId = UTIL_UnitTestData_TEST.mockId(User.SObjectType);
+        Error_Settings__c errorSettings = UTIL_CustomSettingsFacade.getErrorSettingsForTests(
+            new Error_Settings__c(
+                Error_Notifications_On__c = True,
+                Error_Notifications_To__c = UserInfo.getUserId()
+            )
+        );
+        String errorNotifRecipient = errorSettings.Error_Notifications_To__c;
+
+        Test.startTest();
+        ERR_Notifier notifierService = new ERR_Notifier();
+        List<String> errorRecipients = notifierService.getErrorEmailRecipients(errorNotifRecipient);
+        Messaging.SingleEmailMessage emailMessage = notifierService.createEmailMessage(null, new List<Error__c>(), errorRecipients);
+        Test.stopTest();
+
+        System.assert(!emailMessage.getPlainTextBody().containsIgnoreCase('not an active user'));
+    }
+
+    /**********************************************************************************************
     * @description Confirm that send error notification process retrieves all errors created
     * that meet the criteria and sends an email for them.
     */

--- a/src/classes/ERR_Notifier_TEST.cls
+++ b/src/classes/ERR_Notifier_TEST.cls
@@ -146,8 +146,8 @@ private class ERR_Notifier_TEST {
     }
 
     /**********************************************************************************************
-    * @description Verify that if the specified Error Notification User is inactive (or doesn't exist), that the
-    * generated email includes a note about it.
+    * @description Verify that if the specified Error Notification User is inactive (or doesn't exist),
+    * that the generated email includes a note about it.
     */
     @IsTest
     private static void shouldIncludeNoteAboutInactiveNotificationUserInEmail() {
@@ -171,12 +171,11 @@ private class ERR_Notifier_TEST {
     }
 
     /**********************************************************************************************
-    * @description Verify that if the specified Error Notification User is inactive (or doesn't exist), that the
-    * generated email includes a note about it.
+    * @description Verify that if the specified Error Notification User is active, that the
+    * generated email does not state that the specified user is inactive.
     */
     @IsTest
     private static void shouldNotIncludeNoteAboutInactiveNotificationUserInEmail() {
-        Id fakeUserId = UTIL_UnitTestData_TEST.mockId(User.SObjectType);
         Error_Settings__c errorSettings = UTIL_CustomSettingsFacade.getErrorSettingsForTests(
             new Error_Settings__c(
                 Error_Notifications_On__c = True,

--- a/src/classes/RD_RecurringDonations_TEST2.cls
+++ b/src/classes/RD_RecurringDonations_TEST2.cls
@@ -399,7 +399,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
     @isTest
     private static void testErrorHandlingAllSysAdmins() {
         UTIL_CustomSettingsFacade.getRecurringDonationsSettingsForTest(new npe03__Recurring_Donations_Settings__c(
-            npe03__Error_Email_Notifications__c ='All Sys Admins',
+            npe03__Error_Email_Notifications__c = ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS,
             npe03__Opportunity_Forecast_Months__c = 12                
         ));         
         

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -407,13 +407,13 @@ global without sharing class STG_InstallScript implements InstallHandler {
             try {
                 Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
                 mail.setUseSignature(false);
-                mail.setReplyTo('donotreply@salesforce.org');
-                mail.setSenderDisplayName('Nonprofit Success Pack');
+                mail.setReplyTo(ERR_Notifier.EMAIL_REPLYTO);
+                mail.setSenderDisplayName(ERR_Notifier.EMAIL_SENDER_NAME);
                 mail.setSubject('NPSP Install Errors');
 
                 mail.setPlainTextBody(buildEmailBody());  
 
-                mail.setToAddresses(new String[] { 'errors@salesforce.org', getUserEmail() });
+                mail.setToAddresses(new String[] { ERR_Notifier.EMAIL_SYSTEM_ERRORS_TO, getUserEmail() });
 
                 Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
 

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -407,7 +407,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
             try {
                 Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
                 mail.setUseSignature(false);
-                mail.setReplyTo(ERR_Notifier.EMAIL_REPLYTO);
+                mail.setReplyTo(ERR_Notifier.EMAIL_REPLY_TO);
                 mail.setSenderDisplayName(ERR_Notifier.EMAIL_SENDER_NAME);
                 mail.setSubject('NPSP Install Errors');
 

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -234,7 +234,7 @@ public with sharing class STG_InstallScript_TEST {
         
         System.assertEquals(true, errorSettings.Store_Errors_On__c);
         System.assertEquals(true, errorSettings.Error_Notifications_On__c);
-        System.assertEquals(ERR_Notifier.NotificationOptions.sysAdmins, errorSettings.Error_Notifications_To__c);
+        System.assertEquals(ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS, errorSettings.Error_Notifications_To__c);
 
         System.assertEquals(false, addrVerificationSetgs.Enable_Automatic_Verification__c);
         System.assertEquals(false, addrVerificationSetgs.Reject_Ambiguous_Addresses__c);

--- a/src/classes/STG_PanelERR_CTRL.cls
+++ b/src/classes/STG_PanelERR_CTRL.cls
@@ -71,11 +71,11 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
                 listSOERRNotifOptions.add(new SelectOption('None', 'None'));
 
                 if (Schema.SObjectType.User.isFeedEnabled()) {
-                    listSOERRNotifOptions.add(new SelectOption(ERR_Notifier.notificationOptions.chatterGroup, 'Chatter Group'));
+                    listSOERRNotifOptions.add(new SelectOption(ERR_Notifier.ERROR_NOTIFICATION_CHATTER_PREFIX, 'Chatter Group'));
                 }
 
                 listSOERRNotifOptions.add(new SelectOption(
-                        ERR_Notifier.notificationOptions.sysAdmins,
+                        ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS,
                         ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS)
                 );
 
@@ -97,7 +97,7 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
             String errorNotifRecipient = UTIL_CustomSettingsFacade.getErrorSettings().Error_Notifications_To__c;
 
             if (errorNotifRecipient != null) {
-                if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.chatterGroup)
+                if (errorNotifRecipient.startsWith(ERR_Notifier.ERROR_NOTIFICATION_CHATTER_PREFIX)
                         && Schema.SObjectType.User.isFeedEnabled()
                 ) {
                    strErrorNotifDisplayName = 'Group: ';
@@ -107,7 +107,7 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
                        strErrorNotifDisplayName += chatterGroupsNotif[0].get('Name');
                    }
 
-                } else if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.userPrefix)) {
+                } else if (errorNotifRecipient.startsWith(ERR_Notifier.ERROR_NOTIFICATION_USER_PREFIX)) {
                    strErrorNotifDisplayName = 'User: ';
                    List<User> usersNotif = [SELECT Name FROM User WHERE Id = :errorNotifRecipient];
                    if (usersNotif.size() > 0) {
@@ -133,10 +133,10 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
     public override PageReference saveSettings() {
         UTIL_Debug.debug('****notification to drop down: ' + notificationToDropDown);
         UTIL_Debug.debug('****group ID: ' + groupId);
-        if(notificationToDropDown == ERR_Notifier.NotificationOptions.chatterGroup && String.isBlank(groupId)) { 
+        if(notificationToDropDown == ERR_Notifier.ERROR_NOTIFICATION_CHATTER_PREFIX && String.isBlank(groupId)) {
             saveErrorMessage = 'Please enter valid Chatter group name.';
             return null;
-        } else if(notificationToDropDown == ERR_Notifier.NotificationOptions.chatterGroup && !String.isBlank(groupId)) { 
+        } else if(notificationToDropDown == ERR_Notifier.ERROR_NOTIFICATION_CHATTER_PREFIX && !String.isBlank(groupId)) {
            STG_SettingsService.stgService.stgErr.Error_Notifications_To__c = groupId;
            saveErrorMessage = null;
         } else {
@@ -160,8 +160,8 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
     * @return PageReference The page to redirect to, if any.
     */
     public override PageReference editSettings() {
-        if((STG_SettingsService.stgService.stgErr.Error_Notifications_To__c).startsWith(ERR_Notifier.NotificationOptions.chatterGroup)) {
-            notificationToDropDown = ERR_Notifier.NotificationOptions.chatterGroup;
+        if((STG_SettingsService.stgService.stgErr.Error_Notifications_To__c).startsWith(ERR_Notifier.ERROR_NOTIFICATION_CHATTER_PREFIX)) {
+            notificationToDropDown = ERR_Notifier.ERROR_NOTIFICATION_CHATTER_PREFIX;
         }
 
         return super.editSettings();
@@ -180,14 +180,14 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
                 UTIL_Namespace.StrTokenNSPrefix('Error_Notifications_To__c'));
 
         if (es.Error_Notifications_On__c && errorNotifRecipient != null) {
-            if (errorNotifRecipient != ERR_Notifier.notificationOptions.sysAdmins) {
+            if (errorNotifRecipient != ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS) {
                 if (!(errorNotifRecipient instanceof Id)) {
                     ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError, System.Label.healthDetailsInvalidErrorRecipient,
                             String.format(System.Label.healthSolutionEditSetting, new String[]{strSetting, System.Label.stgNavSystem, System.Label.stgNavErrorNotify}));
                     return;
                 }
 
-                if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.chatterGroup) && Schema.SObjectType.User.isFeedEnabled()) {
+                if (errorNotifRecipient.startsWith(ERR_Notifier.ERROR_NOTIFICATION_CHATTER_PREFIX) && Schema.SObjectType.User.isFeedEnabled()) {
 
                     // verify chatter group exists
                     List<SObject> listCG = Database.query('SELECT Id, Name FROM CollaborationGroup WHERE Id = :errorNotifRecipient');
@@ -200,7 +200,7 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
 
                 } else {
 
-                    if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.userPrefix)) {
+                    if (errorNotifRecipient.startsWith(ERR_Notifier.ERROR_NOTIFICATION_USER_PREFIX)) {
                         // verify user exists and is active
                         List<User> listUser = [SELECT Name, Email, IsActive FROM User WHERE Id = :errorNotifRecipient AND IsActive = True];
 

--- a/src/classes/STG_PanelERR_CTRL.cls
+++ b/src/classes/STG_PanelERR_CTRL.cls
@@ -58,7 +58,7 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
     * @description Class constructor that set error notifications recipient to the one stored in the settings.
     */
     public STG_PanelERR_CTRL() {
-    	notificationToDropDown = STG_SettingsService.stgService.stgErr.Error_Notifications_To__c;
+        notificationToDropDown = STG_SettingsService.stgService.stgErr.Error_Notifications_To__c;
     }
     
     /*******************************************************************************************************
@@ -67,13 +67,20 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
     public List<SelectOption> listSOERRNotifOptions {
         get {
             if (listSOERRNotifOptions == null) {
-                listSOERRNotifOptions = new list<SelectOption>();
+                listSOERRNotifOptions = new List<SelectOption>();
                 listSOERRNotifOptions.add(new SelectOption('None', 'None'));
-                if(Schema.SObjectType.User.isFeedEnabled())
-                    listSOERRNotifOptions.add(new SelectOption(ERR_Notifier.NotificationOptions.chatterGroup, 'Chatter Group'));
-                listSOERRNotifOptions.add(new SelectOption(ERR_Notifier.NotificationOptions.sysAdmins, 'All Sys Admins'));
-                for (User u : [select Name, id from User where User.Profile.Name = 'System Administrator']) {
-                    listSOERRNotifOptions.add(new SelectOption(u.id, 'User: ' + u.Name));
+
+                if (Schema.SObjectType.User.isFeedEnabled()) {
+                    listSOERRNotifOptions.add(new SelectOption(ERR_Notifier.notificationOptions.chatterGroup, 'Chatter Group'));
+                }
+
+                listSOERRNotifOptions.add(new SelectOption(
+                        ERR_Notifier.notificationOptions.sysAdmins,
+                        ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS)
+                );
+
+                for (User u : [SELECT Name, Id FROM User WHERE User.Profile.Name = :UTIL_Profile.SYSTEM_ADMINISTRATOR]) {
+                    listSOERRNotifOptions.add(new SelectOption(u.Id, 'User: ' + u.Name));
                 }
             }
             return listSOERRNotifOptions;
@@ -87,24 +94,32 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
     //Displays the Error Notification Recipients (View Mode only)
     public String strErrorNotifDisplayName {
         get {
-        	String errorNotifRecipient = UTIL_CustomSettingsFacade.getErrorSettings().Error_Notifications_To__c; 
-        	
+            String errorNotifRecipient = UTIL_CustomSettingsFacade.getErrorSettings().Error_Notifications_To__c;
+
             if (errorNotifRecipient != null) {
-                if (errorNotifRecipient.startsWith(ERR_Notifier.NotificationOptions.chatterGroup) && Schema.SObjectType.User.isFeedEnabled()) {
+                if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.chatterGroup)
+                        && Schema.SObjectType.User.isFeedEnabled()
+                ) {
                    strErrorNotifDisplayName = 'Group: ';
-                   List<SObject> chatterGroupsNotif = Database.query('select Id, Name from CollaborationGroup where id = :errorNotifRecipient');
-                   if(chatterGroupsNotif.size() > 0) 
+                   List<SObject> chatterGroupsNotif = Database.query(
+                           'SELECT Id, Name FROM CollaborationGroup WHERE Id = :errorNotifRecipient');
+                   if (chatterGroupsNotif.size() > 0) {
                        strErrorNotifDisplayName += chatterGroupsNotif[0].get('Name');
-                } else if (errorNotifRecipient.startsWith(ERR_Notifier.NotificationOptions.user)) {
+                   }
+
+                } else if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.userPrefix)) {
                    strErrorNotifDisplayName = 'User: ';
-                   List<User> usersNotif = [select Name from User where id = :errorNotifRecipient];
-                   if(usersNotif.size() > 0)
-                       strErrorNotifDisplayName += usersNotif[0].Name;              
+                   List<User> usersNotif = [SELECT Name FROM User WHERE Id = :errorNotifRecipient];
+                   if (usersNotif.size() > 0) {
+                       strErrorNotifDisplayName += usersNotif[0].Name;
+                   }
+
                 } else {
                    strErrorNotifDisplayName = errorNotifRecipient;
                 }
+
             } else {
-            	strErrorNotifDisplayName = '';
+                strErrorNotifDisplayName = '';
             }
             return strErrorNotifDisplayName;
         }
@@ -136,8 +151,8 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
     * @return PageReference The page to redirect to, if any.
     */
     public override PageReference cancelEdit() {
-    	saveErrorMessage = null;
-    	return super.cancelEdit();
+        saveErrorMessage = null;
+        return super.cancelEdit();
     }
     
     /*******************************************************************************************************
@@ -145,10 +160,68 @@ public with sharing class STG_PanelERR_CTRL extends STG_Panel {
     * @return PageReference The page to redirect to, if any.
     */
     public override PageReference editSettings() {
-    	if((STG_SettingsService.stgService.stgErr.Error_Notifications_To__c).startsWith(ERR_Notifier.NotificationOptions.chatterGroup)) {
-    		notificationToDropDown = ERR_Notifier.NotificationOptions.chatterGroup;
-    	}
-    	
-    	return super.editSettings();
+        if((STG_SettingsService.stgService.stgErr.Error_Notifications_To__c).startsWith(ERR_Notifier.NotificationOptions.chatterGroup)) {
+            notificationToDropDown = ERR_Notifier.NotificationOptions.chatterGroup;
+        }
+
+        return super.editSettings();
+    }
+
+    /*******************************************************************************************************
+    * @description Verifies error settings are still valid for the Health Check page
+    * @param ctrl The controller that calls the method.
+    * @return void
+    */
+    public static void verifyErrorSettings(STG_PanelHealthCheck_CTRL ctrl) {
+
+        Error_Settings__c es = UTIL_CustomSettingsFacade.getErrorSettings();
+        String errorNotifRecipient = es.Error_Notifications_To__c;
+        String strSetting = UTIL_Describe.getFieldLabel(UTIL_Namespace.StrTokenNSPrefix('Error_Settings__c'),
+                UTIL_Namespace.StrTokenNSPrefix('Error_Notifications_To__c'));
+
+        if (es.Error_Notifications_On__c && errorNotifRecipient != null) {
+            if (errorNotifRecipient != ERR_Notifier.notificationOptions.sysAdmins) {
+                if (!(errorNotifRecipient instanceof Id)) {
+                    ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError, System.Label.healthDetailsInvalidErrorRecipient,
+                            String.format(System.Label.healthSolutionEditSetting, new String[]{strSetting, System.Label.stgNavSystem, System.Label.stgNavErrorNotify}));
+                    return;
+                }
+
+                if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.chatterGroup) && Schema.SObjectType.User.isFeedEnabled()) {
+
+                    // verify chatter group exists
+                    List<SObject> listCG = Database.query('SELECT Id, Name FROM CollaborationGroup WHERE Id = :errorNotifRecipient');
+                    if (listCG.size() == 0) {
+                        ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError,
+                                String.format(System.Label.healthDetailsInvalidErrorChatterGroup, new String[]{errorNotifRecipient}),
+                                String.format(System.Label.healthSolutionEditSetting, new String[]{strSetting, System.Label.stgNavSystem, System.Label.stgNavErrorNotify}));
+                        return;
+                    }
+
+                } else {
+
+                    if (errorNotifRecipient.startsWith(ERR_Notifier.notificationOptions.userPrefix)) {
+                        // verify user exists and is active
+                        List<User> listUser = [SELECT Name, Email, IsActive FROM User WHERE Id = :errorNotifRecipient AND IsActive = True];
+
+                        if (listUser.size() == 0) {
+                            ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError,
+                                    String.format(System.Label.healthDetailsInvalidErrorUser, new String[]{errorNotifRecipient}),
+                                    String.format(System.Label.healthSolutionEditSetting, new String[]{strSetting, System.Label.stgNavSystem, System.Label.stgNavErrorNotify}));
+                            return;
+                        }
+
+                        if (listUser[0].IsActive == false) {
+                            ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusError,
+                                    String.format(System.Label.healthDetailsInvalidErrorUser, new String[]{listUser[0].Name}),
+                                    String.format(System.Label.healthSolutionEditSetting, new String[]{strSetting, System.Label.stgNavSystem, System.Label.stgNavErrorNotify}));
+                            return;
+                        }
+                    }
+                }
+            }
+            // settings ok.
+            ctrl.createDR(strSetting, STG_PanelHealthCheck_CTRL.statusSuccess, null, System.Label.healthLabelErrorRecipientValid);
+        }
     }
 }

--- a/src/classes/STG_PanelHealthCheck_CTRL.cls
+++ b/src/classes/STG_PanelHealthCheck_CTRL.cls
@@ -179,7 +179,7 @@ public without sharing class STG_PanelHealthCheck_CTRL extends STG_Panel {
         STG_PanelOppRollups_CTRL.verifyFiscalYearRollups(this);
         STG_PanelOpps_CTRL.verifyOpportunityStageForPaymentAutoCloseIsActiveClosedWon(this);
         verifyScheduledJobs();
-        ERR_Notifier.verifyErrorSettings(this);
+        STG_PanelERR_CTRL.verifyErrorSettings(this);
         verifyOppContactRoles();
         verifyOppContactRolesSettings();
         verifyTriggerHandlers();

--- a/src/classes/USER_InActiveUser_TDTM_TEST.cls
+++ b/src/classes/USER_InActiveUser_TDTM_TEST.cls
@@ -60,7 +60,7 @@ public with sharing class USER_InActiveUser_TDTM_TEST {
         Test.stopTest();
 
         Error_Settings__c errorSettingsSysAdmin = UTIL_CustomSettingsFacade.getErrorSettings();
-        System.assertEquals(USER_UserService.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS, errorSettingsSysAdmin.Error_Notifications_To__c);
+        System.assertEquals(ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS, errorSettingsSysAdmin.Error_Notifications_To__c);
     }
 
 

--- a/src/classes/USER_UserService.cls
+++ b/src/classes/USER_UserService.cls
@@ -35,12 +35,11 @@
 * @description Service Class to handle actions on the User object.
 */
 public with sharing class USER_UserService {
-    public static final String OBJECT_ID_PREFIX_USER = '005';
-    public static final String ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS = 'All Sys Admins';
+
+    public static final String OBJECT_ID_PREFIX_USER = User.SObjectType.getDescribe().getKeyPrefix();
     public static final String JOB_TYPE_SCHEDULED_APEX = '7';
     public static final String ERROR_TYPE_SCHEDULED_APEX = 'Scheduled Apex Error';
     public static final String OBJECT_TYPE_USER = 'User';
-
 
     /*********************************************************************************************************
     * @description Determines if a User in the List is a System Administrator based on ProfileId.
@@ -137,7 +136,7 @@ public with sharing class USER_UserService {
         if (errorSettings.Error_Notifications_To__c.startsWith(OBJECT_ID_PREFIX_USER)) {
             for (Id currentSysAdminId: sysAdminUserIds) {
                 if (errorSettings.Error_Notifications_To__c == currentSysAdminId) {
-                    errorSettings.Error_Notifications_To__c = ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS;
+                    errorSettings.Error_Notifications_To__c = ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS;
                     Database.update(errorSettings, true);
                     break;
                 }

--- a/src/classes/USER_UserService_TEST.cls
+++ b/src/classes/USER_UserService_TEST.cls
@@ -86,7 +86,7 @@ public with sharing class USER_UserService_TEST {
         Test.stopTest();
 
         Error_Settings__c errorSettingsSysAdmin = UTIL_CustomSettingsFacade.getErrorSettings();
-        System.assertEquals(USER_UserService.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS, errorSettingsSysAdmin.Error_Notifications_To__c);    
+        System.assertEquals(ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS, errorSettingsSysAdmin.Error_Notifications_To__c);
     }
 
 
@@ -109,7 +109,7 @@ public with sharing class USER_UserService_TEST {
         Test.stopTest();
 
         Error_Settings__c errorSettingsSysAdmin = UTIL_CustomSettingsFacade.getErrorSettings();
-        System.assertEquals(USER_UserService.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS, errorSettingsSysAdmin.Error_Notifications_To__c);
+        System.assertEquals(ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS, errorSettingsSysAdmin.Error_Notifications_To__c);
     }
 
 

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -586,7 +586,7 @@ public without sharing class UTIL_CustomSettingsFacade {
     private static void configErrorSettings(Error_Settings__c es, String notificationsTo) {
         es.Store_Errors_On__c = true;
         es.Error_Notifications_On__c = true;
-        es.Error_Notifications_To__c = ERR_Notifier.NotificationOptions.sysAdmins;
+        es.Error_Notifications_To__c = ERR_Notifier.ERROR_NOTIFICATION_RECIPIENT_ALL_SYS_ADMINS;
         es.Disable_Error_Handling__c = false;
         es.Enable_Debug__c = false;
         es.Respect_Duplicate_Rule_Settings__c = false;

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1184,11 +1184,11 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>ErrorEmailMessage</shortDescription>
-        <value>Salesforce reported the below errors as NPSP was attempting to execute its batch jobs, or at a time when it was unable to display error messages directly to a user. It’s likely that NPSP was attempting to update summary fields on Accounts and Contacts, but was unable to save certain records. This failure might have been caused by a variety of issues unrelated to NPSP, such as custom code or validation rules.
+        <value>Salesforce reported the below errors as NPSP was attempting to execute its batch jobs, or at a time when it was unable to display error messages directly to a user. It&apos;s likely that NPSP was attempting to update summary fields on Accounts and Contacts, but was unable to save certain records. This failure might have been caused by a variety of issues unrelated to NPSP, such as custom code or validation rules.
 
 Read this article on the Power of Us Hub to learn how these Scheduled Jobs work: https://powerofus.force.com/NPSP_Scheduled_Jobs
 
-If you’re not sure how to resolve these errors, post a message in the Nonprofit Success Pack group in the Power of Us Hub: https://powerofus.force.com/HUB_NPSP_Group</value>
+If you&apos;re not sure how to resolve these errors, post a message in the Nonprofit Success Pack group in the Power of Us Hub: https://powerofus.force.com/HUB_NPSP_Group</value>
     </labels>
     <labels>
         <fullName>HiddenForSecurity</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes

* Resolve two issues where the scheduled ERR_Notifier job consistently fails. These fixes eliminate scenarios where the Error Notification job created additional Error__c records, which would continue to perpetuate the job failure issue. Customers who had previously configured error notification via email or chatter, but who had not been receiving these notifications may find that they are now working again.
    1. When either Email or Chatter Post notification is enabled and there are more than 50,000 Error__c records in an org, limit the number of error notifications to the most recent 500 errors created in the last 48 hours. Note that this would normally be a single email with a list of all the errors.
    1.  If the User or Chatter Group specified for Error notification is either inactive or has been deleted, the error notification job will simply mute the error rather than fail the job.

# Issues Closed

# New Metadata

# Deleted Metadata
