### PR TITLE
Adjust the main installer steps to use the ensure_record_type task instead of deploy_pre

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -394,16 +394,20 @@ plans:
         tier: primary
         steps:
             1:
-                flow: dependencies
-                ui_options:
-                    deploy_pre:
-                        account_record_types:
-                            name: Account Record Types
-                        opportunity_record_types:
-                            name: Opportunity Record Types
+                task: update_dependencies
             2:
-                task: install_managed
+                task: deploy
+                options:
+                    path: unpackaged/pre/account_record_types
+                ui_options:
+                    name: Account Record Types
             3:
+                task: ensure_record_type
+                ui_options:
+                    name: Opportunity Record Types
+            4:
+                task: install_managed
+            5:
                 task: deploy_post
                 options:
                     unmanaged: False


### PR DESCRIPTION
I've tested this by deploying to the staging copy of MetaDeploy and running the installation.

One thing I'm wondering is whether we should adjust EnsureRecordTypes to include all active stages instead of just one.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
