### PR TITLE
Replacement of NAMESPACE placeholder to use npsp prefix

### DIFF
--- a/unpackaged/post/first/layouts/Global-Global Layout.layout
+++ b/unpackaged/post/first/layouts/Global-Global Layout.layout
@@ -5,7 +5,7 @@
             <quickActionName>FeedItem.TextPost</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>%%%NAMESPACE%%%NewContact</quickActionName>
+            <quickActionName>npsp__NewContact</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
             <quickActionName>New_Organization</quickActionName>
@@ -14,19 +14,19 @@
             <quickActionName>New_Household_Account</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>%%%NAMESPACE%%%New_Recurring_Donation</quickActionName>
+            <quickActionName>npsp__New_Recurring_Donation</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>%%%NAMESPACE%%%New_Campaign</quickActionName>
+            <quickActionName>npsp__New_Campaign</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>%%%NAMESPACE%%%NewTask</quickActionName>
+            <quickActionName>npsp__NewTask</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
             <quickActionName>FeedItem.ContentPost</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>%%%NAMESPACE%%%LogACall</quickActionName>
+            <quickActionName>npsp__LogACall</quickActionName>
         </quickActionListItems>
     </quickActionList>
     <showEmailCheckbox>false</showEmailCheckbox>

--- a/unpackaged/post/first/objects/Account.object
+++ b/unpackaged/post/first/objects/Account.object
@@ -4,7 +4,7 @@
         <fullName>NPSP_Household_Account</fullName>
         <fields>Name</fields>
         <fields>npo02__TotalOppAmount__c</fields>
-        <fields>%%%NAMESPACE%%%Number_of_Household_Members__c</fields>
+        <fields>npsp__Number_of_Household_Members__c</fields>
         <label>NPSP Household Account</label>
     </compactLayouts>
     <compactLayouts>


### PR DESCRIPTION
# Critical Changes
N/A
# Changes
Update of the Global Layout metadata and the Account field Number of Household Members to reference the global actions in the Nonprofit Success Pack (npsp) package instead of the NAMESPACE placeholder.

I'm not sure if all the metadata in the post install step is still relevant, but since these files haven't been touched since 2014 wanted to help out 😄 
# Issues Closed
N/A
# New Metadata
N/A
# Deleted Metadata
N/A