### PR TITLE
W-033232 - Adding the ability to create parent additional objects

### DIFF
--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -193,28 +193,66 @@ public with sharing class BDI_AdditionalObjectService {
 
             BDI_ObjectWrapper[] objWrapsForChildPredecessorUpdate = new BDI_ObjectWrapper[]{};
 
+            List<BDI_ObjectWrapper[]> objWrapsForUpdateList = new List<BDI_ObjectWrapper[]>();
+            BDI_ObjectWrapper[] currentObjWrapsForUpdate = new BDI_ObjectWrapper[]{};
+
+            List<BDI_ObjectWrapper[]> objWrapsForInsertList = new List<BDI_ObjectWrapper[]>();
+            BDI_ObjectWrapper[] currentObjWrapsForInsert = new BDI_ObjectWrapper[]{};
+
+            List<SObject[]> sObjsForUpdateLists = new List<SObject[]>();
+            SObject[] currentSObjectForUpdateList = new SObject[]{};
+
+            List<SObject[]> sObjsForInsertLists = new List<SObject[]>();
+            SObject[] currentSObjectForInsertList = new SObject[]{};
+
+            Integer objTypeCount = 1;
             for (String objApiName : objAPINameToObjWraps.keySet()) {
 
                 BDI_ObjectWrapper[] objWraps = objAPINameToObjWraps.get(objApiName);
-                
-                SObject[] sObjsForUpdate = new SObject[]{};
-                SObject[] sObjsForInsert = new SObject[]{};
-
-                BDI_ObjectWrapper[] objWrapsForUpdate = new BDI_ObjectWrapper[]{};
-                BDI_ObjectWrapper[] objWrapsForInsert = new BDI_ObjectWrapper[]{};
 
                 for (BDI_ObjectWrapper objWrap : objWraps) {
                     if (objWrap.sObj.Id != null) {
-                        sObjsForUpdate.add(objWrap.sObj);
-                        objWrapsForUpdate.add(objWrap);
+                        currentSObjectForUpdateList.add(objWrap.sObj);
+                        currentObjWrapsForUpdate.add(objWrap);
                     } else {
-                        sObjsForInsert.add(objWrap.sObj);
-                        objWrapsForInsert.add(objWrap);
+                        currentSObjectForInsertList.add(objWrap.sObj);
+                        currentObjWrapsForInsert.add(objWrap);
                     }
                 }
 
-                if (sObjsForUpdate.size() > 0) {
+                //If the loop is on its 10th run then add the lists to the array 
+                // and start a new list and reset the counter.
+                if (objTypeCount == 10) {
+                    sObjsForUpdateLists.add(currentSObjectForUpdateList);
+                    currentSObjectForUpdateList = new SObject[]{};
 
+                    objWrapsForUpdateList.add(currentObjWrapsForUpdate);
+                    currentObjWrapsForUpdate = new BDI_ObjectWrapper[]{};
+
+                    sObjsForInsertLists.add(currentSObjectForInsertList);
+                    currentSObjectForInsertList = new SObject[]{};
+
+                    objWrapsForInsertList.add(currentObjWrapsForInsert);
+                    currentObjWrapsForInsert = new BDI_ObjectWrapper[]{};
+
+                    objTypeCount = 1;
+                } else {
+                    objTypeCount++;
+                }
+            }
+
+            sObjsForUpdateLists.add(currentSObjectForUpdateList);
+            objWrapsForUpdateList.add(currentObjWrapsForUpdate);
+
+            sObjsForInsertLists.add(currentSObjectForInsertList);
+            objWrapsForInsertList.add(currentObjWrapsForInsert);
+
+            for (Integer i = 0; i < sObjsForUpdateLists.size(); i++) {
+
+                SObject[] sObjsForUpdate = sObjsForUpdateLists[i];
+                BDI_ObjectWrapper[] objWrapsForUpdate = objWrapsForUpdateList[i];
+
+                if (sObjsForUpdate.size() > 0) {
                     Database.SaveResult[] updateSaveResults = UTIL_DMLService.updateRecords(sObjsForUpdate,false);
                     
                     // Cycle through all the upsert results and update the data import records with status 
@@ -233,11 +271,18 @@ public with sharing class BDI_AdditionalObjectService {
                                 objWrap.objMapping.Imported_Record_Status_Field_Name__c);
                         }
                     }
-                }
+                }        
+            }
+
+
+            for (Integer i = 0; i < sObjsForInsertLists.size(); i++) {
+
+                SObject[] sObjsForInsert = sObjsForInsertLists[i];
+                BDI_ObjectWrapper[] objWrapsForInsert = objWrapsForInsertList[i];
 
                 if (sObjsForInsert.size() > 0) {
-
                     Database.SaveResult[] insertSaveResults = UTIL_DMLService.insertRecords(sObjsForInsert,false);
+
                     // Cycle through all the upsert results and update the data import records with status 
                     // appropriately.
                     for (Integer t = 0; t < insertSaveResults.size(); t++) {
@@ -264,6 +309,7 @@ public with sharing class BDI_AdditionalObjectService {
                     }
                 }
             }
+
             if (objWrapsForChildPredecessorUpdate.size() > 0) {
                 updateChildPredecessorRecords(objWrapsForChildPredecessorUpdate);
             }
@@ -306,16 +352,16 @@ public with sharing class BDI_AdditionalObjectService {
             Id predecessorId = (Id)objWrap.dataImport.get(objWrap.predecessorObjMapping.Imported_Record_Field_Name__c);
             SObject sObjForUpdate;
 
-            Map<Id,SObject> tempSObjMap = new Map<Id,SObject>();
+            Map<Id,SObject> sObjectById = new Map<Id,SObject>();
 
             if (childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name__c) != null) {
-                tempSObjMap = childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name__c);
+                sObjectById = childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name__c);
             }
 
             // Attempt to find if the predecessor sobject if it is already in the map for update and update 
             // the existing SObject if possible.  Otherwise initialize a new SObject for update.
