### PR TITLE
Adding filtering of the Link To Record picklist by object

### DIFF
--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -164,10 +164,28 @@ public class BDI_ManageAdvancedMappingCtrl {
     */
     @AuraEnabled
     public static FieldInfo[] getObjectFieldDescribes(String objectName) {
+        return getObjectFieldDescribes(objectName,false);
+    }
+
+    /*******************************************************************************************************
+    * @description Gets all the field describes from a given object, and retrieves the reference object information.
+    *
+    * @param objectName: Object name
+    * @param includeReferenceToObjectList: Boolean indicating whether the reference to objects should be returned 
+    * as part of field info.
+    *
+    * @return List: List of BDI_ManageAdvancedMappingCtrl.FieldInfo
+    */
+    @AuraEnabled
+    public static FieldInfo[] getObjectFieldDescribes(String objectName, Boolean includeReferenceToObjectList) {
         FieldInfo[] fieldInfos = new List<FieldInfo>();
 
-        objectName = UTIL_Namespace.StrAllNSPrefix(objectName);
+        if (includeReferenceToObjectList == null) {
+            includeReferenceToObjectList = false;
+        }
 
+        objectName = UTIL_Namespace.StrAllNSPrefix(objectName);
+    
         Map<String, Schema.DescribeFieldResult> fieldDescribes =
             UTIL_Describe.getAllFieldsDescribe(objectName);
 
@@ -176,7 +194,7 @@ public class BDI_ManageAdvancedMappingCtrl {
             //Only include fields that are createable by the current user
             //This will filter out System / formula fields
             if (fieldDescribes.get(key).isCreateable()) {
-                fieldInfos.add(new FieldInfo(fieldDescribes.get(key)));
+                fieldInfos.add(new FieldInfo(fieldDescribes.get(key),includeReferenceToObjectList));
             }
         }
 
@@ -522,11 +540,32 @@ public class BDI_ManageAdvancedMappingCtrl {
         @AuraEnabled public String label;
         @AuraEnabled public String value;
         @AuraEnabled public String displayType;
+        @AuraEnabled public String[] referenceToObjectList;
 
         public FieldInfo(DescribeFieldResult dfr) {
             this.value = dfr.getName();
             this.label = dfr.getLabel();
             this.displayType = dfr.getType().name();
+        }
+
+        public FieldInfo(DescribeFieldResult dfr, Boolean includeReferenceToObjectList) {
+            this.value = dfr.getName();
+            this.label = dfr.getLabel();
+            this.displayType = dfr.getType().name();
+
+            if (includeReferenceToObjectList) {
+                this.referenceToObjectList = new String[]{};
+                if (dfr.getType().name() == 'REFERENCE') {
+
+                    List<Schema.sObjectType> objTypes = dfr.getReferenceTo();
+                    
+                    if (objTypes != null) {
+                        for (Schema.sObjectType objType : objTypes) {
+                            this.referenceToObjectList.add(objType.getDescribe().getName().toLowerCase());
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -669,7 +708,7 @@ public class BDI_ManageAdvancedMappingCtrl {
         for (String key : fieldDescribes.keySet()) {
             Schema.DescribeFieldResult dfr = fieldDescribes.get(key);
 
-            if (dfr.getType().name() == 'REFERENCE' && fieldDescribes.get(key).isCreateable() ) {
+            if (dfr.getType().name() == 'REFERENCE' && dfr.isCreateable()) {
 
                 List<Schema.sObjectType> objTypes = dfr.getReferenceTo();
 

--- a/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
+++ b/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
@@ -481,7 +481,8 @@ export default class bdiObjectMappingModal extends LightningElement {
     * for the ImportedRecordFieldName and ImportedRecordStatusField Name picklists.
     */    
     getDataImportFieldDescribes() {
-        getObjectFieldDescribes({objectName: 'DataImport__c'})
+        getObjectFieldDescribes({objectName: 'DataImport__c',
+                                includeReferenceToObjectList: true })
             .then((data) => {
                 this.dataImportFieldData = data;
                 this.refreshImportRecordFieldOptions();
@@ -513,9 +514,19 @@ export default class bdiObjectMappingModal extends LightningElement {
                         value: fieldData.value
                     }
         
-                    if (fieldData.value !== this.row.Imported_Record_Status_Field_Name &&
-                        (fieldData.displayType === 'REFERENCE' || fieldData.displayType === 'STRING')) {
-                        this.diImportRecordFieldOptions.push(labelOption);
+                    if (fieldData.value !== this.row.Imported_Record_Status_Field_Name) {
+
+                        if (fieldData.displayType === 'REFERENCE' 
+                            && fieldData.referenceToObjectList
+                            && (this.row.Object_API_Name 
+                                && fieldData.referenceToObjectList.includes(this.row.Object_API_Name.toLowerCase())
+                                || !this.row.Object_API_Name)){
+
+                            this.diImportRecordFieldOptions.push(labelOption);
+                            
+                        } else if (fieldData.displayType === 'STRING') {
+                            this.diImportRecordFieldOptions.push(labelOption);
+                        }
                     }
         
                     if (fieldData.value !== this.row.Imported_Record_Field_Name &&
@@ -605,6 +616,7 @@ export default class bdiObjectMappingModal extends LightningElement {
     handleObjectAPINameChange(event){
         this.row.Object_API_Name = event.detail.value;
         this.getRelationshipFieldOptions();
+        this.refreshImportRecordFieldOptions();
     }
 
     /*******************************************************************************


### PR DESCRIPTION

# Critical Changes

# Changes
Adding filtering to the picklist that is used for the "Link to Record" field on the Mapping Group modal. It will now only allow "Reference" fields that actually look up to the object defined in the Object Name field.  It will still allow Text fields for selection to support those standard objects that cannot be looked up to.

# Issues Closed

# New Metadata

# Deleted Metadata
