### PR TITLE
Tweaks for trailhead installer

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -466,23 +466,26 @@ plans:
                     first:
                         name: NPSP Config for Salesforce Mobile App
     new_org:
-        slug: trial
-        title: Install NPSP Trial
-        # This will be tier: unlisted once that is an option.
+        slug: trailhead
+        title: Install NPSP for Trailhead Playgrounds
         tier: additional
         is_listed: False
         steps:
             1:
-                flow: dependencies
-                ui_options:
-                    deploy_pre:
-                        account_record_types:
-                            name: Account Record Types
-                        opportunity_record_types:
-                            name: Opportunity Record Types
+                task: update_dependencies
             2:
-                task: install_managed
+                task: deploy
+                options:
+                    path: unpackaged/pre/account_record_types
+                ui_options:
+                    name: Account Record Types
             3:
+                task: ensure_record_type
+                ui_options:
+                    name: Opportunity Record Types
+            4:
+                task: install_managed
+            5:
                 flow: config_managed
                 options:
                     deploy_reports:
@@ -497,6 +500,8 @@ plans:
                         is_required: False
                     deploy_trial_config:
                         name: NPSP Trial Experience
+                    test_data_relationships:
+                        name: Set Default Relationship Settings
                     deploy_reports:
                         name: NPSP Reports & Dashboards
                         is_required: False


### PR DESCRIPTION
* Update plan title and slug to match manual edits I made previously in the Django admin UI
* Only use the special task to deploy opportunity record types
* Add a label for the test_data_relationships step

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
