### PR TITLE
Find Matching Gifts page: provide diagnostic message(s) when search for matching opp fails #1992

### DIFF
--- a/src/classes/MTCH_FindGifts_CTRL.cls
+++ b/src/classes/MTCH_FindGifts_CTRL.cls
@@ -356,6 +356,11 @@ public with sharing class MTCH_FindGifts_CTRL {
         // now rather than displaying in a seperate list, let's just add them to our first list!
         potentialGifts.addAll(potentialGifts2);
         
+        if (potentialGifts.size() == 0){
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, Label.mtchNotFindMoreGifts));
+   
+        }
+
         return null;
     }
 }

--- a/src/package.xml
+++ b/src/package.xml
@@ -1769,6 +1769,7 @@
         <members>mtchFindMatchedGiftsSectionHeader</members>
         <members>mtchFindMoreGifts</members>
         <members>mtchFindMoreGiftsInfo</members>
+        <members>mtchNotFindMoreGifts</members>
         <members>mtchItems</members>
         <members>mtchSearchCriteriaEmpty</members>
         <members>mtchSelectCbxTitle</members>


### PR DESCRIPTION
# Critical Changes
Nothing Special - Only Added a Warning Message
# Changes
Added Custom Label - mtchNotFindMoreGifts & Changes the Apex Class MTCH_FindGifts_CTRL
# Issues Closed
Issue #1992 
# New Metadata
Custom Label - mtchNotFindMoreGifts
# Deleted Metadata
