### PR TITLE
Enabling Customizable Rollups the first time does not fully enable the feature

### DIFF
--- a/src/classes/CRLP_ApiService.cls
+++ b/src/classes/CRLP_ApiService.cls
@@ -361,7 +361,6 @@ public without sharing class CRLP_ApiService {
          */
         public Boolean hasChanged() {
             if (isNew) {
-                System.debug('has changed new');
                 return true;
             }
 
@@ -369,7 +368,6 @@ public without sharing class CRLP_ApiService {
                 if (cmtRollup.recordName == rlp.DeveloperName) {
                     if (cmtRollup.isDifferent(rlp)) {
                         oldRollupType = new CRLP_RollupCMT.Rollup(rlp).getRollupType();
-                        system.debug('rollup has changed' + rlp.DeveloperName);
                         return true;
                     }
                     break;
@@ -445,7 +443,6 @@ public without sharing class CRLP_ApiService {
                     existingGroup.withRules(rulesByGroupId.get(existingGroup.recordId))
                 )) {
                     hasChanged = true;
-                    System.debug('has changed ' + cmtFilterGroup);
                 }
 
                 break;
@@ -494,15 +491,16 @@ public without sharing class CRLP_ApiService {
         * @description success handler - will call the ApiService to set rollup as stale 
         **/
         public void performSuccessHandler(Map<String, Object> callbackParams, String status) {
+            updateDeploymentStatus(status, true);
 
             if (callbackParams == null || callbackParams.isEmpty()) {
                 return;
             }
 
-            updateDeploymentStatus(status, true);
-
             try {
-                new CRLP_ApiService().setRollupStateAsStale( (Set<String>)callbackParams.get(CallableApiParameters.PARAM_ROLLUP_TYPES) );
+                new CRLP_ApiService().setRollupStateAsStale(
+                    (Set<String>)callbackParams.get(CallableApiParameters.PARAM_ROLLUP_TYPES)
+                );
             } catch (Exception ex) {
                 logError(ex);
             }
@@ -522,10 +520,11 @@ public without sharing class CRLP_ApiService {
         */
         private void updateDeploymentStatus(String status, Boolean isSuccess) {
             Customizable_Rollup_Settings__c crlpSettings = UTIL_CustomSettingsFacade.getCustomizableRollupSettings();
+            
             crlpSettings.CMT_API_Status__c = status;
             crlpSettings.Customizable_Rollups_Enabled__c = (isSuccess || crlpSettings.Customizable_Rollups_Enabled__c == true);
-            update crlpSettings;
 
+            update crlpSettings;
         }
 
         /**


### PR DESCRIPTION
# Critical Changes

# Changes
In addition to resolving an issue with Customizable Rollups not being enabled on the first try, we also resolved an issue where customers received a false timeout error message every time they saved a new or updated Customizable Rollup or Filter Group. Note that this does not completely resolve intermittent false timeouts that we have been tracking and we are still investigating a different strategy. If you do receive a false timeout, go to Setup --> Deployment Status and verify that the deployment succeeded. Otherwise, you may be at risk of duplicate records.

# Issues Closed
Fixes #4346 

# New Metadata

# Deleted Metadata
