### PR TITLE
Feature/bdi co update qa org config

### DIFF
--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.ASC_Amount_cac3e1cd0.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.ASC_Amount_cac3e1cd0.md
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>ASC Amount</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">ASC_Amount__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">Amount__c</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">AccountSoftCredits_ee5babc24</value>
+    </values>
+</CustomMetadata>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.ASC_Role_f8860e39d.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.ASC_Role_f8860e39d.md
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>ASC Role</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">ASC_Role__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">Role__c</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">AccountSoftCredits_ee5babc24</value>
+    </values>
+</CustomMetadata>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Date_2cb21281d.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Date_2cb21281d.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Date</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Date_37b322bd6.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Date_37b322bd6.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Date</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Number_21e98c57a.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Number_21e98c57a.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Number</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Number_53ae81fff.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Number_53ae81fff.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Number</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Phone_97db48921.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Phone_97db48921.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Phone</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Phone_d399fb3fe.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Phone_d399fb3fe.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Phone</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Picklist_52bab1bba.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Picklist_52bab1bba.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Picklist</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Picklist_57bf42e30.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Picklist_57bf42e30.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Picklist</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Text_9f7f926f9.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Text_9f7f926f9.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Text</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Text_c4f14f3a7.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_Text_c4f14f3a7.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 Text</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_currency_88bd4cc36.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_currency_88bd4cc36.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 currency</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_currency_94097b2d5.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_currency_94097b2d5.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 currency</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_text2_1611ab645.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_text2_1611ab645.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 text2</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_textarea_7b77be471.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_textarea_7b77be471.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 textarea</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_url_ddad63107.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO1_url_ddad63107.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO1 url</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO2_Currency2_e6bb2adc4.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO2_Currency2_e6bb2adc4.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO2 Currency2</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO2_Currency2_e6bb2adc4.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO2_Currency2_e6bb2adc4.md
@@ -16,7 +16,7 @@
     </values>
     <values>
         <field>Source_Field_API_Name__c</field>
-        <value xsi:type="xsd:string">CO2_Currency2__c</value>
+        <value xsi:type="xsd:string">CO1_Currency2__c</value>
     </values>
     <values>
         <field>Target_Field_API_Name__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO2_Currency2_efa17795f.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO2_Currency2_efa17795f.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO2 Currency2</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Date_29f945088.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Date_29f945088.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO3 Date</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Number_ffb4d33db.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Number_ffb4d33db.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO3 Number</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Phone_31e4c19e4.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Phone_31e4c19e4.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO3 Phone</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Phone_eacb81703.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Phone_eacb81703.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO3 Phone</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Picklist_445f63ff6.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Picklist_445f63ff6.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO3 Picklist</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Picklist_e38aa0476.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Picklist_e38aa0476.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO3 Picklist</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Text_3532e6023.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.CO3_Text_3532e6023.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CO3 Text</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_MaintenancePlan_0395868c1.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_MaintenancePlan_0395868c1.md
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WO MaintenancePlan</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">WO_MaintenancePlan__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">MaintenancePlan</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">WorkOrder_f516282fb</value>
+    </values>
+</CustomMetadata>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_MinimumCrewSize_5c6970260.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_MinimumCrewSize_5c6970260.md
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WO MinimumCrewSize</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">WO_MinimumCrewSize__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">MinimumCrewSize</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">WorkOrder_f516282fb</value>
+    </values>
+</CustomMetadata>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_RecommendedCrewSize_3cc44b330.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_RecommendedCrewSize_3cc44b330.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>WO RecommendedCrewSize</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_Subject_7d6b4fcfb.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_Subject_7d6b4fcfb.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>WO Subject</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_SuggestedMaintenanceDate_9ea67eb8e.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping.WO_SuggestedMaintenanceDate_9ea67eb8e.md
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>WO SuggestedMaintenanceDate</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Data_Import_Field_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Field_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping_Set.Migrated_Custom_Field_Mapping_Set.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Field_Mapping_Set.Migrated_Custom_Field_Mapping_Set.md
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Migrated_Custom_Field_Mapping_Set</label>
-    <protected>false</protected>
-    <values>
-        <field>Data_Import_Object_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Object_Mapping_Set</value>
-    </values>
-</CustomMetadata>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.AccountSoftCredits_ee5babc24.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.AccountSoftCredits_ee5babc24.md
@@ -12,7 +12,7 @@
     </values>
     <values>
         <field>Legacy_Data_Import_Object_Name__c</field>
