### PR TITLE
BDI: Feature/bdi co  filter field mappings for del obj mappings issue 3

### DIFF
--- a/src/classes/BDI_FieldMappingCustomMetadata.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata.cls
@@ -199,7 +199,8 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
                                                     Is_Deleted__c
                                         FROM Data_Import_Field_Mapping__mdt
                                         WHERE Target_Object_Mapping__r.Data_Import_Object_Mapping_Set__r.DeveloperName =: diFieldMappingSet.Data_Import_Object_Mapping_Set__r.DeveloperName
-                                            AND Is_Deleted__c = false]) {
+                                            AND Is_Deleted__c = false
+                                            AND Target_Object_Mapping__r.Is_Deleted__c = false]) {
 
                 // Removing the npsp namespace since the code is not currently packaged.
                 if (removeNPSPNamespace) {


### PR DESCRIPTION
Includes a filter on field mappings in the CMT field mapping class that will filter out field mappings connected to deleted object mappings

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
