### PR TITLE
BDI: Concatenate Additional Object Error Messages

### DIFF
--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -181,55 +181,6 @@ public with sharing class BDI_AdditionalObjectService {
         return objAPINameToObjWraps;
     }
 
-    Map<Id, String> errorMessagesByDataImportId;
-    void logError(BDI_ObjectWrapper objectWrapper, String errorMessage) {
-        DataImport__c dataImport = objectWrapper.dataImport;
-
-        //Set the overall data import record status
-        dataImport.Status__c = BDI_DataImport_API.bdiFailed;
-
-        //Set the import status for this specific additional object
-        String statusField = objectWrapper.objMapping.Imported_Record_Status_Field_Name__c;
-        if (statusField != null) {
-            dataImport.put(statusField, errorMessage.left(255));
-        }
-
-        //Data Import Failure Message handling
-        String errorMessageToAppend;
-        if (objectWrapper.objMapping.Imported_Record_Status_Field_Name__c != null) {
-
-            String importedRecordStatusField = UTIL_Namespace.StrAllNSPrefix(objectWrapper
-                    .objMapping.Imported_Record_Status_Field_Name__c);
-
-            String importedRecordStatusFieldLabel = UTIL_Describe.getFieldDescribe(
-                    DataImport__c.SObjectType.getDescribe().getName(),
-                    importedRecordStatusField).getLabel();
-
-            errorMessageToAppend = String.join(new
-                    List<String>{importedRecordStatusFieldLabel, errorMessage}, ':\n');
-        } else {
-            errorMessageToAppend = errorMessage;
-        }
-
-        if (errorMessagesByDataImportId == null) {
-            errorMessagesByDataImportId = new Map<Id, String>();
-        }
-
-        String combinedErrorMessage =
-                errorMessagesByDataImportId.get(dataImport.Id);
-
-        if (combinedErrorMessage == null) {
-            errorMessagesByDataImportId.put(dataImport.Id, errorMessageToAppend);
-        } else {
-            errorMessagesByDataImportId.put(dataImport.Id,
-                    String.join(new List<String>{
-                            combinedErrorMessage, errorMessageToAppend
-                    }, '\n\n'));
-        }
-        dataImport.FailureInformation__c = errorMessagesByDataImportId
-                .get(dataImport.Id);
-    }
-
     /*******************************************************************************************************
     * @description Takes a map of SObject api name to the object wrappers for that SObject and either updates 
     *  or inserts the data.
@@ -635,4 +586,68 @@ public with sharing class BDI_AdditionalObjectService {
         return importedRecordFieldNames;
     }
 
+    private void logError(BDI_ObjectWrapper objectWrapper, String errorMessage) {
+        objectWrapper.setDataImportStatus(BDI_DataImport_API.bdiFailed);
+
+        objectWrapper.setImportedRecordStatusError(errorMessage);
+
+        logCombinedFailureInformation(objectWrapper, errorMessage);
+
+        objectWrapper.setFailureInformation(
+                failureInformationByDataImportId.get(objectWrapper.dataImport.Id)
+        );
+    }
+
+    private Map<Id, String> failureInformationByDataImportId;
+
+    private void logCombinedFailureInformation(
+            BDI_ObjectWrapper objectWrapper,
+            String errorMessage) {
+
+        DataImport__c dataImport = objectWrapper.dataImport;
+        String errorMessageToAppend =
+                getFailureInformationErrorMessage(objectWrapper, errorMessage);
+
+        if (failureInformationByDataImportId == null) {
+            failureInformationByDataImportId = new Map<Id, String>();
+        }
+
+        String combinedErrorMessage =
+                failureInformationByDataImportId.get(dataImport.Id);
+
+        if (combinedErrorMessage == null) {
+            failureInformationByDataImportId.put(dataImport.Id, errorMessageToAppend);
+        } else {
+            failureInformationByDataImportId.put(dataImport.Id,
+                    String.join(
+                            new List<String>{
+                                    combinedErrorMessage, errorMessageToAppend
+                            }, '\n\n'));
+        }
+    }
+
+    private String getFailureInformationErrorMessage(
+            BDI_ObjectWrapper objectWrapper,
+            String errorMessage) {
+
+        String errorMessageToAppend;
+        if (objectWrapper.objMapping.Imported_Record_Status_Field_Name__c != null) {
+
+            String importedRecordStatusField = UTIL_Namespace.StrAllNSPrefix(
+                    objectWrapper.objMapping.Imported_Record_Status_Field_Name__c
+            );
+
+            String importedRecordStatusFieldLabel = UTIL_Describe.getFieldDescribe(
+                    DataImport__c.SObjectType.getDescribe().getName(),
+                    importedRecordStatusField).getLabel();
+
+            errorMessageToAppend = String.join(
+                    new List<String>{
+                            importedRecordStatusFieldLabel, errorMessage
+                    }, ':\n');
+        } else {
+            errorMessageToAppend = errorMessage;
+        }
+        return errorMessageToAppend;
+    }
 }

--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -181,6 +181,55 @@ public with sharing class BDI_AdditionalObjectService {
         return objAPINameToObjWraps;
     }
 
+    Map<Id, String> errorMessagesByDataImportId;
+    void logError(BDI_ObjectWrapper objectWrapper, String errorMessage) {
+        DataImport__c dataImport = objectWrapper.dataImport;
+
+        //Set the overall data import record status
+        dataImport.Status__c = BDI_DataImport_API.bdiFailed;
+
+        //Set the import status for this specific additional object
+        String statusField = objectWrapper.objMapping.Imported_Record_Status_Field_Name__c;
+        if (statusField != null) {
+            dataImport.put(statusField, errorMessage.left(255));
+        }
+
+        //Data Import Failure Message handling
+        String errorMessageToAppend;
+        if (objectWrapper.objMapping.Imported_Record_Status_Field_Name__c != null) {
+
+            String importedRecordStatusField = UTIL_Namespace.StrAllNSPrefix(objectWrapper
+                    .objMapping.Imported_Record_Status_Field_Name__c);
+
+            String importedRecordStatusFieldLabel = UTIL_Describe.getFieldDescribe(
+                    DataImport__c.SObjectType.getDescribe().getName(),
+                    importedRecordStatusField).getLabel();
+
+            errorMessageToAppend = String.join(new
+                    List<String>{importedRecordStatusFieldLabel, errorMessage}, ':\n');
+        } else {
+            errorMessageToAppend = errorMessage;
+        }
+
+        if (errorMessagesByDataImportId == null) {
+            errorMessagesByDataImportId = new Map<Id, String>();
+        }
+
+        String combinedErrorMessage =
+                errorMessagesByDataImportId.get(dataImport.Id);
+
+        if (combinedErrorMessage == null) {
+            errorMessagesByDataImportId.put(dataImport.Id, errorMessageToAppend);
+        } else {
+            errorMessagesByDataImportId.put(dataImport.Id,
+                    String.join(new List<String>{
+                            combinedErrorMessage, errorMessageToAppend
+                    }, '\n\n'));
+        }
+        dataImport.FailureInformation__c = errorMessagesByDataImportId
+                .get(dataImport.Id);
+    }
+
     /*******************************************************************************************************
     * @description Takes a map of SObject api name to the object wrappers for that SObject and either updates 
     *  or inserts the data.
@@ -265,10 +314,8 @@ public with sharing class BDI_AdditionalObjectService {
                         if (result.isSuccess()) {
                             objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Status_Field_Name__c,
                                 System.label.bdiUpdated);
-                        } else { 
-                            dataImportService.LogBDIError(objWrap.dataImport, 
-                                result.getErrors()[0].getMessage(),
-                                objWrap.objMapping.Imported_Record_Status_Field_Name__c);
+                        } else {
+                            logError(objWrap, result.getErrors()[0].getMessage());
                         }
                     }
                 }        
@@ -301,10 +348,8 @@ public with sharing class BDI_AdditionalObjectService {
                             if (objWrap.objMapping.Relationship_To_Predecessor__c == 'Parent') { 
                                 objWrapsForChildPredecessorUpdate.add(objWrap);
                             }
-                        } else { 
-                            dataImportService.LogBDIError(objWrap.dataImport, 
-                                result.getErrors()[0].getMessage(),
-                                objWrap.objMapping.Imported_Record_Status_Field_Name__c);
+                        } else {
+                            logError(objWrap, result.getErrors()[0].getMessage());
                         }
                     }
                 }
@@ -425,12 +470,10 @@ public with sharing class BDI_AdditionalObjectService {
                 // for all successor objects.
                 if (!result.isSuccess()) {
                     for (BDI_ObjectWrapper objWrap : successorObjWraps) {
-                    
-                        String errorMessage = System.label.bdiAdditionalObjChildNotUpdated + 
-                                                result.getErrors()[0].getMessage();
-                        dataImportService.LogBDIError(objWrap.dataImport, 
-                            errorMessage,
-                            objWrap.objMapping.Imported_Record_Status_Field_Name__c);
+
+                        String errorMessage = System.label.bdiAdditionalObjChildNotUpdated +
+                                result.getErrors()[0].getMessage();
+                        logError(objWrap, errorMessage);
                     }
                 }
             }
@@ -447,9 +490,7 @@ public with sharing class BDI_AdditionalObjectService {
         Boolean result = true;
         if (objWrap.dataImport.get(predecessor.Imported_Record_Field_Name__c) == null) {
             result = false;
-            dataImportService.LogBDIError(objWrap.dataImport, 
-                System.label.bdiAdditionalObjPredNotFound,
-                objWrap.objMapping.Imported_Record_Status_Field_Name__c);
+            logError(objWrap, System.label.bdiAdditionalObjPredNotFound);
         }
         return result;
     }
@@ -504,9 +545,7 @@ public with sharing class BDI_AdditionalObjectService {
 
             } else if (anyNonImportedRecordFieldsPopulated && !allRequiredFieldsPopulated) {
                 requiredFieldErrorMsg = requiredFieldErrorMsg.removeEnd('; ').abbreviate(255);
-                dataImportService.LogBDIError(objWrap.dataImport, 
-                    requiredFieldErrorMsg,
-                    objWrap.objMapping.Imported_Record_Status_Field_Name__c);
+                logError(objWrap, requiredFieldErrorMsg);
             }
         }
 

--- a/src/classes/BDI_AdditionalObjectServiceTest.cls
+++ b/src/classes/BDI_AdditionalObjectServiceTest.cls
@@ -942,4 +942,74 @@ private class BDI_AdditionalObjectServiceTest {
         System.assertNotEquals(null,testDataImportBResult.Opportunity_Contact_Role_2_Imported__c);
         System.assertEquals(System.label.bdiCreated,testDataImportBResult.Opportunity_Contact_Role_2_ImportStatus__c);
     }
+
+    @isTest
+    static void givenAdditionalObjectsFailWhenProcessedThenAssertFailureInformation() {
+        General_Accounting_Unit__c testGAU = new General_Accounting_Unit__c(Name = 'testGAU');
+        insert testGAU;
+
+        DataImport__c singleErrorDataImport = new DataImport__c(
+                Account1_Name__c = 'a0',
+                Donation_Donor__c = 'Account1',
+                Donation_Amount__c = 100,
+                Donation_Date__c = Date.today(),
+                GAU_Allocation_1_GAU__c = testGAU.Id,
+                GAU_Allocation_1_Percent__c = 110
+        );
+
+        DataImport__c doubleErrorDataImport = new DataImport__c(
+                Account1_Name__c = 'a1',
+                Donation_Donor__c = 'Account1',
+                Donation_Amount__c = 100,
+                Donation_Date__c = Date.today(),
+                GAU_Allocation_1_GAU__c = testGAU.Id,
+                GAU_Allocation_1_Percent__c = 110,
+                Opportunity_Contact_Role_1_Role__c = 'testOCRole'
+        );
+        insert new List<DataImport__c>{
+                singleErrorDataImport, doubleErrorDataImport
+        };
+
+        //run batch data import
+        Test.StartTest();
+        BDI_DataImportService dataImportService =
+                new BDI_DataImportService(
+                        false,
+                        BDI_FieldMappingCustomMetadata.getInstance());
+
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);
+
+        Database.executeBatch(bdi, 10);
+        Test.stopTest();
+
+        List<DataImport__c> dataImports = [
+                SELECT
+                        Status__c,
+                        FailureInformation__c,
+                        GAU_Allocation_1_Import_Status__c,
+                        Opportunity_Contact_Role_1_ImportStatus__c
+                FROM DataImport__c
+                WHERE Id = :singleErrorDataImport.Id
+                OR Id = :doubleErrorDataImport.Id
+        ];
+
+        for (DataImport__c dataImport : dataImports) {
+            System.assertEquals(BDI_DataImport_API.bdiFailed, dataImport.Status__c);
+            System.assertNotEquals(null, dataImport.GAU_Allocation_1_Import_Status__c);
+            System.assertNotEquals(null, dataImport.FailureInformation__c);
+            System.assert(dataImport.FailureInformation__c.contains(dataImport
+                    .GAU_Allocation_1_Import_Status__c),
+                    'The Data Import Failure Information field should contain ' +
+                            'the GAU Allocation error message.');
+
+            if (dataImport.Id == doubleErrorDataImport.Id) {
+                System.assertNotEquals(null,
+                        dataImport.Opportunity_Contact_Role_1_ImportStatus__c);
+                System.assert(dataImport.FailureInformation__c.contains(
+                        dataImport.Opportunity_Contact_Role_1_ImportStatus__c),
+                        'The Data Import Failure Information field should contain both the ' +
+                                'GAU Allocation and Opportunity Contact Role error messages.');
+            }
+        }
+    }
 }

--- a/src/classes/BDI_ObjectWrapper.cls
+++ b/src/classes/BDI_ObjectWrapper.cls
@@ -51,4 +51,19 @@ public with sharing class BDI_ObjectWrapper {
         this.fieldMappings = fieldMappings;
         this.dataImport = dataImport;
     }
+
+    public void setDataImportStatus(String status) {
+        dataImport.Status__c = status;
+    }
+
+    public void setImportedRecordStatusError(String errorMessage) {
+        String statusField = objMapping.Imported_Record_Status_Field_Name__c;
+        if (statusField != null && errorMessage != null) {
+            dataImport.put(statusField, errorMessage.left(255));
+        }
+    }
+
+    public void setFailureInformation(String failureInformation) {
+        dataImport.FailureInformation__c = failureInformation;
+    }
 }


### PR DESCRIPTION
This set of changes collects all error messages that occur within
the additional objects service class and concatenates them so that
there is one combined summary error message that is placed in the Data
Import Failure Information field.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