-        <value xsi:type="xsd:boolean">AccountSoftCredits_ee5babc24</value>
+        <value xsi:type="xsd:string">AccountSoftCredits_ee5babc24</value>
     </values>
     <values>
         <field>Imported_Record_Field_Name__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.AccountSoftCredits_ee5babc24.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.AccountSoftCredits_ee5babc24.md
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>AccountSoftCredits</label>
+    <protected>true</protected>
+    <values>
+        <field>Custom_Mapping_Logic_Class__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Data_Import_Object_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Object_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Legacy_Data_Import_Object_Name__c</field>
+        <value xsi:type="xsd:boolean">AccountSoftCredits_ee5babc24</value>
+    </values>
+    <values>
+        <field>Imported_Record_Field_Name__c</field>
+        <value xsi:type="xsd:string">AccountSoftCreditsImported__c</value>
+    </values>
+    <values>
+        <field>Imported_Record_Status_Field_Name__c</field>
+        <value xsi:type="xsd:string">AccountSoftCreditsImportStatus__c</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Object_API_Name__c</field>
+        <value xsi:type="xsd:string">Account_Soft_Credit__c</value>
+    </values>
+    <values>
+        <field>Predecessor__c</field>
+        <value xsi:type="xsd:string">Account1</value>
+    </values>
+    <values>
+        <field>Relationship_Field__c</field>
+        <value xsi:type="xsd:string">Account__c</value>
+    </values>
+    <values>
+        <field>Relationship_To_Predecessor__c</field>
+        <value xsi:type="xsd:string">Child</value>
+    </values>
+</CustomMetadata>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject1_7b96c6e1b.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject1_7b96c6e1b.md
@@ -19,6 +19,10 @@
         <value xsi:type="xsd:string">CustomObject1ImportStatus__c</value>
     </values>
     <values>
+        <field>Legacy_Data_Import_Object_Name__c</field>
+        <value xsi:type="xsd:boolean">CustomObject1_7b96c6e1b</value>
+    </values>
+    <values>
         <field>Is_Deleted__c</field>
         <value xsi:type="xsd:boolean">false</value>
     </values>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject1_7b96c6e1b.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject1_7b96c6e1b.md
@@ -20,7 +20,7 @@
     </values>
     <values>
         <field>Legacy_Data_Import_Object_Name__c</field>
-        <value xsi:type="xsd:boolean">CustomObject1_7b96c6e1b</value>
+        <value xsi:type="xsd:string">CustomObject1_7b96c6e1b</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject1_7b96c6e1b.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject1_7b96c6e1b.md
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CustomObject1</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Custom_Mapping_Logic_Class__c</field>
         <value xsi:nil="true"/>
     </values>
     <values>
         <field>Data_Import_Object_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Object_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Object_Mapping_Set</value>
     </values>
     <values>
         <field>Imported_Record_Field_Name__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject3_f3f9b20ad.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject3_f3f9b20ad.md
@@ -24,7 +24,7 @@
     </values>
     <values>
         <field>Legacy_Data_Import_Object_Name__c</field>
-        <value xsi:type="xsd:boolean">CustomObject3_f3f9b20ad</value>
+        <value xsi:type="xsd:string">CustomObject3_f3f9b20ad</value>
     </values>
     <values>
         <field>Object_API_Name__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject3_f3f9b20ad.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject3_f3f9b20ad.md
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CustomObject3</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Custom_Mapping_Logic_Class__c</field>
         <value xsi:nil="true"/>
     </values>
     <values>
         <field>Data_Import_Object_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Object_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Object_Mapping_Set</value>
     </values>
     <values>
         <field>Imported_Record_Field_Name__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject3_f3f9b20ad.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.CustomObject3_f3f9b20ad.md
@@ -23,6 +23,10 @@
         <value xsi:type="xsd:boolean">false</value>
     </values>
     <values>
+        <field>Legacy_Data_Import_Object_Name__c</field>
+        <value xsi:type="xsd:boolean">CustomObject3_f3f9b20ad</value>
+    </values>
+    <values>
         <field>Object_API_Name__c</field>
         <value xsi:type="xsd:string">CustomObject3__c</value>
     </values>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.WorkOrder_f516282fb.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.WorkOrder_f516282fb.md