-            if (tempSObjMap.size() > 0 && tempSObjMap.get(predecessorId) != null) {
-                sObjForUpdate = tempSObjMap.get(predecessorId);
+            if (sObjectById.size() > 0 && sObjectById.get(predecessorId) != null) {
+                sObjForUpdate = sObjectById.get(predecessorId);
             } else {
                 sObjForUpdate = UTIL_Describe.getPrototypeObject(objWrap.predecessorObjMapping.Object_API_Name__c);
             }
@@ -327,8 +373,8 @@ public with sharing class BDI_AdditionalObjectService {
             sObjForUpdate.put(objWrap.objMapping.Relationship_Field__c,objWrap.sObj.Id);
 
             // Put the SObject back into the enclosing maps.
-            tempSObjMap.put(predecessorId, sObjForUpdate);
-            childSObjectMapByObjectAPIName.put(objWrap.predecessorObjMapping.Object_API_Name__c,tempSObjMap);
+            sObjectById.put(predecessorId, sObjForUpdate);
+            childSObjectMapByObjectAPIName.put(objWrap.predecessorObjMapping.Object_API_Name__c,sObjectById);
 
             // Store the successor object wraps by their predecessor id for later use in recording errors.
             if (successorObjWrapsByPredecessorId.get(predecessorId) != null) {
@@ -338,36 +384,55 @@ public with sharing class BDI_AdditionalObjectService {
             }
         }
 
-        if (childSObjectMapByObjectAPIName.size() > 0) {
-            for (String objAPIName : childSObjectMapByObjectAPIName.keySet()) {
+        List<SObject[]> sObjForUpdateLists = new List<SObject[]>();
 
-                SObject[] sObjsForUpdate = childSObjectMapByObjectAPIName.get(objAPIName).values();
+        SObject[] currentSObjectForUpdateList = new SObject[]{};
 
-                if (sObjsForUpdate.size() > 0) {
+        // If the number of different sObject types being updated exceeds 10 then split into separate lists to avoid
+        // the limit on the number of sObject types per dml operation.
+        Integer n = 1;
+        for (String objAPIName : childSObjectMapByObjectAPIName.keySet()) {
 
-                    Database.SaveResult[] updateSaveResults = UTIL_DMLService.updateRecords(sObjsForUpdate,false);
+            currentSObjectForUpdateList.addAll(childSObjectMapByObjectAPIName.get(objAPIName).values());
+
+            //If the loop is on its 10th run then add the list to the array and start a new one and reset the counter.
+            if (n == 10) {
+                sObjForUpdateLists.add(currentSObjectForUpdateList);
+                currentSObjectForUpdateList = new SObject[]{};
+                n = 1;
+            } else {
+                n++;
+            }
+        }
+
+        if (currentSObjectForUpdateList.size() > 0) {
+            sObjForUpdateLists.add(currentSObjectForUpdateList);
+        }
+
+        for (Integer t = 0; t < sObjForUpdateLists.size(); t++) {
+            SObject[] sObjsForUpdate = sObjForUpdateLists[t];
+
+            Database.SaveResult[] updateSaveResults = UTIL_DMLService.updateRecords(sObjsForUpdate,false);
+            
+            // Cycle through all the update results and update the data import records with status 
+            // appropriately.
+            for (Integer i = 0; i < updateSaveResults.size(); i++) {
+                Database.SaveResult result = updateSaveResults[i];
+
+                BDI_ObjectWrapper[] successorObjWraps = successorObjWrapsByPredecessorId.get(result.getId());
+
+                // If the update of the child object fails then record an error in the status field
+                // for all successor objects.
+                if (!result.isSuccess()) {
+                    for (BDI_ObjectWrapper objWrap : successorObjWraps) {
                     
-                    // Cycle through all the upsert results and update the data import records with status 
-                    // appropriately.
-                    for (Integer i = 0; i < updateSaveResults.size(); i++) {
-                        Database.SaveResult result = updateSaveResults[i];
-
-                        BDI_ObjectWrapper[] successorObjWraps = successorObjWrapsByPredecessorId.get(result.getId());
-
-                        // If the update of the child object fails then record an error in the status field
-                        // for all successor objects.
-                        if (!result.isSuccess()) {
-                            for (BDI_ObjectWrapper objWrap : successorObjWraps) {
-                            
-                                String errorMessage = System.label.bdiAdditionalObjChildNotUpdated + 
-                                                        result.getErrors()[0].getMessage();
-                                dataImportService.LogBDIError(objWrap.dataImport, 
-                                    errorMessage,
-                                    objWrap.objMapping.Imported_Record_Status_Field_Name__c);
-                            }
-                        }
+                        String errorMessage = System.label.bdiAdditionalObjChildNotUpdated + 
+                                                result.getErrors()[0].getMessage();
+                        dataImportService.LogBDIError(objWrap.dataImport, 
+                            errorMessage,
+                            objWrap.objMapping.Imported_Record_Status_Field_Name__c);
                     }
-                }                
+                }
             }
         }
     }

--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -190,6 +190,9 @@ public with sharing class BDI_AdditionalObjectService {
     private void importObjectWrappers (Map<String,BDI_ObjectWrapper[]> objAPINameToObjWraps) {
         //If there are any records to create, then combine them into lists for update
         if (objAPINameToObjWraps.size() > 0) {
+
+            BDI_ObjectWrapper[] objWrapsForChildPredecessorUpdate = new BDI_ObjectWrapper[]{};
+
             for (String objApiName : objAPINameToObjWraps.keySet()) {
 
                 BDI_ObjectWrapper[] objWraps = objAPINameToObjWraps.get(objApiName);
@@ -247,6 +250,12 @@ public with sharing class BDI_AdditionalObjectService {
                                 System.Label.bdiCreated);
                             objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Field_Name__c,
                                 objWrap.sObj.Id);
+
+                            // If the newly created sobject is a parent to its predecesssor, then
+                            // add it to a list for updating child predcessors.
+                            if (objWrap.objMapping.Relationship_To_Predecessor__c == 'Parent') { 
+                                objWrapsForChildPredecessorUpdate.add(objWrap);
+                            }
                         } else { 
                             dataImportService.LogBDIError(objWrap.dataImport, 
                                 result.getErrors()[0].getMessage(),
@@ -254,6 +263,9 @@ public with sharing class BDI_AdditionalObjectService {
                         }
                     }
                 }
+            }
+            if (objWrapsForChildPredecessorUpdate.size() > 0) {
+                updateChildPredecessorRecords(objWrapsForChildPredecessorUpdate);
             }
         }
     }
@@ -279,7 +291,90 @@ public with sharing class BDI_AdditionalObjectService {
 
 
     /*******************************************************************************************************
-    * @description Determines if the predecessor to this Data Import Object Mapping exists
+    * @description For newly created parent sobjects, this method updates the appropriate child predecessor
+    * record's lookup field to the id of the newly created object.
+    * @param objWrapsForChildPredecessorUpdate list of object wraps that were successfully created
+    * and need to update their child predecessors.
+    */
+    private void updateChildPredecessorRecords(BDI_ObjectWrapper[] objWrapsForChildPredecessorUpdate){
+
+        Map<String,Map<Id,SObject>> childSObjectMapByObjectAPIName = new Map<String,Map<Id,SObject>>();
+        Map<Id,BDI_ObjectWrapper[]> successorObjWrapsByPredecessorId = new Map<Id,BDI_ObjectWrapper[]>();
+
+        for (BDI_ObjectWrapper objWrap : objWrapsForChildPredecessorUpdate) {
+
+            Id predecessorId = (Id)objWrap.dataImport.get(objWrap.predecessorObjMapping.Imported_Record_Field_Name__c);
+            SObject sObjForUpdate;
+
+            Map<Id,SObject> tempSObjMap = new Map<Id,SObject>();
+
+            if (childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name__c) != null) {
+                tempSObjMap = childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name__c);
+            }
+
+            // Attempt to find if the predecessor sobject if it is already in the map for update and update 
+            // the existing SObject if possible.  Otherwise initialize a new SObject for update.
+            if (tempSObjMap.size() > 0 && tempSObjMap.get(predecessorId) != null) {
+                sObjForUpdate = tempSObjMap.get(predecessorId);
+            } else {
+                sObjForUpdate = UTIL_Describe.getPrototypeObject(objWrap.predecessorObjMapping.Object_API_Name__c);
+            }
+
+            // Set the id of the sobject to the predecessors record id
+            sObjForUpdate.put('Id',predecessorId);
+
+            // Place the Id of the newly created SObject into the appropriate relationship field on the child.
+            sObjForUpdate.put(objWrap.objMapping.Relationship_Field__c,objWrap.sObj.Id);
+
+            // Put the SObject back into the enclosing maps.
+            tempSObjMap.put(predecessorId, sObjForUpdate);
+            childSObjectMapByObjectAPIName.put(objWrap.predecessorObjMapping.Object_API_Name__c,tempSObjMap);
+
+            // Store the successor object wraps by their predecessor id for later use in recording errors.
+            if (successorObjWrapsByPredecessorId.get(predecessorId) != null) {
+                successorObjWrapsByPredecessorId.get(predecessorId).add(objWrap);
+            } else {
+                successorObjWrapsByPredecessorId.put(predecessorId, new BDI_ObjectWrapper[]{objWrap});
+            }
+        }
+
+        if (childSObjectMapByObjectAPIName.size() > 0) {
+            for (String objAPIName : childSObjectMapByObjectAPIName.keySet()) {
+
+                SObject[] sObjsForUpdate = childSObjectMapByObjectAPIName.get(objAPIName).values();
+
+                if (sObjsForUpdate.size() > 0) {
+
+                    Database.SaveResult[] updateSaveResults = UTIL_DMLService.updateRecords(sObjsForUpdate,false);
+                    
+                    // Cycle through all the upsert results and update the data import records with status 
+                    // appropriately.
+                    for (Integer i = 0; i < updateSaveResults.size(); i++) {
+                        Database.SaveResult result = updateSaveResults[i];
+
+                        BDI_ObjectWrapper[] successorObjWraps = successorObjWrapsByPredecessorId.get(result.getId());
+
+                        // If the update of the child object fails then record an error in the status field
+                        // for all successor objects.
+                        if (!result.isSuccess()) {
+                            for (BDI_ObjectWrapper objWrap : successorObjWraps) {
+                            
+                                String errorMessage = System.label.bdiAdditionalObjChildNotUpdated + 
+                                                        result.getErrors()[0].getMessage();
+                                dataImportService.LogBDIError(objWrap.dataImport, 
+                                    errorMessage,
+                                    objWrap.objMapping.Imported_Record_Status_Field_Name__c);
+                            }
+                        }
+                    }
+                }                
+            }
+        }
+    }
+
+
+    /*******************************************************************************************************
+    * @description 
     * @param predecessor The Data Import Object Mapping for which the imported field can be checked to see 
     *  if it exists.
     */

--- a/src/classes/BDI_AdditionalObjectServiceTest.cls
+++ b/src/classes/BDI_AdditionalObjectServiceTest.cls
@@ -57,151 +57,149 @@ private class BDI_AdditionalObjectServiceTest {
                                              EndDate = Date.today().addDays(10));
         insert testCampaign;
 
-        DataImport__c testDataImportA = new DataImport__c(Account1_City__c = 'Faketown',
-                                                        Account1_Country__c = 'US',
-                                                        Account1_Name__c = 'TestGroupA Org 1',
-                                                        Account1_Phone__c = '555-123-0001',
-                                                        Account1_State_Province__c = 'CA',
-                                                        Account1_Street__c = '100 Fakeaccount St',  
-                                                        Account1_Website__c = 'www.fakeorgacct01.com',
-                                                        Account1_Zip_Postal_Code__c = '94607',
-                                                        Account2_City__c = 'Faketown',
-                                                        Account2_Country__c = 'US',
-                                                        Account2_Name__c = 'Org2TestGroupA',
-                                                        Account2_Phone__c = '555-234-0002',
-                                                        Account2_State_Province__c = 'CA',
-                                                        Account2_Street__c = '200 FakeOrgaccount St',   
-                                                        Account2_Website__c = 'www.fakeorgacct02.com',
-                                                        Account2_Zip_Postal_Code__c = '94100',
-                                                        Donation_Campaign_Name__c = 'TestGroupA Campaign',
-                                                        Contact1_Alternate_Email__c = 'testgroupAcontact01Alternate@fakedata.com',
-                                                        Contact1_Birthdate__c = Date.today().addDays(-1000),
-                                                        Contact1_Firstname__c = 'Susie',
-                                                        Contact1_Home_Phone__c = '555-321-0001',
-                                                        Contact1_Lastname__c = 'TestGroupA01',
-                                                        Contact1_Mobile_Phone__c ='555-231-0001',
-                                                        Contact1_Other_Phone__c = '555-456-0001',
-                                                        Contact1_Personal_Email__c = 'testgroupAcontact01Personal@fakedata.com',
-                                                        Contact1_Preferred_Email__c = 'testgroupAcontact01Preferred@fakedata.com',
-                                                        Contact1_Preferred_Phone__c = '555-567-0001',
-                                                        Contact1_Salutation__c = 'Ms.',
-                                                        Contact1_Title__c = 'President',
-                                                        Contact1_Work_Email__c = 'testgroupAcontact01Preferred@fakedata.com',
-                                                        Contact1_Work_Phone__c = '555-678-0001',
-                                                        Contact2_Alternate_Email__c = 'testgroupAcontact02Alternate@fakedata.com',
-                                                        Contact2_Birthdate__c = Date.today().addDays(-1000),
-                                                        Contact2_Firstname__c = 'John',
-                                                        Contact2_Home_Phone__c = '555-321-0002',
-                                                        Contact2_Lastname__c = 'TestGroupA02',
-                                                        Contact2_Mobile_Phone__c ='555-231-0002',
-                                                        Contact2_Other_Phone__c = '555-456-0002',
-                                                        Contact2_Personal_Email__c = 'testgroupAcontact02Personal@fakedata.com',
-                                                        Contact2_Preferred_Email__c = 'testgroupAcontact02Preferred@fakedata.com',
-                                                        Contact2_Preferred_Phone__c = '555-567-0002',
-                                                        Contact2_Salutation__c = 'Mr.',
-                                                        Contact2_Title__c = 'CEO',
-                                                        Contact2_Work_Email__c = 'testgroupAcontact02Preferred@fakedata.com',
-                                                        Contact2_Work_Phone__c = '555-678-0002',
-                                                        Donation_Amount__c = 1000,
-                                                        Donation_Date__c = Date.today(),
-                                                        Donation_Description__c = 'Most excellent donation',
-                                                        Donation_Donor__c = 'Contact1',
-                                                        Donation_Member_Level__c = 'Gold',
-                                                        Donation_Membership_End_Date__c = Date.today().addDays(200),
-                                                        Donation_Membership_Origin__c = 'Outer Space',
-                                                        Donation_Membership_Start_Date__c =  Date.today().addDays(-200),
-                                                        Donation_Name__c = 'TestGroupA',    
-                                                        Donation_Stage__c = 'Closed Won',
-                                                        Donation_Type__c = null,
-                                                        GAU_Allocation_1_Amount__c = 750,
-                                                        GAU_Allocation_1_GAU__c = gau1.Id,
-                                                        GAU_Allocation_1_Percent__c = .75,
-                                                        GAU_Allocation_2_Amount__c = 250,
-                                                        GAU_Allocation_2_GAU__c = gau2.Id,
-                                                        GAU_Allocation_2_Percent__c = .25,
-                                                        Home_City__c = 'Fakeville',
-                                                        Home_Country__c = 'US',
-                                                        Home_State_Province__c = 'CA',
-                                                        Home_Street__c = '500 Fake Blvd',
-                                                        Home_Zip_Postal_Code__c = '94105',
-                                                        Household_Phone__c = '555-789-0001',
-                                                        Opportunity_Contact_Role_1_Role__c = 'Soft Credit',
-                                                        Opportunity_Contact_Role_2_Role__c = 'Soft Credit',
-                                                        Payment_Check_Reference_Number__c = '453',
-                                                        Payment_Method__c = 'Check');
+        DataImport__c testDataImportA = 
+                            new DataImport__c(Account1_City__c = 'Faketown',
+                                            Account1_Country__c = 'US',
+                                            Account1_Name__c = 'TestGroupA Org 1',
+                                            Account1_Phone__c = '555-123-0001',
+                                            Account1_State_Province__c = 'CA',
+                                            Account1_Street__c = '100 Fakeaccount St',  
+                                            Account1_Website__c = 'www.fakeorgacct01.com',
+                                            Account1_Zip_Postal_Code__c = '94607',
+                                            Account2_City__c = 'Faketown',
+                                            Account2_Country__c = 'US',
+                                            Account2_Name__c = 'Org2TestGroupA',
+                                            Account2_Phone__c = '555-234-0002',
+                                            Account2_State_Province__c = 'CA',
+                                            Account2_Street__c = '200 FakeOrgaccount St',   
+                                            Account2_Website__c = 'www.fakeorgacct02.com',
+                                            Account2_Zip_Postal_Code__c = '94100',
+                                            Donation_Campaign_Name__c = 'TestGroupA Campaign',
+                                            Contact1_Alternate_Email__c = 'testgroupAcontact01Alternate@fakedata.com',
+                                            Contact1_Birthdate__c = Date.today().addDays(-1000),
+                                            Contact1_Firstname__c = 'Susie',
+                                            Contact1_Home_Phone__c = '555-321-0001',
+                                            Contact1_Lastname__c = 'TestGroupA01',
+                                            Contact1_Mobile_Phone__c ='555-231-0001',
+                                            Contact1_Other_Phone__c = '555-456-0001',
+                                            Contact1_Personal_Email__c = 'testgroupAcontact01Personal@fakedata.com',
+                                            Contact1_Preferred_Email__c = 'testgroupAcontact01Preferred@fakedata.com',
+                                            Contact1_Preferred_Phone__c = '555-567-0001',
+                                            Contact1_Salutation__c = 'Ms.',
+                                            Contact1_Work_Email__c = 'testgroupAcontact01Preferred@fakedata.com',
+                                            Contact1_Work_Phone__c = '555-678-0001',
+                                            Contact2_Alternate_Email__c = 'testgroupAcontact02Alternate@fakedata.com',
+                                            Contact2_Birthdate__c = Date.today().addDays(-1000),
+                                            Contact2_Firstname__c = 'John',
+                                            Contact2_Home_Phone__c = '555-321-0002',
+                                            Contact2_Lastname__c = 'TestGroupA02',
+                                            Contact2_Mobile_Phone__c ='555-231-0002',
+                                            Contact2_Other_Phone__c = '555-456-0002',
+                                            Contact2_Personal_Email__c = 'testgroupAcontact02Personal@fakedata.com',
+                                            Contact2_Preferred_Email__c = 'testgroupAcontact02Preferred@fakedata.com',
+                                            Contact2_Preferred_Phone__c = '555-567-0002',
+                                            Contact2_Salutation__c = 'Mr.',
+                                            Contact2_Work_Email__c = 'testgroupAcontact02Preferred@fakedata.com',
+                                            Contact2_Work_Phone__c = '555-678-0002',
+                                            Donation_Amount__c = 10000,
+                                            Donation_Date__c = Date.today(),
+                                            Donation_Description__c = 'Most excellent donation',
+                                            Donation_Donor__c = 'Contact1',
+                                            Donation_Member_Level__c = 'Gold',
+                                            Donation_Membership_End_Date__c = Date.today().addDays(200),
+                                            Donation_Membership_Origin__c = 'Outer Space',
+                                            Donation_Membership_Start_Date__c =  Date.today().addDays(-200),
+                                            Donation_Name__c = 'TestGroupA',    
+                                            Donation_Stage__c = 'Closed Won',
+                                            Donation_Type__c = null,
+                                            GAU_Allocation_1_Amount__c = 750,
+                                            GAU_Allocation_1_GAU__c = gau1.Id,
+                                            GAU_Allocation_1_Percent__c = 75,
+                                            GAU_Allocation_2_Amount__c = 250,
+                                            GAU_Allocation_2_GAU__c = gau2.Id,
+                                            GAU_Allocation_2_Percent__c = 25,
+                                            Home_City__c = 'Fakeville',
+                                            Home_Country__c = 'US',
+                                            Home_State_Province__c = 'CA',
+                                            Home_Street__c = '500 Fake Blvd',
+                                            Home_Zip_Postal_Code__c = '94105',
+                                            Household_Phone__c = '555-789-0001',
+                                            Opportunity_Contact_Role_1_Role__c = 'Soft Credit',
+                                            Opportunity_Contact_Role_2_Role__c = 'Soft Credit',
+                                            Payment_Check_Reference_Number__c = '453',
+                                            Payment_Method__c = 'Check');
 
-        DataImport__c testDataImportB = new DataImport__c(Account1_City__c = 'Faketown',
-                                                        Account1_Country__c = 'US',
-                                                        Account1_Name__c = 'TestGroupB Org 1',
-                                                        Account1_Phone__c = '554-123-0001',
-                                                        Account1_State_Province__c = 'CA',
-                                                        Account1_Street__c = '954 Fakey St',    
-                                                        Account1_Website__c = 'www.groupBfakeorgacct01.com',
-                                                        Account1_Zip_Postal_Code__c = '20000',
-                                                        Account2_City__c = 'Faketown',
-                                                        Account2_Country__c = 'US',
-                                                        Account2_Name__c = 'Org2TestGroupB',
-                                                        Account2_Phone__c = '554-234-0002',
-                                                        Account2_State_Province__c = 'CA',
-                                                        Account2_Street__c = '546 Main St', 
-                                                        Account2_Website__c = 'www.groupbfakeorgacct02.com',
-                                                        Account2_Zip_Postal_Code__c = '10000',
-                                                        Donation_Campaign_Name__c = 'TestGroupB Campaign',
-                                                        Contact1_Alternate_Email__c = 'testgroupBcontact01Alternate@fakedata.com',
-                                                        Contact1_Birthdate__c = Date.today().addDays(-1000),
-                                                        Contact1_Firstname__c = 'Susie',
-                                                        Contact1_Home_Phone__c = '554-321-0001',
-                                                        Contact1_Lastname__c = 'TestGroupB01',
-                                                        Contact1_Mobile_Phone__c ='554-231-0001',
-                                                        Contact1_Other_Phone__c = '554-456-0001',
-                                                        Contact1_Personal_Email__c = 'testgroupBcontact01Personal@fakedata.com',
-                                                        Contact1_Preferred_Email__c = 'testgroupBcontact01Preferred@fakedata.com',
-                                                        Contact1_Preferred_Phone__c = '554-567-0001',
-                                                        Contact1_Salutation__c = 'Ms.',
-                                                        Contact1_Title__c = 'President',
-                                                        Contact1_Work_Email__c = 'testgroupBcontact01Preferred@fakedata.com',
-                                                        Contact1_Work_Phone__c = '554-678-0001',
-                                                        Contact2_Alternate_Email__c = 'testgroupBcontact02Alternate@fakedata.com',
-                                                        Contact2_Birthdate__c = Date.today().addDays(-1000),
-                                                        Contact2_Firstname__c = 'John',
-                                                        Contact2_Home_Phone__c = '554-321-0002',
-                                                        Contact2_Lastname__c = 'TestGroupB02',
-                                                        Contact2_Mobile_Phone__c ='554-231-0002',
-                                                        Contact2_Other_Phone__c = '554-456-0002',
-                                                        Contact2_Personal_Email__c = 'testgroupBcontact02Personal@fakedata.com',
-                                                        Contact2_Preferred_Email__c = 'testgroupBcontact02Preferred@fakedata.com',
-                                                        Contact2_Preferred_Phone__c = '554-567-0002',
-                                                        Contact2_Salutation__c = 'Mr.',
-                                                        Contact2_Title__c = 'CEO',
-                                                        Contact2_Work_Email__c = 'testgroupBcontact02Preferred@fakedata.com',
-                                                        Contact2_Work_Phone__c = '554-678-0002',
-                                                        Donation_Amount__c = 1000,
-                                                        Donation_Date__c = Date.today(),
-                                                        Donation_Description__c = 'Most excellent donation',
-                                                        Donation_Donor__c = 'Contact1',
-                                                        Donation_Member_Level__c = 'Gold',
-                                                        Donation_Membership_End_Date__c = Date.today().addDays(200),
-                                                        Donation_Membership_Origin__c = 'Outer Space',
-                                                        Donation_Membership_Start_Date__c =  Date.today().addDays(-200),
-                                                        Donation_Name__c = 'TestGroupB',    
-                                                        Donation_Stage__c = 'Closed Won',
-                                                        Donation_Type__c = null,
-                                                        GAU_Allocation_1_Amount__c = 750,
-                                                        GAU_Allocation_1_GAU__c = gau1.Id,
-                                                        GAU_Allocation_1_Percent__c = .75,
-                                                        GAU_Allocation_2_Amount__c = 250,
-                                                        GAU_Allocation_2_GAU__c = gau2.Id,
-                                                        GAU_Allocation_2_Percent__c = .25,
-                                                        Home_City__c = 'Fakopolis',
-                                                        Home_Country__c = 'US',
-                                                        Home_State_Province__c = 'CA',
-                                                        Home_Street__c = '333 Fakington Blvd',
-                                                        Home_Zip_Postal_Code__c = '94115',
-                                                        Household_Phone__c = '554-789-0001',
-                                                        Opportunity_Contact_Role_1_Role__c = 'Soft Credit',
-                                                        Opportunity_Contact_Role_2_Role__c = 'Soft Credit',
-                                                        Payment_Check_Reference_Number__c = '453',
-                                                        Payment_Method__c = 'Check');
+        DataImport__c testDataImportB = 
+                            new DataImport__c(Account1_City__c = 'Faketown',
+                                            Account1_Country__c = 'US',
+                                            Account1_Name__c = 'TestGroupB Org 1',
+                                            Account1_Phone__c = '554-123-0001',
+                                            Account1_State_Province__c = 'CA',
+                                            Account1_Street__c = '954 Fakey St',    
+                                            Account1_Website__c = 'www.groupBfakeorgacct01.com',
+                                            Account1_Zip_Postal_Code__c = '20000',
+                                            Account2_City__c = 'Faketown',
+                                            Account2_Country__c = 'US',
+                                            Account2_Name__c = 'Org2TestGroupB',
+                                            Account2_Phone__c = '554-234-0002',
+                                            Account2_State_Province__c = 'CA',
+                                            Account2_Street__c = '546 Main St', 
+                                            Account2_Website__c = 'www.groupbfakeorgacct02.com',
+                                            Account2_Zip_Postal_Code__c = '10000',
+                                            Donation_Campaign_Name__c = 'TestGroupB Campaign',
+                                            Contact1_Alternate_Email__c = 'testgroupBcontact01Alternate@fakedata.com',
+                                            Contact1_Birthdate__c = Date.today().addDays(-1000),
+                                            Contact1_Firstname__c = 'Susie',
+                                            Contact1_Home_Phone__c = '554-321-0001',
+                                            Contact1_Lastname__c = 'TestGroupB01',
+                                            Contact1_Mobile_Phone__c ='554-231-0001',
+                                            Contact1_Other_Phone__c = '554-456-0001',
+                                            Contact1_Personal_Email__c = 'testgroupBcontact01Personal@fakedata.com',
+                                            Contact1_Preferred_Email__c = 'testgroupBcontact01Preferred@fakedata.com',
+                                            Contact1_Preferred_Phone__c = '554-567-0001',
+                                            Contact1_Salutation__c = 'Ms.',
+                                            Contact1_Work_Email__c = 'testgroupBcontact01Preferred@fakedata.com',
+                                            Contact1_Work_Phone__c = '554-678-0001',
+                                            Contact2_Alternate_Email__c = 'testgroupBcontact02Alternate@fakedata.com',
+                                            Contact2_Birthdate__c = Date.today().addDays(-1000),
+                                            Contact2_Firstname__c = 'John',
+                                            Contact2_Home_Phone__c = '554-321-0002',
+                                            Contact2_Lastname__c = 'TestGroupB02',
+                                            Contact2_Mobile_Phone__c ='554-231-0002',
+                                            Contact2_Other_Phone__c = '554-456-0002',
+                                            Contact2_Personal_Email__c = 'testgroupBcontact02Personal@fakedata.com',
+                                            Contact2_Preferred_Email__c = 'testgroupBcontact02Preferred@fakedata.com',
+                                            Contact2_Preferred_Phone__c = '554-567-0002',
+                                            Contact2_Salutation__c = 'Mr.',
+                                            Contact2_Work_Email__c = 'testgroupBcontact02Preferred@fakedata.com',
+                                            Contact2_Work_Phone__c = '554-678-0002',
+                                            Donation_Amount__c = 1000,
+                                            Donation_Date__c = Date.today(),
+                                            Donation_Description__c = 'Most excellent donation',
+                                            Donation_Donor__c = 'Contact1',
+                                            Donation_Member_Level__c = 'Gold',
+                                            Donation_Membership_End_Date__c = Date.today().addDays(200),
+                                            Donation_Membership_Origin__c = 'Outer Space',
+                                            Donation_Membership_Start_Date__c =  Date.today().addDays(-200),
+                                            Donation_Name__c = 'TestGroupB',    
+                                            Donation_Stage__c = 'Closed Won',
+                                            Donation_Type__c = null,
+                                            GAU_Allocation_1_Amount__c = 750,
+                                            GAU_Allocation_1_GAU__c = gau1.Id,
+                                            GAU_Allocation_1_Percent__c = 75,
+                                            GAU_Allocation_2_Amount__c = 250,
+                                            GAU_Allocation_2_GAU__c = gau2.Id,
+                                            GAU_Allocation_2_Percent__c = 25,
+                                            Home_City__c = 'Fakopolis',
+                                            Home_Country__c = 'US',
+                                            Home_State_Province__c = 'CA',
+                                            Home_Street__c = '333 Fakington Blvd',
+                                            Home_Zip_Postal_Code__c = '94115',
+                                            Household_Phone__c = '554-789-0001',
+                                            Opportunity_Contact_Role_1_Role__c = 'Soft Credit',
+                                            Opportunity_Contact_Role_2_Role__c = 'Soft Credit',
+                                            Payment_Check_Reference_Number__c = '453',
+                                            Payment_Method__c = 'Check');
 
         insert new DataImport__c[]{testDataImportA,testDataImportB};
 
@@ -215,7 +213,8 @@ private class BDI_AdditionalObjectServiceTest {
     @isTest static void shouldCreateAdditionalGAUAllocationsAndOCRs() {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
-        dis.Default_Data_Import_Field_Mapping_Set__c = BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+        dis.Default_Data_Import_Field_Mapping_Set__c = 
+            BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
         Test.StartTest();
@@ -364,20 +363,23 @@ private class BDI_AdditionalObjectServiceTest {
 
         // Confirm that the desired GAU Allocations were created correctly
         System.assertEquals(4,gauAlloAll.size());
-        System.assertEquals(.75,gauAlloA1.Percent__c);
-        System.assertEquals(.25,gauAlloA2.Percent__c);
-        System.assertEquals(.75,gauAlloB1.Percent__c);
-        System.assertEquals(.25,gauAlloB2.Percent__c);
+        System.assertEquals(75,gauAlloA1.Percent__c);
+        System.assertEquals(25,gauAlloA2.Percent__c);
+        System.assertEquals(75,gauAlloB1.Percent__c);
+        System.assertEquals(25,gauAlloB2.Percent__c);
     }
+
 
     /*******************************************************************************************************
     * @description Tests that some of the GAU allocations should not be created due to missing required fields. 
     * Also, some of the OCRs should not be created because all non-relationship fields are missing data..
     */
+
     @isTest static void shouldNotCreateGAUAllocationsOrOCRs() {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
-        dis.Default_Data_Import_Field_Mapping_Set__c = BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+        dis.Default_Data_Import_Field_Mapping_Set__c = 
+            BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
         DataImport__c testDataImportA;
@@ -523,7 +525,8 @@ private class BDI_AdditionalObjectServiceTest {
     @isTest static void shouldUpdateAdditionalGAUAllocationsAndOCRs() {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
-        dis.Default_Data_Import_Field_Mapping_Set__c = BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+        dis.Default_Data_Import_Field_Mapping_Set__c = 
+                                    BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
         DataImport__c[] diRecords = Database.query(BDI_DataImportService.strSoqlForBatchProcess(null));
@@ -626,12 +629,12 @@ private class BDI_AdditionalObjectServiceTest {
 
         //Change values on the data import records and reset the status so it will be processed again.
         testDataImportAResult.Status__c = null;
-        testDataImportAResult.GAU_Allocation_1_Percent__c = .65;
-        testDataImportAResult.GAU_Allocation_2_Percent__c = .35;
+        testDataImportAResult.GAU_Allocation_1_Percent__c = 65;
+        testDataImportAResult.GAU_Allocation_2_Percent__c = 35;
         testDataImportAResult.Opportunity_Contact_Role_1_Role__c = 'Other';
         testDataImportBResult.Status__c = null;
-        testDataImportBResult.GAU_Allocation_1_Percent__c = .65;
-        testDataImportBResult.GAU_Allocation_2_Percent__c = .35;
+        testDataImportBResult.GAU_Allocation_1_Percent__c = 65;
+        testDataImportBResult.GAU_Allocation_2_Percent__c = 35;
         testDataImportBResult.Opportunity_Contact_Role_2_Role__c = 'Other';
 
         System.debug('GAU ALLOCATION BEFORE UPDATE IS: ' + testDataImportAResult.GAU_Allocation_1_Imported__c);
@@ -745,9 +748,198 @@ private class BDI_AdditionalObjectServiceTest {
 
         // Confirm that the new values for opportunity contact roles are in place.
         System.assertEquals(4,gauAlloAll.size());
-        System.assertEquals(.65,gauAlloA1.Percent__c);
-        System.assertEquals(.35,gauAlloA2.Percent__c);
-        System.assertEquals(.65,gauAlloB1.Percent__c);
-        System.assertEquals(.35,gauAlloB2.Percent__c);
+        System.assertEquals(65,gauAlloA1.Percent__c);
+        System.assertEquals(35,gauAlloA2.Percent__c);
+        System.assertEquals(65,gauAlloB1.Percent__c);
+        System.assertEquals(35,gauAlloB2.Percent__c);
+    }
+
+
+    /*******************************************************************************************************
+    * @description Tests that parent objects can be created during additional object processing.
+    *  Note that this would be an unconvential setup since we don't have a parent object as part of our 
+    *  default metadata configuration so we are having to re-use existing DI fields for the 
+    *  Imported Record Field Name and Status.
+    */
+    
+    @isTest static void shouldCreateParentAdditionalObjects() {
+        Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
+        dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
+        dis.Default_Data_Import_Field_Mapping_Set__c = 
+            BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+        UTIL_CustomSettingsFacade.setDataImportSettings(dis);
+
+        DataImport__c[] diRecords = Database.query(BDI_DataImportService.strSoqlForBatchProcess(null));
+
+        BDI_DataImportService bdiDIS = new BDI_DataImportService(false, BDI_DataImportService.getDefaultFieldMapping());
+        
+        BDI_FieldMappingCustomMetadata bdiFMCM = BDI_FieldMappingCustomMetadata.getInstance();
+
+        String[] objMappingNames = new List<String>(bdiFMCM.objMappingsByDevName.keySet());
+        Data_Import_Object_Mapping__mdt predecessorObjMapping = bdiFMCM.objMappingsByDevName.get('Opportunity');
+        Data_Import_Field_Mapping__mdt[] opptFieldMappings = bdiFMCM.fieldMappingsByObjMappingDevName.get('Opportunity'); 
+
+
+        Data_Import_Object_Mapping__mdt diom = 
+            new Data_Import_Object_Mapping__mdt(DeveloperName = 'TestTestHonoree324',
+                            MasterLabel = 'Honoree',
+                            Data_Import_Object_Mapping_Set__c = predecessorObjMapping.Data_Import_Object_Mapping_Set__c,
+                            Object_API_Name__c = 'Contact',
+                            Predecessor__c = predecessorObjMapping.DeveloperName,
+                            Imported_Record_Field_Name__c = 'Contact1_Title__c',
+                            Imported_Record_Status_Field_Name__c = 'Contact1ImportStatus__c',
+                            Relationship_Field__c = 'Honoree_Contact__c',
+                            Relationship_To_Predecessor__c = 'Parent');
+        Data_Import_Field_Mapping__mdt honoreeLastName = 
+            new Data_Import_Field_Mapping__mdt(DeveloperName = 'fakeHonoreeLastNameSFDOTest34',
+                            MasterLabel = 'fakeHonoreeLastNameSFDOTest34',
+                            Data_Import_Field_Mapping_Set__c = opptFieldMappings[0].Data_Import_Field_Mapping_Set__c,
+                            Required__c = 'Yes',
+                            Source_Field_API_Name__c = 'Contact1_Alternate_Email__c',
+                            Target_Field_API_Name__c = 'LastName' );
+
+        Data_Import_Field_Mapping__mdt honoreeAccountId = 
+            new Data_Import_Field_Mapping__mdt(DeveloperName = 'fakeHonoreeAcctSFDOTest34',
+                            MasterLabel = 'fakeHonoreeAcctSFDOTest34',
+                            Data_Import_Field_Mapping_Set__c = opptFieldMappings[0].Data_Import_Field_Mapping_Set__c,
+                            Required__c = 'No',
+                            Source_Field_API_Name__c = 'Account1Imported__c',
+                            Target_Field_API_Name__c = 'AccountId' );
+
+        Data_Import_Field_Mapping__mdt[] honoreeFieldMappings = 
+            new Data_Import_Field_Mapping__mdt[]{honoreeLastName,honoreeAccountId};
+
+        bdiFMCM.objMappingsByDevName.put(diom.DeveloperName,diom);
+        bdiFMCM.fieldMappingsByObjMappingDevName.put(diom.DeveloperName,honoreeFieldMappings);
+
+        bdiDIS.process(null, dis, diRecords);
+        
+        DataImport__c testDataImportAResult;
+        DataImport__c testDataImportBResult;
+
+        for (DataImport__c di : [SELECT Id,
+                                        Status__c,
+                                        FailureInformation__c,
+                                        Contact1_Title__c,
+                                        GAU_Allocation_1_Import_Status__c,
+                                        GAU_Allocation_1_Imported__c,
+                                        GAU_Allocation_2_Import_Status__c,
+                                        GAU_Allocation_2_Imported__c,
+                                        Opportunity_Contact_Role_1_Imported__c,
+                                        Opportunity_Contact_Role_1_ImportStatus__c,
+                                        Opportunity_Contact_Role_2_Imported__c,
+                                        Opportunity_Contact_Role_2_ImportStatus__c,
+                                        Contact1_Lastname__c,
+                                        Account1ImportStatus__c,
+                                        Account1Imported__c, 
+                                        Account2ImportStatus__c,
+                                        Account2Imported__c,
+                                        Contact1ImportStatus__c,
+                                        Contact1Imported__c,
+                                        Contact2ImportStatus__c,
+                                        Contact2Imported__c,
+                                        DonationCampaignImportStatus__c,
+                                        DonationCampaignImported__c,
+                                        DonationImportStatus__c,
+                                        DonationImported__c,
+                                        HomeAddressImportStatus__c,
+                                        HomeAddressImported__c,
+                                        HouseholdAccountImported__c,
+                                        PaymentImportStatus__c,
+                                        PaymentImported__c
+                                    FROM DataImport__c]) {
+
+            if (di.Contact1_Lastname__c == 'TestGroupA01') {
+                testDataImportAResult = di;
+            } else if (di.Contact1_Lastname__c == 'TestGroupB01'){
+                testDataImportBResult = di;
+            }
+        }
+
+        Contact honoreeContA;
+        Contact honoreeContB;
+
+        Contact[] createdConts = [SELECT Id, LastName FROM Contact];
+        System.assertEquals(6,createdConts.size());
+
+        for (Contact cont : createdConts) {
+            if (cont.LastName == 'testgroupAcontact01Alternate@fakedata.com') {
+                honoreeContA = cont;
+            } else if (cont.LastName == 'testgroupBcontact01Alternate@fakedata.com') {
+                honoreeContB = cont;
+            }
+        }
+
+        // Checking to make sure that the honoree contacts were created.
+        System.assert(honoreeContA != null);
+        System.assert(honoreeContB != null);
+
+        Opportunity opptA;
+        Opportunity opptB;
+
+        Opportunity[] updatedOppts = [SELECT Id, Honoree_Contact__c FROM Opportunity];
+        System.assertEquals(2,updatedOppts.size());
+
+        for (Opportunity oppt : updatedOppts) {
+            if (oppt.Id == testDataImportAResult.DonationImported__c) {
+                opptA = oppt;
+            } else if (oppt.Id == testDataImportBResult.DonationImported__c) {
+                opptB = oppt;
+            }
+        }
+
+        //Confirm that the predecessor child opportunities exist and were properly updated with the
+        //Honoree contact id.
+        System.assert(opptA != null);
+        System.assert(opptB != null);
+        System.assertEquals(honoreeContA.Id,opptA.Honoree_Contact__c);
+        System.assertEquals(honoreeContB.Id,opptB.Honoree_Contact__c);
+    
+        System.assertEquals(System.label.bdiImported,testDataImportAResult.Status__c);
+        System.assertNotEquals(null,testDataImportAResult.Account1Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.Account1ImportStatus__c);
+        System.assertNotEquals(null,testDataImportAResult.Account2Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.Account2ImportStatus__c);
+        System.assertNotEquals(null,testDataImportAResult.Contact1Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.Contact1ImportStatus__c);
+        System.assertNotEquals(null,testDataImportAResult.Contact2Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.Contact2ImportStatus__c);
+        System.assertNotEquals(null,testDataImportAResult.DonationCampaignImported__c);
+        System.assertEquals(System.label.bdiMatched,testDataImportAResult.DonationCampaignImportStatus__c);
+        System.assertNotEquals(null,testDataImportAResult.DonationImported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.DonationImportStatus__c);
+        System.assertNotEquals(null,testDataImportAResult.HouseholdAccountImported__c);
+        System.assertNotEquals(null,testDataImportAResult.GAU_Allocation_1_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.GAU_Allocation_1_Import_Status__c);
+        System.assertNotEquals(null,testDataImportAResult.GAU_Allocation_2_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.GAU_Allocation_2_Import_Status__c);
+        System.assertNotEquals(null,testDataImportAResult.Opportunity_Contact_Role_1_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.Opportunity_Contact_Role_1_ImportStatus__c);
+        System.assertNotEquals(null,testDataImportAResult.Opportunity_Contact_Role_2_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportAResult.Opportunity_Contact_Role_2_ImportStatus__c);
+
+        System.assertEquals(System.label.bdiImported,testDataImportBResult.Status__c);
+        System.assertNotEquals(null,testDataImportBResult.Account1Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.Account1ImportStatus__c);
+        System.assertNotEquals(null,testDataImportBResult.Account2Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.Account2ImportStatus__c);
+        System.assertNotEquals(null,testDataImportBResult.Contact1Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.Contact1ImportStatus__c);
+        System.assertNotEquals(null,testDataImportBResult.Contact2Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.Contact2ImportStatus__c);
+
+        System.assertNotEquals(null,testDataImportBResult.DonationCampaignImported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.DonationCampaignImportStatus__c);
+        System.assertNotEquals(null,testDataImportBResult.DonationImported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.DonationImportStatus__c);
+        System.assertNotEquals(null,testDataImportBResult.HouseholdAccountImported__c);
+        System.assertNotEquals(null,testDataImportBResult.GAU_Allocation_1_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.GAU_Allocation_1_Import_Status__c);
+        System.assertNotEquals(null,testDataImportBResult.GAU_Allocation_2_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.GAU_Allocation_2_Import_Status__c);
+        System.assertNotEquals(null,testDataImportBResult.Opportunity_Contact_Role_1_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.Opportunity_Contact_Role_1_ImportStatus__c);
+        System.assertNotEquals(null,testDataImportBResult.Opportunity_Contact_Role_2_Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDataImportBResult.Opportunity_Contact_Role_2_ImportStatus__c);
     }
 }

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -50,7 +50,7 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
         for (BDI_ObjectWrapper objWrap : objWraps) {
             Map<String, Schema.DescribeFieldResult> targetFieldDescByFieldName = UTIL_Describe.getAllFieldsDescribe(objWrap.objMapping.Object_API_Name__c);
 
-            objWrap.sObj = Schema.getGlobalDescribe().get(objWrap.objMapping.Object_API_Name__c).newSObject();
+            objWrap.sObj = UTIL_Describe.getPrototypeObject(objWrap.objMapping.Object_API_Name__c);
 
             if (objWrap.existingSObjectId != null) {
                 objWrap.sObj.put('Id', objWrap.existingSObjectId);

--- a/src/classes/BDI_ObjectMappingLogic.cls
+++ b/src/classes/BDI_ObjectMappingLogic.cls
@@ -48,7 +48,7 @@ public with sharing virtual class BDI_ObjectMappingLogic {
         for (BDI_ObjectWrapper objWrap : objWraps) {
             Map<String, Schema.DescribeFieldResult> targetFieldDescribeMap = UTIL_Describe.getAllFieldsDescribe(objWrap.objMapping.Object_API_Name__c);
 
-            objWrap.sObj = Schema.getGlobalDescribe().get(objWrap.objMapping.Object_API_Name__c).newSObject();
+            objWrap.sObj = UTIL_Describe.getPrototypeObject(objWrap.objMapping.Object_API_Name__c);
 
             // If the object already has an existing SObject Id, then set it in the sObj
             if (objWrap.existingSObjectId != null) {

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1914,6 +1914,13 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>The Account Custom Unique ID setting field {0} must have matching fields in the NPSP Data Import object whose API Names are {1} and {2}.</value>
     </labels>
     <labels>
+        <fullName>bdiAdditionalObjChildNotUpdated</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>bdiAdditionalObjChildNotUpdated</shortDescription>
+        <value>Error when updating child record lookup field(s) with new parent record id. Error message is:</value>
+    </labels>
+    <labels>
         <fullName>bdiAdditionalObjPredNotFound</fullName>
         <categories>Data Importer</categories>
         <language>en_US</language>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1918,7 +1918,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>bdiAdditionalObjChildNotUpdated</shortDescription>
-        <value>Error when updating child record lookup field(s) with new parent record id. Error message is:</value>
+        <value>Unable to update the child record's lookup field with new parent record's ID. It was unable to update because of this system error:</value>
     </labels>
     <labels>
         <fullName>bdiAdditionalObjPredNotFound</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1413,6 +1413,7 @@
         <members>alloTotals</members>
         <members>alloUnallocated</members>
         <members>bdiAccountCustomIdError</members>
+        <members>bdiAdditionalObjChildNotUpdated</members>
         <members>bdiAdditionalObjPredNotFound</members>
         <members>bdiAdditionalObjRequiredFieldsNull</members>
         <members>bdiBatchException</members>


### PR DESCRIPTION
- Added the ability to have additional objects created as a parent of their predecessor, and for the id of the new record to populated in the designated relationship field on the child predecessor.
- Also started using an existing utility method to generate new SObjects which should reduce  metadata describe calls.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
