### PR TITLE
Updated Trailhead URL constant

### DIFF
--- a/src/classes/RP_Constants.cls
+++ b/src/classes/RP_Constants.cls
@@ -47,7 +47,7 @@ public with sharing class RP_Constants {
     public static final String RP_CUSTOMER_JOURNEY_LINK = 'http://www.salesforce.org/events/';
     public static final String RP_NPSP_DOCUMENTATION_LINK = 'https://powerofus.force.com/articles/Best_Practice_Business_Process/Salesforce-Fundamentals';
     public static final String RP_SALESFORCE_ORG_OFFICE_HOURS_LINK = 'https://powerofus.force.com/articles/Customer_Service/Salesforce-com-Foundation-Weekly-Office-Hours';
-    public static final String RP_TRAILHEAD_LINK = 'https://trailhead.salesforce.com/users/00550000006yYDZAA2/trailmixes/npsp';
+    public static final String RP_TRAILHEAD_LINK = 'https://trailhead.salesforce.com/en/content/learn/modules/nonprofit-cloud-basics';
     public static final String RP_US_LINK = 'https://powerofus.force.com';
     public static final String RP_WEBINAR_LINK = 'https://powerofus.force.com/articles/Resource/NPSP-Documentation';
 


### PR DESCRIPTION
Updates the link to trailhead from the getting started page ("1. Learn with Trailhead") based on request

# Critical Changes

# Changes
- Updated the link on the NPSP Getting Started page to direct users to the Salesforce.org Nonprofit Cloud: Quick Look module on Trailhead.

# Issues Closed
- Fixes [#4165](https://github.com/SalesforceFoundation/Cumulus/issues/4165)

# New Metadata

# Deleted Metadata