@@ -19,6 +19,10 @@
         <value xsi:type="xsd:string">WorkOrderImportStatus__c</value>
     </values>
     <values>
+        <field>Legacy_Data_Import_Object_Name__c</field>
+        <value xsi:type="xsd:boolean">WorkOrder_f516282fb</value>
+    </values>
+    <values>
         <field>Is_Deleted__c</field>
         <value xsi:type="xsd:boolean">false</value>
     </values>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.WorkOrder_f516282fb.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.WorkOrder_f516282fb.md
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>WorkOrder</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>Custom_Mapping_Logic_Class__c</field>
         <value xsi:nil="true"/>
     </values>
     <values>
         <field>Data_Import_Object_Mapping_Set__c</field>
-        <value xsi:type="xsd:string">Migrated_Custom_Object_Mapping_Set</value>
+        <value xsi:type="xsd:string">Default_Object_Mapping_Set</value>
     </values>
     <values>
         <field>Imported_Record_Field_Name__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.WorkOrder_f516282fb.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping.WorkOrder_f516282fb.md
@@ -20,7 +20,7 @@
     </values>
     <values>
         <field>Legacy_Data_Import_Object_Name__c</field>
-        <value xsi:type="xsd:boolean">WorkOrder_f516282fb</value>
+        <value xsi:type="xsd:string">WorkOrder_f516282fb</value>
     </values>
     <values>
         <field>Is_Deleted__c</field>

--- a/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping_Set.Migrated_Custom_Object_Mapping_Set.md
+++ b/unpackaged/config/qa/customMetadata/Data_Import_Object_Mapping_Set.Migrated_Custom_Object_Mapping_Set.md
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata">
-    <label>Migrated_Custom_Object_Mapping_Set</label>
-    <protected>false</protected>
-</CustomMetadata>

--- a/unpackaged/config/qa/objects/Account.object
+++ b/unpackaged/config/qa/objects/Account.object
@@ -16,7 +16,7 @@
         <fullName>custom_acc_text__c</fullName>
         <externalId>false</externalId>
         <label>custom_acc_text</label>
-        <length>10</length>
+        <length>255</length>
         <required>false</required>
         <trackFeedHistory>false</trackFeedHistory>
         <type>Text</type>

--- a/unpackaged/config/qa/objects/CustomObject1__c.object
+++ b/unpackaged/config/qa/objects/CustomObject1__c.object
@@ -137,7 +137,7 @@
         <fullName>C1_text2__c</fullName>
         <externalId>false</externalId>
         <label>C1_text2</label>
-        <length>10</length>
+        <length>255</length>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Text</type>
@@ -147,7 +147,7 @@
         <fullName>C1_text__c</fullName>
         <externalId>false</externalId>
         <label>C1_text</label>
-        <length>10</length>
+        <length>255</length>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Text</type>

--- a/unpackaged/config/qa/objects/CustomObject3__c.object
+++ b/unpackaged/config/qa/objects/CustomObject3__c.object
@@ -147,7 +147,7 @@
         <fullName>C3_text__c</fullName>
         <externalId>false</externalId>
         <label>C3_text</label>
-        <length>10</length>
+        <length>255</length>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Text</type>

--- a/unpackaged/config/qa/objects/Opportunity.object
+++ b/unpackaged/config/qa/objects/Opportunity.object
@@ -123,4 +123,14 @@
         <trackTrending>false</trackTrending>
         <type>TextArea</type>
     </fields>
+    <fields>
+        <fullName>npe01__Do_Not_Automatically_Create_Payment__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>If payments are active, and if this is checked, a new payment will not be automatically created for this Opportunity.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>If payments are active, and if checked, a new payment will not be automatically created for this Opportunity.</inlineHelpText>
+        <label>Do Not Automatically Create Payment</label>
+        <trackFeedHistory>false</trackFeedHistory>
+        <type>Checkbox</type>
+    </fields>
 </CustomObject>

--- a/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
+++ b/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
@@ -390,6 +390,17 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>WO_MinimumCrewSize__c</fullName>
+        <externalId>false</externalId>
+        <label>WO MinimumCrewSize</label>
+        <precision>18</precision>
+        <required>false</required>
+        <scale>0</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>WO_RecommendedCrewSize__c</fullName>
         <externalId>false</externalId>
         <label>WO RecommendedCrewSize</label>
@@ -399,6 +410,18 @@
         <trackTrending>false</trackTrending>
         <type>Number</type>
         <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>WO_MaintenancePlan__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <externalId>false</externalId>
