### PR TITLE
Updates to add the Payment's Scheduled Date to the Quick Action

### DIFF
--- a/src/quickActions/Opportunity.New_Payment.quickAction
+++ b/src/quickActions/Opportunity.New_Payment.quickAction
@@ -17,6 +17,11 @@
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
+                <field>npe01__Scheduled_Date__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
                 <field>npe01__Payment_Amount__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>

--- a/src/quickActions/npe01__OppPayment__c.Quick_Update.quickAction
+++ b/src/quickActions/npe01__OppPayment__c.Quick_Update.quickAction
@@ -17,6 +17,11 @@
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
+                <field>npe01__Scheduled_Date__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
                 <field>npe01__Payment_Amount__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>


### PR DESCRIPTION
# Critical Changes

# Changes
The Payment Scheduled Date, which is required for scheduled payments if Enforce Accounting Data Consistency is enabled, was not on the Opportunity "New Payment" Action or the Payment "Quick Update" Action.  It is now added.

# Issues Closed

# New Metadata

# Deleted Metadata
