### PR TITLE
Restore Opportunity unpackaged metadata for extension packages

### DIFF
--- a/unpackaged/pre/opportunity_record_types/objects/Opportunity.object
+++ b/unpackaged/pre/opportunity_record_types/objects/Opportunity.object
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <businessProcesses>
+        <fullName>NPSP_Default</fullName>
+        <isActive>true</isActive>
+        <values>
+            <fullName>Closed Lost</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Closed Won</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Id%2E Decision Makers</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Needs Analysis</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Negotiation%2FReview</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Perception Analysis</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Proposal%2FPrice Quote</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Prospecting</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Qualification</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Value Proposition</fullName>
+            <default>false</default>
+        </values>
+    </businessProcesses>
+
+    <recordTypes>
+        <fullName>NPSP_Default</fullName>
+        <active>true</active>
+        <businessProcess>NPSP_Default</businessProcess>
+        <label>NPSP Default</label>
+    </recordTypes>
+</CustomObject>

--- a/unpackaged/pre/opportunity_record_types/objects/Opportunity.object
+++ b/unpackaged/pre/opportunity_record_types/objects/Opportunity.object
@@ -4,43 +4,7 @@
         <fullName>NPSP_Default</fullName>
         <isActive>true</isActive>
         <values>
-            <fullName>Closed Lost</fullName>
-            <default>false</default>
-        </values>
-        <values>
             <fullName>Closed Won</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Id%2E Decision Makers</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Needs Analysis</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Negotiation%2FReview</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Perception Analysis</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Proposal%2FPrice Quote</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Prospecting</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Qualification</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Value Proposition</fullName>
             <default>false</default>
         </values>
     </businessProcesses>

--- a/unpackaged/pre/opportunity_record_types/package.xml
+++ b/unpackaged/pre/opportunity_record_types/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>*</members>
+    <name>CustomObject</name>
+  </types>
+  <version>29.0</version>
+</Package>


### PR DESCRIPTION
This PR restores the Opportunity unpackaged metadata, which was removed in favor of a dynamic Task-based solution, pending a resolution to the needs of extension packages.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