+        <label>WO MaintenancePlan</label>
+        <referenceTo>WorkOrder</referenceTo>
+        <relationshipLabel>Maintenance Plans</relationshipLabel>
+        <relationshipName>MaintenancePlans</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
     </fields>
     <fields>
         <fullName>WO_Subject__c</fullName>

--- a/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
+++ b/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
@@ -506,5 +506,66 @@
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Lookup</type>
-    </fields>      
+    </fields>
+    <fields>
+        <fullName>ASC_Amount__c</fullName>
+        <externalId>false</externalId>
+        <label>ASC Amount</label>
+        <precision>18</precision>
+        <required>false</required>
+        <scale>0</scale>
+        <trackTrending>false</trackTrending>
+        <type>Currency</type>
+    </fields>
+    <fields>
+        <fullName>ASC_Role__c</fullName>
+        <externalId>false</externalId>
+        <label>ASC Role</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Picklist</type>
+        <valueSet>
+            <restricted>true</restricted>
+            <valueSetDefinition>
+                <sorted>false</sorted>
+                <value>
+                    <fullName>Option1</fullName>
+                    <default>false</default>
+                    <label>Option1</label>
+                </value>
+                <value>
+                    <fullName>Option2</fullName>
+                    <default>false</default>
+                    <label>Option2</label>
+                </value>
+                <value>
+                    <fullName>Option3</fullName>
+                    <default>false</default>
+                    <label>Option3</label>
+                </value>
+            </valueSetDefinition>
+        </valueSet>
+    </fields>
+    <fields>
+        <fullName>AccountSoftCreditsImportStatus__c</fullName>
+        <externalId>false</externalId>
+        <label>AccountSoftCreditsImportStatus</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>AccountSoftCreditsImported__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <externalId>false</externalId>
+        <label>AccountSoftCreditsImported</label>
+        <referenceTo>Account_Soft_Credit__c</referenceTo>
+        <relationshipLabel>Account Soft Credits</relationshipLabel>
+        <relationshipName>Account_Soft_Credits</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
 </CustomObject>

--- a/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
+++ b/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
@@ -14,7 +14,7 @@
         <externalId>false</externalId>
         <inlineHelpText>Account1.custom_acc_text__c</inlineHelpText>
         <label>custom_acc_text</label>
-        <length>10</length>
+        <length>255</length>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Text</type>
@@ -422,7 +422,7 @@
         <fullName>WorkOrderImportStatus__c</fullName>
         <externalId>false</externalId>
         <label>WorkOrderImportStatus</label>
-        <length>10</length>
+        <length>255</length>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Text</type>

--- a/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
+++ b/unpackaged/config/qa/objects/___NAMESPACE___DataImport__c.object
@@ -304,9 +304,9 @@
         <type>Url</type>
     </fields>
     <fields>
-        <fullName>CO2_Currency2__c</fullName>
+        <fullName>CO1_Currency2__c</fullName>
         <externalId>false</externalId>
-        <label>CO2 Currency2</label>
+        <label>CO1 Currency2</label>
         <precision>18</precision>
         <required>false</required>
         <scale>0</scale>

--- a/unpackaged/config/qa/package.xml
+++ b/unpackaged/config/qa/package.xml
@@ -35,7 +35,7 @@
         <members>%%%NAMESPACE%%%DataImport__c.CO1_text2__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.CO1_textarea__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.CO1_url__c</members>
-        <members>%%%NAMESPACE%%%DataImport__c.CO2_Currency2__c</members>
+        <members>%%%NAMESPACE%%%DataImport__c.CO1_Currency2__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.CO3_Currency__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.CO3_Date__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.CO3_Number__c</members>

--- a/unpackaged/config/qa/package.xml
+++ b/unpackaged/config/qa/package.xml
@@ -75,7 +75,6 @@
         <name>CustomObject</name>
     </types>
     <types>
