### PR TITLE
Add config_platformencryption flow

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -145,6 +145,39 @@ tasks:
             options:
                 outputdir: robot/Cumulus/results
 
+    platformencryption_deploy_permset:
+        class_path: cumulusci.tasks.salesforce.Deploy
+        options:
+            path: unpackaged/config/platformencryption_permset
+            namespace_inject: $project_config.project__package__namespace
+
+    platformencryption_assign_permset:
+        class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
+        options:
+            apex: >
+                PermissionSet p = [
+                    SELECT Id, Name
+                    FROM PermissionSet
+                    WHERE Name = 'Encryption'
+                ];
+
+                insert new PermissionSetAssignment(
+                    PermissionSetId = p.Id,
+                    AssigneeId = UserInfo.getUserId()
+                );
+
+    platformencryption_create_tenant_secret:
+        description: 'Create a placeholder Tenant Secret to use Platform Encryption'
+        class_path: cumulusci.tasks.sfdx.SFDXOrgTask
+        options:
+            command: 'force:data:record:create -s TenantSecret -v "Description=test"'
+
+    platformencryption_deploy_field_configuration:
+        class_path: cumulusci.tasks.salesforce.Deploy
+        options:
+            path: unpackaged/config/platformencryption_fields
+            namespace_inject: $project_config.project__package__namespace
+
     pmd:
         description: Run Apex code analysis with PMD. This task assumes that PMD is available in PATH. On MacOS PMD is available to install in brew.
         class_path: tasks.pmd.PMDTask
@@ -405,6 +438,18 @@ flows:
             1:
                 task: add_second_currency
 
+    config_platformencryption:
+        description: 'Configure Platform Encryption org to encrypt standard fields'
+        steps:
+            1:
+                task: platformencryption_deploy_permset
+            2:
+                task: platformencryption_assign_permset
+            3:
+                task: platformencryption_create_tenant_secret
+            4:
+                task: platformencryption_deploy_field_configuration
+
     test_data_dev_org:
         description: 'WARNING: This flow deletes all data first, then loads the complete test data set based on 100 Contacts into the target org.'
         steps:
@@ -484,6 +529,8 @@ orgs:
             config_file: orgs/beta_multicurrency.json
         beta_personaccounts:
             config_file: orgs/beta_personaccounts.json
+        beta_platformencryption:
+            config_file: orgs/beta_platformencryption.json
         beta_statecountry:
             config_file: orgs/beta_statecountry.json
         prerelease:

--- a/orgs/beta_platformencryption.json
+++ b/orgs/beta_platformencryption.json
@@ -1,7 +1,6 @@
 {
   "orgName": "NPSP - Beta Org - Platform Encryption",
   "edition": "Developer",
-  "instance": "cs46",
   "features": [
     "PlatformEncryption"
   ],

--- a/orgs/beta_platformencryption.json
+++ b/orgs/beta_platformencryption.json
@@ -1,0 +1,17 @@
+{
+  "orgName": "NPSP - Beta Org - Platform Encryption",
+  "edition": "Developer",
+  "instance": "cs46",
+  "features": [
+    "PlatformEncryption"
+  ],
+  "hasSampleData": "true",
+  "settings": {
+    "orgPreferenceSettings": {
+      "chatterEnabled": true,
+      "disableParallelApexTesting": true,
+      "notesReservedPref01": true,
+      "s1DesktopEnabled": true
+    }
+  }
+}

--- a/unpackaged/config/platformencryption_fields/objects/Account.object
+++ b/unpackaged/config/platformencryption_fields/objects/Account.object
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>BillingAddress</fullName>
+        <encryptionScheme>ProbabilisticEncryption</encryptionScheme>
+        <trackFeedHistory>false</trackFeedHistory>
+    </fields>
+    <fields>
+        <fullName>Name</fullName>
+        <encryptionScheme>ProbabilisticEncryption</encryptionScheme>
+        <trackFeedHistory>true</trackFeedHistory>
+    </fields>
+    <fields>
+        <fullName>Website</fullName>
+        <encryptionScheme>ProbabilisticEncryption</encryptionScheme>
+        <trackFeedHistory>false</trackFeedHistory>
+    </fields>
+</CustomObject>

--- a/unpackaged/config/platformencryption_fields/objects/Contact.object
+++ b/unpackaged/config/platformencryption_fields/objects/Contact.object
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>MailingAddress</fullName>
+        <encryptionScheme>ProbabilisticEncryption</encryptionScheme>
+        <trackFeedHistory>false</trackFeedHistory>
+    </fields>
+    <fields>
+        <fullName>Name</fullName>
+        <encryptionScheme>ProbabilisticEncryption</encryptionScheme>
+        <trackFeedHistory>true</trackFeedHistory>
+    </fields>
+    <fields>
+        <fullName>OtherAddress</fullName>
+        <encryptionScheme>ProbabilisticEncryption</encryptionScheme>
+        <trackFeedHistory>false</trackFeedHistory>
+    </fields>
+    <fields>
+        <fullName>Title</fullName>
+        <encryptionScheme>ProbabilisticEncryption</encryptionScheme>
+        <trackFeedHistory>false</trackFeedHistory>
+    </fields>
+</CustomObject>

--- a/unpackaged/config/platformencryption_fields/package.xml
+++ b/unpackaged/config/platformencryption_fields/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Account.BillingAddress</members>
+        <members>Account.Name</members>
+        <members>Account.Website</members>
+        <members>Contact.MailingAddress</members>
+        <members>Contact.Name</members>
+        <members>Contact.OtherAddress</members>
+        <members>Contact.Title</members>
+        <name>CustomField</name>
+    </types>
+    <version>46.0</version>
+</Package>

--- a/unpackaged/config/platformencryption_permset/package.xml
+++ b/unpackaged/config/platformencryption_permset/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Encryption</members>
+        <name>PermissionSet</name>
+    </types>
+    <version>46.0</version>
+</Package>

--- a/unpackaged/config/platformencryption_permset/permissionsets/Encryption.permissionset
+++ b/unpackaged/config/platformencryption_permset/permissionsets/Encryption.permissionset
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+	<hasActivationRequired>false</hasActivationRequired>
+	<label>Encryption</label>
+	<userPermissions>
+		<enabled>true</enabled>
+		<name>ManageEncryptionKeys</name>
+	</userPermissions>
+</PermissionSet>


### PR DESCRIPTION
This PR introduces a flow, `config_platformencryption`, and a new org type, `beta_platformencryption`, that can be used with `ci_beta` to configure a Beta - Platform Encryption org type.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
