### PR TITLE
Remove Opportunity related list blocking prerelease builds

### DIFF
--- a/src/layouts/Campaign-NPSP Campaign Layout.layout
+++ b/src/layouts/Campaign-NPSP Campaign Layout.layout
@@ -194,13 +194,6 @@
         <relatedList>Allocation__c.Campaign__c</relatedList>
     </relatedLists>
     <relatedLists>
-        <fields>OPPORTUNITY.NAME</fields>
-        <fields>OPPORTUNITY.STAGE_NAME</fields>
-        <fields>OPPORTUNITY.AMOUNT</fields>
-        <fields>OPPORTUNITY.CLOSE_DATE</fields>
-        <relatedList>RelatedOpportunityList</relatedList>
-    </relatedLists>
-    <relatedLists>
         <fields>TASK.SUBJECT</fields>
         <fields>TASK.WHO_NAME</fields>
         <fields>ACTIVITY.TASK</fields>

--- a/unpackaged/config/trial/layouts/Campaign-___NAMESPACE___NPSP Campaign Layout.layout
+++ b/unpackaged/config/trial/layouts/Campaign-___NAMESPACE___NPSP Campaign Layout.layout
@@ -281,13 +281,6 @@
         <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Campaign__c</relatedList>
     </relatedLists>
     <relatedLists>
-        <fields>OPPORTUNITY.NAME</fields>
-        <fields>OPPORTUNITY.STAGE_NAME</fields>
-        <fields>OPPORTUNITY.AMOUNT</fields>
-        <fields>OPPORTUNITY.CLOSE_DATE</fields>
-        <relatedList>RelatedOpportunityList</relatedList>
-    </relatedLists>
-    <relatedLists>
         <fields>TASK.SUBJECT</fields>
         <fields>TASK.WHO_NAME</fields>
         <fields>ACTIVITY.TASK</fields>


### PR DESCRIPTION
This PR removes the Opportunities related list from the NPSP's Campaign page layout. Prerelease orgs include the Customizable Campaign Influence feature, which is incompatible with this related list and blocks NPSP deployments. At present, we are not aware of a programmatic route to deactivate this feature.

As a consequence of this PR, if accepted, manual NPSP installs through MetaDeploy would require an additional manual setup step to configure this related list if it is desired and if Customizable Campaign Influence is not in use.

Merging this PR would allow us to resume performing prerelease builds and tests of NPSP as we approach the release of Summer '19. It would also ensure that NPSP installs are compatible with orgs created in Summer '19 that may have this feature active. We do not know at this time exactly which newly created orgs will be so configured.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