-        <members>%%%NAMESPACE%%%Data_Import_Field_Mapping_Set.Migrated_Custom_Field_Mapping_Set</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO1_Date_2cb21281d</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO1_Date_37b322bd6</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO1_Number_21e98c57a</members>
@@ -103,7 +102,6 @@
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_RecommendedCrewSize_3cc44b330</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_Subject_7d6b4fcfb</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_SuggestedMaintenanceDate_9ea67eb8e</members>
-        <members>%%%NAMESPACE%%%Data_Import_Object_Mapping_Set.Migrated_Custom_Object_Mapping_Set</members>
         <members>%%%NAMESPACE%%%Data_Import_Object_Mapping.CustomObject1_7b96c6e1b</members>
         <members>%%%NAMESPACE%%%Data_Import_Object_Mapping.CustomObject3_f3f9b20ad</members>
         <members>%%%NAMESPACE%%%Data_Import_Object_Mapping.WorkOrder_f516282fb</members>

--- a/unpackaged/config/qa/package.xml
+++ b/unpackaged/config/qa/package.xml
@@ -42,6 +42,8 @@
         <members>%%%NAMESPACE%%%DataImport__c.CO3_Phone__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.CO3_Picklist__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.CO3_Text__c</members>
+        <members>%%%NAMESPACE%%%DataImport__c.WO_MaintenancePlan__c</members>
+        <members>%%%NAMESPACE%%%DataImport__c.WO_MinimumCrewSize__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.WO_RecommendedCrewSize__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.WO_Subject__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.WO_SuggestedMaintenanceDate__c</members>
@@ -75,6 +77,8 @@
         <name>CustomObject</name>
     </types>
     <types>
+        <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.ASC_Amount_cac3e1cd0</members>
+        <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.ASC_Role_f8860e39d</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO1_Date_2cb21281d</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO1_Date_37b322bd6</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO1_Number_21e98c57a</members>
@@ -104,6 +108,7 @@
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_RecommendedCrewSize_3cc44b330</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_Subject_7d6b4fcfb</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_SuggestedMaintenanceDate_9ea67eb8e</members>
+        <members>%%%NAMESPACE%%%Data_Import_Object_Mapping.AccountSoftCredits_ee5babc24</members>
         <members>%%%NAMESPACE%%%Data_Import_Object_Mapping.CustomObject1_7b96c6e1b</members>
         <members>%%%NAMESPACE%%%Data_Import_Object_Mapping.CustomObject3_f3f9b20ad</members>
         <members>%%%NAMESPACE%%%Data_Import_Object_Mapping.WorkOrder_f516282fb</members>

--- a/unpackaged/config/qa/package.xml
+++ b/unpackaged/config/qa/package.xml
@@ -99,6 +99,8 @@
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO3_Picklist_445f63ff6</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO3_Picklist_e38aa0476</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.CO3_Text_3532e6023</members>
+        <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_MaintenancePlan_0395868c1</members>
+        <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_MinimumCrewSize_5c6970260</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_RecommendedCrewSize_3cc44b330</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_Subject_7d6b4fcfb</members>
         <members>%%%NAMESPACE%%%Data_Import_Field_Mapping.WO_SuggestedMaintenanceDate_9ea67eb8e</members>

--- a/unpackaged/config/qa/package.xml
+++ b/unpackaged/config/qa/package.xml
@@ -13,6 +13,10 @@
         <members>Contact.Work_Order__c</members>
         <members>Opportunity.UniqueId__c</members>
         <members>Opportunity.A_User_Defined_Rollup_Field__c</members>
+        <members>%%%NAMESPACE%%%DataImport__c.AccountSoftCreditsImported__c</members>
+        <members>%%%NAMESPACE%%%DataImport__c.AccountSoftCreditsImportStatus__c</members>
+        <members>%%%NAMESPACE%%%DataImport__c.ASC_Amount__c</members>
+        <members>%%%NAMESPACE%%%DataImport__c.ASC_Role__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.Custom_add_date__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.custom_acc_text__c</members>
         <members>%%%NAMESPACE%%%DataImport__c.custom_cont_num__c</members>

--- a/unpackaged/config/qa/package.xml
+++ b/unpackaged/config/qa/package.xml
@@ -65,6 +65,7 @@
         <members>Opportunity.custom_picklist__c</members>
         <members>Opportunity.custom_text__c</members>
         <members>Opportunity.custom_textarea__c</members>
+        <members>Opportunity.npe01__Do_Not_Automatically_Create_Payment__c</members>
         <members>npe01__OppPayment__c.custom_email__c</members>
         <members>npe01__OppPayment__c.custom_multipick__c</members>
         <members>npe01__OppPayment__c.custom_phone__c</members>


### PR DESCRIPTION
mark prepackaged metadata records as protected, update lookups to default sets, update text field lengths to 255, and remove migrated object and field mapping sets

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
