### PR TITLE
Add new batch size for Account Soft Credit Rollups

### DIFF
--- a/src/classes/CRLP_RecalculateBTN_TEST.cls
+++ b/src/classes/CRLP_RecalculateBTN_TEST.cls
@@ -162,6 +162,7 @@ private class CRLP_RecalculateBTN_TEST {
                         Rollups_Contact_SkewMode_Batch_Size__c = 200,
                         Rollups_Contact_Soft_Credit_Batch_Size__c = 200,
                         Rollups_Account_Soft_Credit_Batch_Size__c = 200,
+                        Rollups_AcctContactSoftCredit_Batch_Size__c = 200,
                         Rollups_Account_Batch_Size__c = 20,
                         Rollups_Contact_Batch_Size__c = 20,
                         Rollups_GAU_Batch_Size__c = 400

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -276,6 +276,9 @@ public class CRLP_RollupBatch_SVC {
                                 when ContactSoftCredit {
                                     batchSize = customizableRollupSettings.Rollups_Contact_Soft_Credit_Batch_Size__c;
                                 }
+                                when AccountSoftCredit {
+                                    batchSize = customizableRollupSettings.Rollups_AccSoftCredit_Batch_Size__c;
+                                }
                             }
                         }
                         when else {
@@ -291,6 +294,9 @@ public class CRLP_RollupBatch_SVC {
                                 }
                                 when ContactSoftCredit {
                                     batchSize = customizableRollupSettings.Rollups_Contact_SkewMode_Batch_Size__c;
+                                }
+                                when AccountSoftCredit {
+                                    batchSize = customizableRollupSettings.Rollups_AccSoftCredit_Skew_Batch_Size__c;
                                 }
                             }
                         }

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -271,13 +271,13 @@ public class CRLP_RollupBatch_SVC {
                                     batchSize = customizableRollupSettings.Rollups_Contact_Batch_Size__c;
                                 }
                                 when AccountContactSoftCredit {
-                                    batchSize = customizableRollupSettings.Rollups_Account_Soft_Credit_Batch_Size__c;
+                                    batchSize = customizableRollupSettings.Rollups_AcctContactSoftCredit_Batch_Size__c;
                                 }
                                 when ContactSoftCredit {
                                     batchSize = customizableRollupSettings.Rollups_Contact_Soft_Credit_Batch_Size__c;
                                 }
                                 when AccountSoftCredit {
-                                    batchSize = customizableRollupSettings.Rollups_AccSoftCredit_Batch_Size__c;
+                                    batchSize = customizableRollupSettings.Rollups_Account_Soft_Credit_Batch_Size__c;
                                 }
                             }
                         }
@@ -296,7 +296,7 @@ public class CRLP_RollupBatch_SVC {
                                     batchSize = customizableRollupSettings.Rollups_Contact_SkewMode_Batch_Size__c;
                                 }
                                 when AccountSoftCredit {
-                                    batchSize = customizableRollupSettings.Rollups_AccSoftCredit_Skew_Batch_Size__c;
+                                    batchSize = customizableRollupSettings.Rollups_Account_SkewMode_Batch_Size__c;
                                 }
                             }
                         }

--- a/src/classes/CRLP_RollupRecurringDonation_TEST.cls
+++ b/src/classes/CRLP_RollupRecurringDonation_TEST.cls
@@ -132,6 +132,7 @@ private class CRLP_RollupRecurringDonation_TEST {
                 Rollups_Contact_SkewMode_Batch_Size__c = 200,
                 Rollups_Account_Soft_Credit_Batch_Size__c = 200,
                 Rollups_Contact_Soft_Credit_Batch_Size__c = 200,
+                Rollups_AcctContactSoftCredit_Batch_Size__c = 200,
                 Rollups_Account_Batch_Size__c = 20,
                 Rollups_Contact_Batch_Size__c = 20
         ));

--- a/src/classes/CRLP_RollupSoftCredit_TEST.cls
+++ b/src/classes/CRLP_RollupSoftCredit_TEST.cls
@@ -179,6 +179,7 @@ public class CRLP_RollupSoftCredit_TEST {
                 Rollups_Contact_SkewMode_Batch_Size__c = 600,
                 Rollups_Contact_Soft_Credit_Batch_Size__c = 600,
                 Rollups_Account_Soft_Credit_Batch_Size__c = 600,
+                Rollups_AcctContactSoftCredit_Batch_Size__c = 600,
                 Rollups_Account_Batch_Size__c = 20,
                 Rollups_Contact_Batch_Size__c = 20
             ));

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -317,7 +317,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
     * added
     */
     private void createNewDefaultCustomSettingRecords() {
-        UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
+        updateDefaultRollupSettings();
         updateDefaultOrgContactsSettings();
     }
 
@@ -331,6 +331,30 @@ global without sharing class STG_InstallScript implements InstallHandler {
             npe01Settings.Contact_Role_for_Organizational_Opps__c = UTIL_CustomSettingsFacade.DEFAULT_OPPORTUNITY_CONTACT_ROLE_SOFT_CREDIT;
             update npe01Settings;
         }
