### PR TITLE
Updated language for Empty HH Account health check error

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4103,7 +4103,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>healthSolutionHHAccNoContacts</shortDescription>
-        <value>Consider deleting these unused Household Account records to save space. View these Household Account records by running the Empty Household Accounts report in the NPSP Health Check reports folder.</value>
+        <value>Consider deleting these unused Household Account records to save space. View these Household Account records by running the &lt;b&gt;Empty Household Accounts&lt;/b&gt; report in the NPSP Health Check reports folder.</value>
     </labels>
     <labels>
         <fullName>healthSolutionHHObjNoContacts</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4103,7 +4103,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>healthSolutionHHAccNoContacts</shortDescription>
-        <value>Consider deleting these unused Household object records to save space. If you have completed a conversion to the Household Account model and no longer need the data on the Household object records, you can safely delete them. View these Household object records by running the Empty Household Objects report in the NPSP Health Check reports folder.</value>
+        <value>Consider deleting these unused Household Account records to save space. View these Household Account records by running the Empty Household Accounts report in the NPSP Health Check reports folder.</value>
     </labels>
     <labels>
         <fullName>healthSolutionHHObjNoContacts</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes
We updated the language in the Empty Household Account health check message to point to the correct health check report. Previously, the error message pointed to the Household object report.

# Issues Closed

# New Metadata

# Deleted Metadata
