### PR TITLE
Engagement Plan Start Date feature

### DIFF
--- a/src/classes/EP_EngagementPlans_TEST.cls
+++ b/src/classes/EP_EngagementPlans_TEST.cls
@@ -114,6 +114,83 @@ private with sharing class EP_EngagementPlans_TEST {
     }
 
     /*********************************************************************************************************
+    * @description Creates a template with two EP Tasks, one of them dependent on the other. Then creates an
+    * Engagement Plan using that template. Verifies that tasks are created, that fields are copied over, and
+    * that both non-dependent and dependent tasks use the correct defaults.
+    */
+    static testMethod void testStartDate() {
+
+        Id otherUserId = getOtherUserId();
+
+        Contact con = new Contact(LastName = 'foo');
+        insert con;
+
+        Engagement_Plan_Template__c template = new Engagement_Plan_Template__c(
+            Name = 'Template',
+            Skip_Weekends__c = false,
+            Default_Assignee__c = EP_EngagementPlans_UTIL.BLANK_ASSIGNMENT_USER_CREATING
+        );
+        insert template;
+
+        Engagement_Plan_Task__c epTask = new Engagement_Plan_Task__c(
+            Name = 'Call',
+            Engagement_Plan_Template__c = template.id,
+            Assigned_To__c = otherUserId,
+            Comments__c = 'This comment should be copied correctly to the Task.',
+            Reminder__c = true,
+            Reminder_Time__c = '660',
+            Send_Email__c = true,
+            Days_After__c = 3,
+            Type__c = 'Call'
+        );
+        insert epTask;
+
+        Engagement_Plan_Task__c dependentEpTask = new Engagement_Plan_Task__c(
+            Name = 'Email',
+            Engagement_Plan_Template__c = template.id,
+            Parent_Task__c = epTask.id,
+            Comments__c = 'This comment should also be copied correctly to the Task.',
+            Reminder__c = true,
+            Reminder_Time__c = '780',
+            Send_Email__c = true,
+            Days_After__c = 10,
+            Type__c = 'Email',
+            Priority__c = 'Low'
+        );
+        insert dependentEpTask;
+
+        Engagement_Plan__c plan = new Engagement_Plan__c(
+            Contact__c = con.id,
+            Engagement_Plan_Template__c = template.id,
+            Start_Date__c = System.Today().AddDays(5)
+        );
+
+        Test.startTest();
+        insert plan;
+        Test.stopTest();
+
+        List<Task> results = [SELECT Id, OwnerId, WhoId, Type, Status, Subject, ActivityDate, Priority, Description,
+                            IsReminderSet, ReminderDateTime FROM Task WHERE WhoId = :con.id ORDER BY ActivityDate];
+        System.assertEquals(2, results.size(), 'Two tasks should be created.');
+
+        System.assertEquals(epTask.Name, results[0].Subject, 'Subject field should be set based on EP Task Name.');
+        System.assertEquals(epTask.Comments__c, results[0].Description, 'Comment field should be copied correctly.');
+        
+        System.assertEquals(System.Today().addDays(8), results[0].ActivityDate, 'Activity Date should be eight days from today.');
+        System.assert(results[0].IsReminderSet, 'Reminder should be set.');
+        System.assertEquals(System.Today().addDays(8), results[0].ReminderDateTime.Date(), 'Reminder should be set eight days from today.');
+        System.assertEquals(UTIL_Describe.getDefaultSelectOption('Task', 'Priority'), results[0].Priority, 'Priority field left blank should be set based on default picklist value.');
+        System.assertEquals(otherUserId, results[0].OwnerId, 'Task owner should be based on EP Task Assigned To field.');
+
+        System.assertEquals(dependentEpTask.Name, results[1].Subject, 'Subject field should be set based on EP Task Name.');
+        System.assertEquals(dependentEpTask.Comments__c, results[1].Description, 'Comment field should be copied correctly.');
+        System.assertEquals(System.Today().addDays(18), results[1].ActivityDate, 'Activity Date should be set eighteen days from today.');
+        System.assert(!results[1].IsReminderSet, 'Reminder should not be set for a dependent task.');
+        System.assertEquals(dependentEpTask.Priority__c, results[1].Priority, 'Priority field should be set based on EP Task Priority.');
+        System.assertEquals(UserInfo.getUserId(), results[1].OwnerId, 'Task owner left blank should be based on running user.');
+    }
+
+    /*********************************************************************************************************
     * @description Creates an EP Task with a delay of the number of days until the weekend, as part of a 
     * template set to delay until Monday. Verifies that the activity date is set on Monday.
     */
@@ -342,7 +419,7 @@ private with sharing class EP_EngagementPlans_TEST {
     }
 
     /*********************************************************************************************************
-    * @description Updates an engagement plan to change the value of the  lookup, verifies an exception is thrown.
+    * @description Updates an engagement plan to change the value of the lookup, verifies an exception is thrown.
     */
     static testMethod void testPlanUpdate() {
 

--- a/src/classes/EP_Task_UTIL.cls
+++ b/src/classes/EP_Task_UTIL.cls
@@ -177,7 +177,8 @@ public class EP_Task_UTIL {
         //this will not be comitted to the database
         epTask.Days_After__c = getParentDelayRecursive(epTask);
 
-        taskResult.ActivityDate = calcActivityDate(epTask, System.today());
+        Date startDate = engagementPlan.Start_Date__c == null ? System.Today() : engagementPlan.Start_Date__c;
+        taskResult.ActivityDate = calcActivityDate(epTask, startDate);
 
         //default the Priority field if none is set
         if (String.isBlank(taskResult.Priority)) {

--- a/src/objects/Engagement_Plan__c.object
+++ b/src/objects/Engagement_Plan__c.object
@@ -144,6 +144,16 @@
         <type>Lookup</type>
     </fields>
     <fields>
+        <fullName>Start_Date__c</fullName>
+        <description>The start date this Engagement Plan should be based off. If blank, the Engagement Plan will be based off of today&apos;s date.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The start date this Engagement Plan should be based off. If blank, the Engagement Plan will be based off of today&apos;s date.</inlineHelpText>
+        <label>Start Date</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Date</type>
+    </fields>
+    <fields>
         <fullName>Status__c</fullName>
         <externalId>false</externalId>
         <formula>IF( Completed_Tasks__c == Total_EP_Tasks__c, $Label.statusCompleted, IF (Completed_Tasks__c &gt; 0, $Label.statusInProgress, $Label.statusNotStarted))</formula>


### PR DESCRIPTION
# Critical Changes

# Changes
- Added a Start Date field to the Engagement Plan object. When populated, the tasks created by the engagement plan are based off of that date instead of today's date.

# Issues Closed

# New Metadata

# Deleted Metadata