+    }
+
+    /*******************************************************************************************************
+    * @description Ensure that any default Org Rollup Settigns are updated for custom settings 
+    * objects accordingly.
+    */
+    public static void updateDefaultRollupSettings() {
+        Customizable_Rollup_Settings__c rollupSettings = UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
+        Boolean isUpdateNeeded = false;
+
+        if (rollupSettings.Rollups_AccSoftCredit_Skew_Batch_Size__c == null) {
+            rollupSettings.Rollups_AccSoftCredit_Skew_Batch_Size__c = UTIL_CustomSettingsFacade.DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
+            isUpdateNeeded = true;
+        }
+
+        if (rollupSettings.Rollups_AccSoftCredit_Batch_Size__c == null) {
+            rollupSettings.Rollups_AccSoftCredit_Batch_Size__c = UTIL_CustomSettingsFacade.DEFAULT_ROLLUP_BATCH_SIZE;
+            isUpdateNeeded = true;
+        }
+        
+        if (isUpdateNeeded) {
+            update rollupSettings;
+        }
+        
     }
 
     /*******************************************************************************************************

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -335,19 +335,20 @@ global without sharing class STG_InstallScript implements InstallHandler {
 
     /*******************************************************************************************************
     * @description Ensure that any default Org Rollup Settigns are updated for custom settings 
-    * objects accordingly.
+    * objects accordingly.  There was a swap of custom setting fields to get the account soft credit settings
+    * pointed to the corresponding setting
     */
     public static void updateDefaultRollupSettings() {
         Customizable_Rollup_Settings__c rollupSettings = UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
         Boolean isUpdateNeeded = false;
+        Decimal currentAccountSoftCreditBatchSize = UTIL_CustomSettingsFacade.DEFAULT_ROLLUP_BATCH_SIZE;
 
-        if (rollupSettings.Rollups_AccSoftCredit_Skew_Batch_Size__c == null) {
-            rollupSettings.Rollups_AccSoftCredit_Skew_Batch_Size__c = UTIL_CustomSettingsFacade.DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
-            isUpdateNeeded = true;
+        if (rollupSettings.Rollups_Account_Soft_Credit_Batch_Size__c != null) {
+            currentAccountSoftCreditBatchSize = rollupSettings.Rollups_Account_Soft_Credit_Batch_Size__c;
         }
 
-        if (rollupSettings.Rollups_AccSoftCredit_Batch_Size__c == null) {
-            rollupSettings.Rollups_AccSoftCredit_Batch_Size__c = UTIL_CustomSettingsFacade.DEFAULT_ROLLUP_BATCH_SIZE;
+        if (rollupSettings.Rollups_AcctContactSoftCredit_Batch_Size__c == null) {
+            rollupSettings.Rollups_AcctContactSoftCredit_Batch_Size__c = currentAccountSoftCreditBatchSize;
             isUpdateNeeded = true;
         }
         

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -43,92 +43,112 @@ public with sharing class STG_InstallScript_TEST {
     */
     private class STG_InstallException extends Exception {}
     
-    /** NPSP to TDTM test - to verify no exception is thrown if the custom settings don't exist **/
-    public testmethod static void mappingsTest_runScriptNoCustomSettings() {
-        //Don't create NPSP custom settings
-        
-        //Run the install script
+    /*********************************************************************************************************
+    @description 
+        Test install on a new org populates the default settings and 
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults.
+    **********************************************************************************************************/ 
+    @isTest
+    public static void newInstallCreatesDefaultSettings() {
         Test.testInstall(new STG_InstallScript(), null);
-        
-        //Verify all settings created
         verifyAllSettingsCreated();
     }
     
-    /** Tests that missing trigger handlers get created **/
-    public static testmethod void missingSettingsCreated() {
-        //Create some of the default settings
+    /*********************************************************************************************************
+    @description 
+        Test install on org with some partial settings will still populate the default settings and 
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults.
+    **********************************************************************************************************/
+    @isTest
+    public static void newInstallPopulatesMissingSettings() {
         createSomeDefaultSettings();
-        
-        //Run the install script               
         Test.testInstall(new STG_InstallScript(), null);
-        
-        //Verify all settings created
         verifyAllSettingsCreated();
     }
 
-    /** Tests that deleted class trigger handlers get deleted **/
-    public static testmethod void deletedHandlers() {
-        //Create some of the default settings
+    /*********************************************************************************************************
+    @description 
+        Test install on org with some deprecated settings will still populate the default settings and 
+        remove the deprecated setting
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults.
+    **********************************************************************************************************/
+    @isTest
+    public static void newInstallRemovesDeprecatedSettings() {
         createSomeDefaultSettings();
 
-        // HH Object contact trigger support
         insert new Trigger_Handler__c(Active__c = true, Asynchronous__c = false, 
               Class__c = 'OPP_OpportunityNaming_TDTM', Load_Order__c = 0, Object__c = 'Opportunity', 
-              Trigger_Action__c = 'AfterInsert;AfterUpdate;AfterDelete');        
+              Trigger_Action__c = 'AfterInsert;AfterUpdate;AfterDelete');
 
-        //Run the install script               
         Test.testInstall(new STG_InstallScript(), null);
-        
-        //Verify all settings created
         verifyAllSettingsCreated();
     }
     
-    public testmethod static void push() {
-        //Create some of the default settings
+    /*********************************************************************************************************
+    @description 
+        Test a push install will create the default settings and update any partial settings 
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults
+    **********************************************************************************************************/
+    @isTest
+    public static void pushInstallCreatesDefaultSettingsAndPopulatesPartialSettings() {
         createSomeDefaultSettings();
         Customizable_Rollup_Settings__c expectedConfig = buildRollupSettingsWithPartialValues();
-        
-        //Run the install script               
         Test.testInstall(new STG_InstallScript(), new Version(1,0), true);
-        
-        //Verify all settings created
         verifyAllSettingsCreated();
-
-        // Verify rollup Settings
         assertRollupSettingsEqual(expectedConfig);
     }
     
-    public testmethod static void upgrade() {
-        //Create some of the default settings
+    /*********************************************************************************************************
+    @description 
+        Test a manual upgrade install will create the default settings and update any partial settings 
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults
+    **********************************************************************************************************/
+    @isTest
+    public static void upgradeInstallCreatesDefaultSettingsAndPopulatesPartialSettings() {
         createSomeDefaultSettings();
-        
-        //Run the install script               
+        Customizable_Rollup_Settings__c expectedConfig = buildRollupSettingsWithPartialValues();
         Test.testInstall(new STG_InstallScript(), new Version(1,0), false);
-        
-        //Verify all settings created
         verifyAllSettingsCreated();
+        assertRollupSettingsEqual(expectedConfig);
     }
     
-    /** NPSP to TDTM test - If it's the first time we install Cumulus and there was no custom DISABLE flag enabled **/
-    public testmethod static void mappingsTest_runScriptNoCustomConfigOnInstall() {
-        //Create NPSP custom settings with all disable flags off
+    /*********************************************************************************************************
+    @description 
+        Test new install with flags all disable flags off will still create all the default settings
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults
+    **********************************************************************************************************/
+    @isTest
+    public static void newInstallWithDisableFlagsOffCreatesDefaultSettings() {
         setAllNpspFlags(false);
-               
-        Test.testInstall(new STG_InstallScript(), null);        
-        
+        Test.testInstall(new STG_InstallScript(), null);
         verifyAllSettingsCreated();
     }
     
-    /** NPSP to TDTM test - If it's the first time we install Cumulus and all the custom DISABLE flag were enabled **/
-    public testmethod static void mappingsTest_runScriptCustomConfigOnInstallAllFlags() {
-        //Create NPSP custom settings with all disable flags on
+    /*********************************************************************************************************
+    @description 
+        Test new install with flags all disable flags on will still create all the default settings
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults
+    **********************************************************************************************************/
+    @isTest
+    public static void newInstallWithDisableFlagsEnabledCreatesDefaultSettings() {
         setAllNpspFlags(true);
-
         Test.testInstall(new STG_InstallScript(), null);
         
-        //Get the TDTM classes that map to the NPSP flags
         List<String> tdtmClasses = TDTM_DefaultConfig.getNpspToCumulusMap().values();
-        //Remove empty values
         Set<String> tdtmClassesWithValues = new Set<String>();
         for(String tdtmClass : tdtmClasses) {
             if(!String.isBlank(tdtmClass)) {
@@ -146,12 +166,18 @@ public with sharing class STG_InstallScript_TEST {
         System.assertEquals(tdtmClassesWithValues.size(), afterScriptConfigClassNames.size(),
                 'The number of inactive handler classes does not match the expected value');
 
-        //Assert old flags have been properly disabled
         assertNpspFlagsDeactivated();
     }
     
-     /** NPSP to TDTM test - If it's the first time we install Cumulus and some the custom DISABLE flag were enabled **/
-    public testmethod static void mappingsTest_runScriptCustomConfigOnInstallSomeFlags() {
+    /*********************************************************************************************************
+    @description 
+        Test new install with flags some disable flags on will still create all the default settings
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults
+    **********************************************************************************************************/
+    @isTest
+    public static void newInstallWithSomeDisableFlagsEnabledCreatesDefaultSettings() {
         //Create NPSP custom settings with some disable flags on
         List<SObject> settingsToUpdate = new List<SObject>();
         
@@ -177,8 +203,15 @@ public with sharing class STG_InstallScript_TEST {
         assertNpspFlagsDeactivated();
     }
 
-    public static testmethod void defaultSettingsCreated() {
-        //Clear all custom settings
+    /*********************************************************************************************************
+    @description 
+        Test new install with custom settings explicitly deleted will still create the default settings
+        no exception is thrown if the custom settings don't exist
+    verify:
+        Settings match the expected defaults
+    **********************************************************************************************************/
+    @isTest
+    public static void newInstallWithDeletedCustomSettingsCreatesDefaultSettings() {
         deleteAllCustomSettings();
                        
         Test.testInstall(new STG_InstallScript(), null);
@@ -261,8 +294,10 @@ public with sharing class STG_InstallScript_TEST {
     verify:
         Successful install actions are applied if another install action results in an error 
     **********************************************************************************************************/ 
-    private static testMethod void testInstallActionsAreIndependent() {
-        UTIL_RecordTypeSettingsUpdate_TEST.UpdateSettingsMock mockUpdateSettings = new UTIL_RecordTypeSettingsUpdate_TEST.UpdateSettingsMock().throwException();
+    @isTest
+    private static void testInstallActionsAreIndependent() {
+        UTIL_RecordTypeSettingsUpdate_TEST.UpdateSettingsMock mockUpdateSettings = 
+        new UTIL_RecordTypeSettingsUpdate_TEST.UpdateSettingsMock().throwException();
         UTIL_RecordTypeSettingsUpdate.instance = mockUpdateSettings;
 
         List<Trigger_Handler__c> triggerHandlers = getTriggerHandlers();
@@ -284,7 +319,8 @@ public with sharing class STG_InstallScript_TEST {
     verify:
         Opportunities' Recurring Donation Installment Number is populated.
     **********************************************************************************************************/ 
-    private static testMethod void testNewInstallSetsRecurringDonationInstallmentNumber() {
+    @isTest
+    private static void testNewInstallSetsRecurringDonationInstallmentNumber() {
         npe03__Recurring_Donation__c rd = createRecurringDonation();
         List<Opportunity> opps = getRecurringDonationOpportunities(rd.Id);
         System.assertEquals(false, opps.isEmpty(), 'At least one Opportunity should be created for the Recurring Donation');
@@ -318,7 +354,8 @@ public with sharing class STG_InstallScript_TEST {
     verify:
         hasErrors() returns true
     **********************************************************************************************************/ 
-    private static testMethod void testErrorLoggerHasErrorsReturnsTrue() {
+    @isTest
+    private static void testErrorLoggerHasErrorsReturnsTrue() {
         STG_InstallScript.ErrorLogger logger = new STG_InstallScript.ErrorLogger(null, ERR_Handler_API.Context.STTG);
 
         logger.add(new STG_InstallException('Test Exception'));
@@ -332,7 +369,8 @@ public with sharing class STG_InstallScript_TEST {
     verify:
         hasErrors() returns false
     **********************************************************************************************************/ 
-    private static testMethod void testErrorLoggerHasErrorsReturnsFalse() {
+    @isTest
+    private static void testErrorLoggerHasErrorsReturnsFalse() {
         STG_InstallScript.ErrorLogger logger = new STG_InstallScript.ErrorLogger(null, ERR_Handler_API.Context.STTG);
 
         System.assert(!logger.hasErrors(), 'Logger should return false since it contains no exception');
@@ -344,7 +382,8 @@ public with sharing class STG_InstallScript_TEST {
     verify:
         The email body contains exception message and stack trace
     **********************************************************************************************************/ 
-    private static testMethod void testErrorLoggerCorrectlyBuildsEmailBody() {
+    @isTest
+    private static void testErrorLoggerCorrectlyBuildsEmailBody() {
         STG_InstallScript.ErrorLogger logger = new STG_InstallScript.ErrorLogger(null, ERR_Handler_API.Context.STTG);
 
         logger.add(new STG_InstallException('Test Exception 1'));
@@ -367,7 +406,8 @@ public with sharing class STG_InstallScript_TEST {
         - Exceptions are emailed.
         - Exception is stored as the error sObject record.
     **********************************************************************************************************/ 
-    private static testMethod void testExceptionsAreEmailedAndLogged() {
+    @isTest
+    private static void testExceptionsAreEmailedAndLogged() {
         Integer emailInvocations = Limits.getEmailInvocations();
 
         UTIL_RecordTypeSettingsUpdate_TEST.UpdateSettingsMock mockUpdateSettings = new UTIL_RecordTypeSettingsUpdate_TEST.UpdateSettingsMock().throwException();
@@ -392,7 +432,8 @@ public with sharing class STG_InstallScript_TEST {
         - No email is sent.
         - No exception is stored as the error sObject record.
     **********************************************************************************************************/ 
-    private static testMethod void testNoEmailIsSentOrErrorLoggedOnSuccessfulInstall() {
+    @isTest
+    private static void testNoEmailIsSentOrErrorLoggedOnSuccessfulInstall() {
         Integer emailInvocations = Limits.getEmailInvocations();
 
         UTIL_RecordTypeSettingsUpdate.instance = new UTIL_RecordTypeSettingsUpdate_TEST.UpdateSettingsMock();
@@ -408,8 +449,9 @@ public with sharing class STG_InstallScript_TEST {
         System.assertEquals(emailInvocations, actualEmailInvocations, 'Email Invocations should not increase');
     }
     
-    // Helpers
-    ////////////
+    /*********************************************************************************************************
+     * Helpers
+    **********************************************************************************************************/ 
 
     private static void assertTriggerHandlersEqual(List<Trigger_Handler__c> afterScriptConfig, List<Trigger_Handler__c> defaultConfig) {
         afterScriptConfig.sort();
@@ -457,6 +499,9 @@ public with sharing class STG_InstallScript_TEST {
         System.assertEquals(ROLLUP_BATCH_SIZE, afterScriptConfig.Rollups_AcctContactSoftCredit_Batch_Size__c, 'The setting should be set to the batch size');
     }
 
+    /*********************************************************************************************************
+    @description Enables or disables all NPSP flag settings based on the flag value
+    **********************************************************************************************************/ 
     private static void setAllNpspFlags(Boolean flagValue) {
         npe01__Contacts_And_Orgs_Settings__c npe01Settings = UTIL_CustomSettingsFacade.getOrgContactsSettings();
         npe01Settings.npe01__DISABLE_IndividualAccounts_trigger__c = flagValue;
@@ -520,6 +565,7 @@ public with sharing class STG_InstallScript_TEST {
         if(errorSettings.Id != null) delete errorSettings;
     }
     
+
     public static void createSomeDefaultSettings() {
         List<Trigger_Handler__c> handlers = new List<Trigger_Handler__c>();
         
@@ -602,6 +648,10 @@ public with sharing class STG_InstallScript_TEST {
         return rd;
     }
 
+    /*******************************************************************************************************
+    * @description Gets errors.
+    * @return List<Error__c> The List of errors.
+    ********************************************************************************************************/
     private static List<Opportunity> getRecurringDonationOpportunities(Id rdId) {
         return [
             SELECT Id, Recurring_Donation_Installment_Number__c 

--- a/src/classes/STG_InstallScript_TEST.cls
+++ b/src/classes/STG_InstallScript_TEST.cls
@@ -36,6 +36,8 @@
 @isTest
 public with sharing class STG_InstallScript_TEST {
 
+    private static final Integer ROLLUP_BATCH_SIZE = 333;
+
     /*******************************************************************************************************
     * @description A test exception class 
     */
@@ -84,12 +86,16 @@ public with sharing class STG_InstallScript_TEST {
     public testmethod static void push() {
         //Create some of the default settings
         createSomeDefaultSettings();
+        Customizable_Rollup_Settings__c expectedConfig = buildRollupSettingsWithPartialValues();
         
         //Run the install script               
         Test.testInstall(new STG_InstallScript(), new Version(1,0), true);
         
         //Verify all settings created
         verifyAllSettingsCreated();
+
+        // Verify rollup Settings
+        assertRollupSettingsEqual(expectedConfig);
     }
     
     public testmethod static void upgrade() {
@@ -425,6 +431,32 @@ public with sharing class STG_InstallScript_TEST {
         }
     }
 
+    /*********************************************************************************************************
+    @description 
+        Verify that the Customizable Rollup Settings matches the expected Configuration
+    **********************************************************************************************************/ 
+    private static void assertRollupSettingsEqual(Customizable_Rollup_Settings__c expectedConfig) {
+        
+        Customizable_Rollup_Settings__c afterScriptConfig = UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
+
+        System.assertEquals(expectedConfig.Customizable_Rollups_Enabled__c, afterScriptConfig.Customizable_Rollups_Enabled__c, 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Account_Batch_Size__c, afterScriptConfig.Rollups_Account_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Contact_Batch_Size__c, afterScriptConfig.Rollups_Contact_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Account_SkewMode_Batch_Size__c, afterScriptConfig.Rollups_Account_SkewMode_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Contact_SkewMode_Batch_Size__c, afterScriptConfig.Rollups_Contact_SkewMode_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Account_Soft_Credit_Batch_Size__c, afterScriptConfig.Rollups_Account_Soft_Credit_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Contact_Soft_Credit_Batch_Size__c, afterScriptConfig.Rollups_Contact_Soft_Credit_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_AcctContactSoftCredit_Batch_Size__c, afterScriptConfig.Rollups_AcctContactSoftCredit_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_GAU_Batch_Size__c, afterScriptConfig.Rollups_GAU_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Skew_Dispatcher_Batch_Size__c, afterScriptConfig.Rollups_Skew_Dispatcher_Batch_Size__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Rollups_Limit_on_Attached_Opps_for_Skew__c, afterScriptConfig.Rollups_Limit_on_Attached_Opps_for_Skew__c , 'The settings should match');
+        System.assertEquals(expectedConfig.Disable_Related_Records_Filter__c, afterScriptConfig.Disable_Related_Records_Filter__c , 'The settings should match');
+        System.assertEquals(expectedConfig.AccountHardCreditNonSkew_Incremental__c, afterScriptConfig.AccountHardCreditNonSkew_Incremental__c , 'The settings should match');
+        System.assertEquals(expectedConfig.ContactHardCreditNonSkew_Incremental__c, afterScriptConfig.ContactHardCreditNonSkew_Incremental__c , 'The settings should match');
+
+        System.assertEquals(ROLLUP_BATCH_SIZE, afterScriptConfig.Rollups_AcctContactSoftCredit_Batch_Size__c, 'The setting should be set to the batch size');
+    }
+
     private static void setAllNpspFlags(Boolean flagValue) {
         npe01__Contacts_And_Orgs_Settings__c npe01Settings = UTIL_CustomSettingsFacade.getOrgContactsSettings();
         npe01Settings.npe01__DISABLE_IndividualAccounts_trigger__c = flagValue;
@@ -519,7 +551,7 @@ public with sharing class STG_InstallScript_TEST {
         insert handlers;
     }
     
-    public static void verifyAllSettingsCreated() {        
+    public static void verifyAllSettingsCreated() {
         assertTriggerHandlersEqual(getTriggerHandlers(), TDTM_DefaultConfig.getDefaultRecords());
     }
 
@@ -530,6 +562,26 @@ public with sharing class STG_InstallScript_TEST {
                 Load_Order__c, Object__c, Trigger_Action__c 
             FROM Trigger_Handler__c
         ];
+    }
+
+    /*********************************************************************************************************
+    @description 
+        Create a new Rollup With Partial Values Set 
+    **********************************************************************************************************/ 
+    private static Customizable_Rollup_Settings__c buildRollupSettingsWithPartialValues() {
+        return UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c (
+                Customizable_Rollups_Enabled__c = true,
+                Rollups_Limit_on_Attached_Opps_for_Skew__c = 150,
+                Rollups_Account_Batch_Size__c = 20,
+                Rollups_GAU_Batch_Size__c = 400,
+                Rollups_Account_SkewMode_Batch_Size__c = 100,
+                Rollups_Contact_SkewMode_Batch_Size__c = 100,
+                Rollups_Contact_Soft_Credit_Batch_Size__c = 100,
+                Rollups_Account_Soft_Credit_Batch_Size__c = ROLLUP_BATCH_SIZE,
+                Rollups_AcctContactSoftCredit_Batch_Size__c = null
+            )
+        );
     }
 
     private static npe03__Recurring_Donation__c createRecurringDonation() {

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -38,6 +38,9 @@ public without sharing class UTIL_CustomSettingsFacade {
     private static final String DEFAULT_OPPORTUNITY_CONTACT_ROLE_DONOR = 'Donor';
     public static final String DEFAULT_OPPORTUNITY_CONTACT_ROLE_SOFT_CREDIT = 'Soft Credit';
 
+    public static final Integer DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE = 1000;
+    public static final Integer DEFAULT_ROLLUP_BATCH_SIZE = 200;
+
     //storing user-level custom settings in-memory to avoid trying to isert/update them
     //twice and thus trigger the "duplicate OwnerId" error
     static npe01__Contacts_And_Orgs_Settings__c contactsSettings;
@@ -870,13 +873,15 @@ public without sharing class UTIL_CustomSettingsFacade {
     private static void configRollupSettings(Customizable_Rollup_Settings__c crs) {
         // New default settings for the Customizable Rollups engine
         crs.Customizable_Rollups_Enabled__c = false;
-        crs.Rollups_Account_Batch_Size__c = 200;
-        crs.Rollups_Contact_Batch_Size__c = 200;
-        crs.Rollups_Account_SkewMode_Batch_Size__c = 1000;
-        crs.Rollups_Contact_SkewMode_Batch_Size__c = 1000;
-        crs.Rollups_Account_Soft_Credit_Batch_Size__c = 200;
-        crs.Rollups_Contact_Soft_Credit_Batch_Size__c = 200;
-        crs.Rollups_GAU_Batch_Size__c = 1000;
+        crs.Rollups_Account_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
+        crs.Rollups_Contact_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
+        crs.Rollups_Account_SkewMode_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
+        crs.Rollups_Contact_SkewMode_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
+        crs.Rollups_Account_Soft_Credit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
+        crs.Rollups_Contact_Soft_Credit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
+        crs.Rollups_AccSoftCredit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
+        crs.Rollups_AccSoftCredit_Skew_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
+        crs.Rollups_GAU_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
         crs.Rollups_Skew_Dispatcher_Batch_Size__c = 300;
         crs.Rollups_Limit_on_Attached_Opps_for_Skew__c = 250;
         crs.Disable_Related_Records_Filter__c = false;

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -879,8 +879,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         crs.Rollups_Contact_SkewMode_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
         crs.Rollups_Account_Soft_Credit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
         crs.Rollups_Contact_Soft_Credit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
-        crs.Rollups_AccSoftCredit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
-        crs.Rollups_AccSoftCredit_Skew_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
+        crs.Rollups_AcctContactSoftCredit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
         crs.Rollups_GAU_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
         crs.Rollups_Skew_Dispatcher_Batch_Size__c = 300;
         crs.Rollups_Limit_on_Attached_Opps_for_Skew__c = 250;
@@ -906,6 +905,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         customizableRollupSettings.Rollups_Contact_Batch_Size__c = mySettings.Rollups_Contact_Batch_Size__c;
         customizableRollupSettings.Rollups_Account_Soft_Credit_Batch_Size__c = mySettings.Rollups_Account_Soft_Credit_Batch_Size__c;
         customizableRollupSettings.Rollups_Contact_Soft_Credit_Batch_Size__c = mySettings.Rollups_Contact_Soft_Credit_Batch_Size__c;
+        customizableRollupSettings.Rollups_AcctContactSoftCredit_Batch_Size__c = mySettings.Rollups_AcctContactSoftCredit_Batch_Size__c;
         customizableRollupSettings.Rollups_Account_SkewMode_Batch_Size__c  = mySettings.Rollups_Account_SkewMode_Batch_Size__c;
         customizableRollupSettings.Rollups_Contact_SkewMode_Batch_Size__c  = mySettings.Rollups_Contact_SkewMode_Batch_Size__c;
         customizableRollupSettings.Rollups_GAU_Batch_Size__c = mySettings.Rollups_GAU_Batch_Size__c;

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -40,6 +40,9 @@ public without sharing class UTIL_CustomSettingsFacade {
 
     public static final Integer DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE = 1000;
     public static final Integer DEFAULT_ROLLUP_BATCH_SIZE = 200;
+    public static final Integer DEFAULT_ROLLUP_SKEW_DISPATCHER_SIZE = 300;
+    public static final Integer DEFAULT_ROLLUP_ATTACHED_OPP_SKEW_LIMIT  = 250;
+
 
     //storing user-level custom settings in-memory to avoid trying to isert/update them
     //twice and thus trigger the "duplicate OwnerId" error
@@ -881,8 +884,8 @@ public without sharing class UTIL_CustomSettingsFacade {
         crs.Rollups_Contact_Soft_Credit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
         crs.Rollups_AcctContactSoftCredit_Batch_Size__c = DEFAULT_ROLLUP_BATCH_SIZE;
         crs.Rollups_GAU_Batch_Size__c = DEFAULT_ROLLUP_SKEW_MODE_BATCH_SIZE;
-        crs.Rollups_Skew_Dispatcher_Batch_Size__c = 300;
-        crs.Rollups_Limit_on_Attached_Opps_for_Skew__c = 250;
+        crs.Rollups_Skew_Dispatcher_Batch_Size__c = DEFAULT_ROLLUP_SKEW_DISPATCHER_SIZE;
+        crs.Rollups_Limit_on_Attached_Opps_for_Skew__c = DEFAULT_ROLLUP_ATTACHED_OPP_SKEW_LIMIT;
         crs.Disable_Related_Records_Filter__c = false;
         crs.AccountHardCreditNonSkew_Incremental__c = true;
         crs.ContactHardCreditNonSkew_Incremental__c = true;

--- a/src/objects/Customizable_Rollup_Settings__c.object
+++ b/src/objects/Customizable_Rollup_Settings__c.object
@@ -116,6 +116,34 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Rollups_AccSoftCredit_Batch_Size__c</fullName>
+        <defaultValue>200</defaultValue>
+        <description>Only used by the new Customizable Rollups engine</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Number of records per batch to process when recalculating soft credit donor rollups to the Account object.</inlineHelpText>
+        <label>Account Soft Credit Batch Size</label>
+        <precision>6</precision>
+        <required>false</required>
+        <scale>0</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Rollups_AccSoftCredit_Skew_Batch_Size__c</fullName>
+        <defaultValue>1000</defaultValue>
+        <description>Only used by the new Customizable Rollups engine</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Number of records per batch to process when recalculating soft credit donor rollups to the Account object.</inlineHelpText>
+        <label>Account Soft Credit Skew Mode Batch Size</label>
+        <precision>18</precision>
+        <required>false</required>
+        <scale>0</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Rollups_Contact_Batch_Size__c</fullName>
         <defaultValue>200</defaultValue>
         <description>Used by the old and new Rollups engine</description>

--- a/src/objects/Customizable_Rollup_Settings__c.object
+++ b/src/objects/Customizable_Rollup_Settings__c.object
@@ -107,20 +107,6 @@
         <description>Only used by the new Customizable Rollups engine</description>
         <externalId>false</externalId>
         <inlineHelpText>Number of records per batch to process when recalculating soft credit donor rollups to the Account object.</inlineHelpText>
-        <label>Contact Soft Credit to Acct Batch Size</label>
-        <precision>6</precision>
-        <required>false</required>
-        <scale>0</scale>
-        <trackTrending>false</trackTrending>
-        <type>Number</type>
-        <unique>false</unique>
-    </fields>
-    <fields>
-        <fullName>Rollups_AccSoftCredit_Batch_Size__c</fullName>
-        <defaultValue>200</defaultValue>
-        <description>Only used by the new Customizable Rollups engine</description>
-        <externalId>false</externalId>
-        <inlineHelpText>Number of records per batch to process when recalculating soft credit donor rollups to the Account object.</inlineHelpText>
         <label>Account Soft Credit Batch Size</label>
         <precision>6</precision>
         <required>false</required>
@@ -130,13 +116,13 @@
         <unique>false</unique>
     </fields>
     <fields>
-        <fullName>Rollups_AccSoftCredit_Skew_Batch_Size__c</fullName>
-        <defaultValue>1000</defaultValue>
+        <fullName>Rollups_AcctContactSoftCredit_Batch_Size__c</fullName>
+        <defaultValue>200</defaultValue>
         <description>Only used by the new Customizable Rollups engine</description>
         <externalId>false</externalId>
         <inlineHelpText>Number of records per batch to process when recalculating soft credit donor rollups to the Account object.</inlineHelpText>
-        <label>Account Soft Credit Skew Mode Batch Size</label>
-        <precision>18</precision>
+        <label>Contact Soft Credit to Acct Batch Size</label>
+        <precision>6</precision>
         <required>false</required>
         <scale>0</scale>
         <trackTrending>false</trackTrending>

--- a/src/package.xml
+++ b/src/package.xml
@@ -768,6 +768,8 @@
         <members>Customizable_Rollup_Settings__c.Rollups_Account_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Account_SkewMode_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Account_Soft_Credit_Batch_Size__c</members>
+        <members>Customizable_Rollup_Settings__c.Rollups_AccSoftCredit_Batch_Size__c</members>
+        <members>Customizable_Rollup_Settings__c.Rollups_AccSoftCredit_Skew_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Contact_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Contact_SkewMode_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Contact_Soft_Credit_Batch_Size__c</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -768,8 +768,7 @@
         <members>Customizable_Rollup_Settings__c.Rollups_Account_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Account_SkewMode_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Account_Soft_Credit_Batch_Size__c</members>
-        <members>Customizable_Rollup_Settings__c.Rollups_AccSoftCredit_Batch_Size__c</members>
-        <members>Customizable_Rollup_Settings__c.Rollups_AccSoftCredit_Skew_Batch_Size__c</members>
+        <members>Customizable_Rollup_Settings__c.Rollups_AcctContactSoftCredit_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Contact_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Contact_SkewMode_Batch_Size__c</members>
         <members>Customizable_Rollup_Settings__c.Rollups_Contact_Soft_Credit_Batch_Size__c</members>

--- a/src/pages/STG_PanelSchedule.page
+++ b/src/pages/STG_PanelSchedule.page
@@ -14,30 +14,30 @@
         <div class="slds-form_horizontal slds-m-around_large" role="list">
 
             <div class="slds-grid slds-gutters_small"> 
-                <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">               
+                <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
                         <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Contact_Batch_Size__c.Label}" for="tbxConHard" styleClass="slds-form-element__label" />
                         <div class="slds-form-element__control">
                             <apex:outputField value="{!stgService.stgCRLP.Rollups_Contact_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                             <apex:inputField value="{!stgService.stgCRLP.Rollups_Contact_Batch_Size__c}" rendered="{!isEditMode}" id="tbxConHard" styleClass="slds-input" />        
-                        </div>                    
+                        </div>
                     </div>
                 </div>
             </div>
 
-            <div class="slds-grid slds-gutters_small">            
+            <div class="slds-grid slds-gutters_small">
                 <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
                         <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_Batch_Size__c.Label}" for="tbxAccHard" styleClass="slds-form-element__label" />
-                        <div class="slds-form-element__control">                        
+                        <div class="slds-form-element__control">
                             <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />                           
                             <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccHard" styleClass="slds-input" />
-                        </div>                        
+                        </div>
                     </div>
                 </div>
             </div>
 
-            <div class="slds-grid slds-gutters_small">            
+            <div class="slds-grid slds-gutters_small">
                 <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
                         <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Contact_Soft_Credit_Batch_Size__c.Label}" for="tbxConSoft" styleClass="slds-form-element__label" />
@@ -49,19 +49,31 @@
                 </div>
             </div>
 
-            <div class="slds-grid slds-gutters_small">            
+            <div class="slds-grid slds-gutters_small">
                 <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
-                        <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_Soft_Credit_Batch_Size__c.Label}" for="tbxAccSoft" styleClass="slds-form-element__label" />
+                        <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_Soft_Credit_Batch_Size__c.Label}" for="tbxAccContactSoft" styleClass="slds-form-element__label" />
                         <div class="slds-form-element__control">
                             <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                            <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSoft" styleClass="slds-input" />
+                            <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccContactSoft" styleClass="slds-input" />
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="slds-grid slds-gutters_small">            
+            <div class="slds-grid slds-gutters_small">
+                <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
+                    <div class="slds-form-element">
+                        <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_AccSoftCredit_Batch_Size__c.Label}" for="tbxAccSoft" styleClass="slds-form-element__label" />
+                        <div class="slds-form-element__control">
+                            <apex:outputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                            <apex:inputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSoft" styleClass="slds-input" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="slds-grid slds-gutters_small">
                 <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
                         <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_GAU_Batch_Size__c.Label}" for="tbxGAU" styleClass="slds-form-element__label" />
@@ -73,7 +85,7 @@
                 </div>
             </div>
 
-            <div class="slds-grid slds-gutters_small">            
+            <div class="slds-grid slds-gutters_small">
                 <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
                         <apex:outputLabel value="{!$ObjectType.npe03__Recurring_Donations_Settings__c.Fields.Recurring_Donation_Batch_Size__c.Label}" for="tbxRD" styleClass="slds-form-element__label" />
@@ -107,7 +119,7 @@
 
             <div class="slds-form_horizontal slds-m-around_large">
 
-                <div class="slds-grid slds-gutters_small">            
+                <div class="slds-grid slds-gutters_small">
                     <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                         <div class="slds-form-element">
                             <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Limit_on_Attached_Opps_for_Skew__c.Label}" for="tbxSkewLimit" styleClass="slds-form-element__label" />
@@ -121,7 +133,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="slds-grid slds-gutters_small">            
+                <div class="slds-grid slds-gutters_small">
                     <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                         <div class="slds-form-element">
                             <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Contact_SkewMode_Batch_Size__c.Label}" for="tbxConSkew" styleClass="slds-form-element__label" />
@@ -132,7 +144,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="slds-grid slds-gutters_small">            
+                <div class="slds-grid slds-gutters_small">
                     <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                         <div class="slds-form-element">
                             <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_SkewMode_Batch_Size__c.Label}" for="tbxAccSkew" styleClass="slds-form-element__label" />
@@ -143,8 +155,19 @@
                         </div>
                     </div>
                 </div>
-                <div class="slds-grid slds-gutters_small">            
-                    <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">                
+                <div class="slds-grid slds-gutters_small">
+                    <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
+                        <div class="slds-form-element">
+                            <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_AccSoftCredit_Skew_Batch_Size__c.Label}" for="tbxAccSoftSkew" styleClass="slds-form-element__label" />
+                            <div class="slds-form-element__control">
+                                <apex:outputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Skew_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                                <apex:inputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Skew_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSoftSkew" html-aria-describedby="{!$Component.tbxAccSoftSkewHelp}" styleClass="slds-input" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slds-grid slds-gutters_small">
+                    <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                         <div class="slds-form-element">
                             <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Skew_Dispatcher_Batch_Size__c.Label}" for="tbxSkewDis" styleClass="slds-form-element__label" />
                             <div class="slds-form-element__control">

--- a/src/pages/STG_PanelSchedule.page
+++ b/src/pages/STG_PanelSchedule.page
@@ -52,10 +52,10 @@
             <div class="slds-grid slds-gutters_small">
                 <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
-                        <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_Soft_Credit_Batch_Size__c.Label}" for="tbxAccContactSoft" styleClass="slds-form-element__label" />
+                        <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_AcctContactSoftCredit_Batch_Size__c.Label}" for="tbxAccContactSoft" styleClass="slds-form-element__label" />
                         <div class="slds-form-element__control">
-                            <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                            <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccContactSoft" styleClass="slds-input" />
+                            <apex:outputField value="{!stgService.stgCRLP.Rollups_AcctContactSoftCredit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                            <apex:inputField value="{!stgService.stgCRLP.Rollups_AcctContactSoftCredit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccContactSoft" styleClass="slds-input" />
                         </div>
                     </div>
                 </div>
@@ -64,10 +64,10 @@
             <div class="slds-grid slds-gutters_small">
                 <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
                     <div class="slds-form-element">
-                        <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_AccSoftCredit_Batch_Size__c.Label}" for="tbxAccSoft" styleClass="slds-form-element__label" />
+                        <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_Account_Soft_Credit_Batch_Size__c.Label}" for="tbxAccSoft" styleClass="slds-form-element__label" />
                         <div class="slds-form-element__control">
-                            <apex:outputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                            <apex:inputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSoft" styleClass="slds-input" />
+                            <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                            <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_Soft_Credit_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSoft" styleClass="slds-input" />
                         </div>
                     </div>
                 </div>
@@ -151,17 +151,6 @@
                             <div class="slds-form-element__control">
                                 <apex:outputField value="{!stgService.stgCRLP.Rollups_Account_SkewMode_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                                 <apex:inputField value="{!stgService.stgCRLP.Rollups_Account_SkewMode_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSkew" html-aria-describedby="{!$Component.tbxAccSkewHelp}" styleClass="slds-input" />
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slds-grid slds-gutters_small">
-                    <div class="slds-col slds-has-flexi-truncate slds-grid" role="listitem">
-                        <div class="slds-form-element">
-                            <apex:outputLabel value="{!$ObjectType.Customizable_Rollup_Settings__c.Fields.Rollups_AccSoftCredit_Skew_Batch_Size__c.Label}" for="tbxAccSoftSkew" styleClass="slds-form-element__label" />
-                            <div class="slds-form-element__control">
-                                <apex:outputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Skew_Batch_Size__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
-                                <apex:inputField value="{!stgService.stgCRLP.Rollups_AccSoftCredit_Skew_Batch_Size__c}" rendered="{!isEditMode}" id="tbxAccSoftSkew" html-aria-describedby="{!$Component.tbxAccSoftSkewHelp}" styleClass="slds-input" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Modified the custom settings for customizable rollup batch sizes.  

# Critical Changes

# Changes
- We introduced a new batch size setting for Customizable Rollups called Contact Soft Credit to Acct Batch Size that will be used for Account Contact Soft Credit Batch Sizes. The existing Account Soft Credit Batch Size will now be used for Account Soft Credits (Non-Skew mode).  The current value from Account Soft Credit Batch Size will be copied to the new Contact Soft Credit to Acct Batch Size so that your existing settings are not modified. For Skew Mode, the Account Skew Mode Batch Size will also be used for Account Soft Credit Skew mode execution.

# Issues Closed
- Fixes #4166

# New Metadata
CustomSetting
- Customizable_Rollup_Settings__c.Rollups_AcctContactSoftCredit_Batch_Size__c

# Deleted Metadata
