### PR TITLE
Updated BDI code to be able to handle working in a non-npsp namespace

### DIFF
--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -323,7 +323,7 @@ public with sharing class BDI_AdditionalObjectService {
 
         if (objMapping.Custom_Mapping_Logic_Class__c != null) {
             Type custLogicClassType = Type.forName(
-                UTIL_Namespace.adjustNPSPNamespace(objMapping.Custom_Mapping_Logic_Class__c));
+                UTIL_Namespace.alignClassNSWithEnvironment(objMapping.Custom_Mapping_Logic_Class__c));
             objMappingLogicClass = (BDI_ObjectMappingLogic)custLogicClassType.newInstance();
         } else {
             objMappingLogicClass = new BDI_ObjectMappingLogic();

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -44,8 +44,8 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
 
         Map<String, Schema.DescribeFieldResult> sourceFieldDescByFieldName = UTIL_Describe.getAllFieldsDescribe(SObjectType.DataImport__c.getName());
 
-        String PAYMENT_FIELDNAME = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__Payment__c');
-        String OPPORTUNITY_FIELDNAME = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__Opportunity__c');
+        String PAYMENT_FIELDNAME = SObjectType.Allocation__c.fields.Payment__c.Name;
+        String OPPORTUNITY_FIELDNAME = SObjectType.Allocation__c.fields.Opportunity__c.Name;
 
         for (BDI_ObjectWrapper objWrap : objWraps) {
             Map<String, Schema.DescribeFieldResult> targetFieldDescByFieldName = UTIL_Describe.getAllFieldsDescribe(objWrap.objMapping.Object_API_Name__c);

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -44,8 +44,8 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
 
         Map<String, Schema.DescribeFieldResult> sourceFieldDescByFieldName = UTIL_Describe.getAllFieldsDescribe(SObjectType.DataImport__c.getName());
 
-        String PAYMENT_FIELDNAME = UTIL_Namespace.adjustNPSPNamespace('npsp__Payment__c');
-        String OPPORTUNITY_FIELDNAME = UTIL_Namespace.adjustNPSPNamespace('npsp__Opportunity__c');
+        String PAYMENT_FIELDNAME = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__Payment__c');
+        String OPPORTUNITY_FIELDNAME = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__Opportunity__c');
 
         for (BDI_ObjectWrapper objWrap : objWraps) {
             Map<String, Schema.DescribeFieldResult> targetFieldDescByFieldName = UTIL_Describe.getAllFieldsDescribe(objWrap.objMapping.Object_API_Name__c);

--- a/src/classes/BDI_DataImportService_TEST.cls
+++ b/src/classes/BDI_DataImportService_TEST.cls
@@ -51,7 +51,7 @@ private with sharing class BDI_DataImportService_TEST {
 
         System.assertEquals('Contact1_Foo__c', BDI_DataImportService.strDICustomIDField('Contact1', 'Foo__c'));
 
-        String expectedCustomIdField = UTIL_Namespace.getNamespace().equalsIgnoreCase('npsp')
+        String expectedCustomIdField = UTIL_Namespace.getNamespace().equalsIgnoreCase(UTIL_Namespace.NPSP_NS)
             ? 'npsp__Contact1_Bar__c'
             : 'Contact1_Bar__c';
         System.assertEquals(expectedCustomIdField, BDI_DataImportService.strDICustomIDField('Contact1', 'npsp__Bar__c'));

--- a/src/classes/BDI_DataImportService_TEST.cls
+++ b/src/classes/BDI_DataImportService_TEST.cls
@@ -51,7 +51,7 @@ private with sharing class BDI_DataImportService_TEST {
 
         System.assertEquals('Contact1_Foo__c', BDI_DataImportService.strDICustomIDField('Contact1', 'Foo__c'));
 
-        String expectedCustomIdField = UTIL_Namespace.getNamespace().equalsIgnoreCase(UTIL_Namespace.NPSP_NS)
+        String expectedCustomIdField = UTIL_Namespace.getNamespace().equalsIgnoreCase(UTIL_Namespace.HARDCODED_NPSP_NAMESPACE)
             ? 'npsp__Contact1_Bar__c'
             : 'Contact1_Bar__c';
         System.assertEquals(expectedCustomIdField, BDI_DataImportService.strDICustomIDField('Contact1', 'npsp__Bar__c'));

--- a/src/classes/BDI_FieldMappingCustomMetadata.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata.cls
@@ -142,7 +142,7 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
 
     private void retrieveCustMetadata(){
         //If the code is not in the npsp namespace, then the npsp field prefixes will need to be systematically removed.
-        Boolean removeNPSPNamespace = (UTIL_Namespace.getNamespace() != UTIL_Namespace.NPSP_NS);
+        Boolean removeNPSPNamespace = (UTIL_Namespace.shouldAlignNamespace);
 
         diFieldMappingSet = [SELECT id, DeveloperName, 
                         Data_Import_Object_Mapping_Set__c,

--- a/src/classes/BDI_FieldMappingCustomMetadata.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata.cls
@@ -134,7 +134,7 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
             //Retreive the Data Import Settings to determine the default field mapping set.
             Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
 
-            fieldMappingSetName = UTIL_Namespace.adjustNPSPNamespace(dis.Default_Data_Import_Field_Mapping_Set__c);
+            fieldMappingSetName = UTIL_Namespace.alignSchemaNSWithEnvironment(dis.Default_Data_Import_Field_Mapping_Set__c);
         }
 
         return fieldMappingSetName;
@@ -142,7 +142,7 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
 
     private void retrieveCustMetadata(){
         //If the code is not in the npsp namespace, then the npsp field prefixes will need to be systematically removed.
-        Boolean removeNPSPNamespace = (UTIL_Namespace.getNamespace() != 'npsp');
+        Boolean removeNPSPNamespace = (UTIL_Namespace.getNamespace() != UTIL_Namespace.NPSP_NS);
 
         diFieldMappingSet = [SELECT id, DeveloperName, 
                         Data_Import_Object_Mapping_Set__c,
@@ -184,12 +184,12 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
                                         AND Is_Deleted__c = false
                                     ORDER BY MasterLabel ASC]) {
 
-            // Removing the npsp namespace since the code is not currently packaged.
+            // Removing the npsp namespace and potentially adding a new namespace if UTIL_Namespace is under a different namespace
             if (removeNPSPNamespace) {
-               diom.Imported_Record_Field_Name__c = UTIL_Namespace.adjustNPSPNamespace(diom.Imported_Record_Field_Name__c);
-               diom.Imported_Record_Status_Field_Name__c = UTIL_Namespace.adjustNPSPNamespace(diom.Imported_Record_Status_Field_Name__c);
-               diom.Object_API_Name__c = UTIL_Namespace.adjustNPSPNamespace(diom.Object_API_Name__c);
-               diom.Relationship_Field__c = UTIL_Namespace.adjustNPSPNamespace(diom.Relationship_Field__c);
+               diom.Imported_Record_Field_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Imported_Record_Field_Name__c);
+               diom.Imported_Record_Status_Field_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Imported_Record_Status_Field_Name__c);
+               diom.Object_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Object_API_Name__c);
+               diom.Relationship_Field__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Relationship_Field__c);
             }
 
             objMappingsByDevName.put(diom.DeveloperName, diom);
@@ -212,8 +212,8 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
 
                 // Removing the npsp namespace since the code is not currently packaged.
                 if (removeNPSPNamespace) {
-                   difm.Source_Field_API_Name__c = UTIL_Namespace.adjustNPSPNamespace(difm.Source_Field_API_Name__c);
-                   difm.Target_Field_API_Name__c = UTIL_Namespace.adjustNPSPNamespace(difm.Target_Field_API_Name__c);
+                   difm.Source_Field_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Source_Field_API_Name__c);
+                   difm.Target_Field_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Target_Field_API_Name__c);
                 }
 
                 Data_Import_Field_Mapping__mdt[] tempDifms = new Data_Import_Field_Mapping__mdt[]{};

--- a/src/classes/BDI_FieldMappingCustomMetadata_TEST.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata_TEST.cls
@@ -63,8 +63,8 @@ private class BDI_FieldMappingCustomMetadata_TEST {
         String namespace = UTIL_Namespace.getNamespace();
         String sampleField = 'npsp__Account1_City__c';
         
-        if (namespace != 'npsp') {
-            sampleField = UTIL_Namespace.removeNSPrefixNpspOnly(sampleField);
+        if (namespace != UTIL_Namespace.NPSP_NS) {
+            sampleField = UTIL_Namespace.alignSchemaNSWithEnvironment(sampleField);
         }
         //Sample one of the fields to convfirm it is mapped correctly.
         System.assertEquals('BillingCity',accountFieldMapping.get(sampleField));

--- a/src/classes/BDI_FieldMappingCustomMetadata_TEST.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata_TEST.cls
@@ -63,7 +63,7 @@ private class BDI_FieldMappingCustomMetadata_TEST {
         String namespace = UTIL_Namespace.getNamespace();
         String sampleField = 'npsp__Account1_City__c';
         
-        if (namespace != UTIL_Namespace.NPSP_NS) {
+        if (UTIL_Namespace.shouldAlignNamespace) {
             sampleField = UTIL_Namespace.alignSchemaNSWithEnvironment(sampleField);
         }
         //Sample one of the fields to convfirm it is mapped correctly.

--- a/src/classes/BDI_FieldMappingHelpText.cls
+++ b/src/classes/BDI_FieldMappingHelpText.cls
@@ -132,7 +132,7 @@ public with sharing class BDI_FieldMappingHelpText implements BDI_FieldMapping {
                     //if we aren't in the npsp namespace, remove those tokens from help text
                     //also removes tokens from actual detected namespace, if we happen to be
                     //in a non-npsp namespace
-                    if (UTIL_Namespace.getNamespace() != 'npsp') {
+                    if (UTIL_Namespace.getNamespace() != UTIL_Namespace.NPSP_NS) {
                         String fieldNameOld = fieldName;
                         fieldName = UTIL_Namespace.StrTokenRemoveNSPrefix(fieldName);
 

--- a/src/classes/BDI_FieldMappingHelpText.cls
+++ b/src/classes/BDI_FieldMappingHelpText.cls
@@ -132,7 +132,7 @@ public with sharing class BDI_FieldMappingHelpText implements BDI_FieldMapping {
                     //if we aren't in the npsp namespace, remove those tokens from help text
                     //also removes tokens from actual detected namespace, if we happen to be
                     //in a non-npsp namespace
-                    if (UTIL_Namespace.getNamespace() != UTIL_Namespace.NPSP_NS) {
+                    if (UTIL_Namespace.shouldAlignNamespace) {
                         String fieldNameOld = fieldName;
                         fieldName = UTIL_Namespace.StrTokenRemoveNSPrefix(fieldName);
 

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -36,10 +36,13 @@
 */
 public class BDI_ManageAdvancedMappingCtrl {
     
-    /** @description what is the namespace (an empty string if unmanaged, or 'npsp' if managed) */
+    /*******************************************************************************************************
+    * @description Returns a wrapper class containing the current namespace and the npsp namespace defined 
+    * in UTIL_Namespace class.
+    */
     @AuraEnabled(cacheable=true)
-    public static string getNamespacePrefix() {
-        return UTIL_Namespace.getNamespace();
+    public static NamespaceWrapper getNamespaceWrapper() {
+        return new NamespaceWrapper();
     }
 
     /*******************************************************************************************************
@@ -232,9 +235,9 @@ public class BDI_ManageAdvancedMappingCtrl {
 
             String diFieldMappingSetFieldName = 'npsp__Data_Import_Field_Mapping_Set__c';
             String targetObjectMappingFieldName = 'npsp__Target_Object_Mapping__c';
-            if (NAMESPACE != 'npsp') {
-                diFieldMappingSetFieldName = diFieldMappingSetFieldName.replaceFirst('npsp__', '');
-                targetObjectMappingFieldName = targetObjectMappingFieldName.replaceFirst('npsp__', '');
+            if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
+                diFieldMappingSetFieldName = UTIL_Namespace.alignSchemaNSWithEnvironment(diFieldMappingSetFieldName);
+                targetObjectMappingFieldName = UTIL_Namespace.alignSchemaNSWithEnvironment(targetObjectMappingFieldName);
             }
 
             //This is a workaround to get the developer name of the Data Import Object Mapping Set into the field since
@@ -283,8 +286,8 @@ public class BDI_ManageAdvancedMappingCtrl {
                 (DataImportObjectMappingWrapper)JSON.deserialize(objectMappingString, DataImportObjectMappingWrapper.class);
 
             String diObjMappingSetFieldName = 'npsp__Data_Import_Object_Mapping_Set__c';
-            if (NAMESPACE != 'npsp') {
-                diObjMappingSetFieldName = diObjMappingSetFieldName.replaceFirst('npsp__','');
+            if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
+                diObjMappingSetFieldName = UTIL_Namespace.alignSchemaNSWithEnvironment(diObjMappingSetFieldName);
             }
 
             //This is a workaround to get the developer name of the Data Import Object Mapping Set into the field since 
@@ -474,15 +477,15 @@ public class BDI_ManageAdvancedMappingCtrl {
             String sourceFieldAPIName = fieldMapping.Source_Field_API_Name__c;
             String targetFieldAPIName = fieldMapping.Target_Field_API_Name__c;
 
-            if (NAMESPACE != 'npsp') {
+            if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
                 dataImport = 'DataImport__c';
                 objectAPIName =
-                    UTIL_Namespace.removeNSPrefixNpspOnly(
+                    UTIL_Namespace.alignSchemaNSWithEnvironment(
                         fieldMapping.Target_Object_Mapping__r.Object_API_Name__c);
                 sourceFieldAPIName =
-                    UTIL_Namespace.removeNSPrefixNpspOnly(fieldMapping.Source_Field_API_Name__c);
+                    UTIL_Namespace.alignSchemaNSWithEnvironment(fieldMapping.Source_Field_API_Name__c);
                 targetFieldAPIName =
-                    UTIL_Namespace.removeNSPrefixNpspOnly(fieldMapping.Target_Field_API_Name__c);
+                    UTIL_Namespace.alignSchemaNSWithEnvironment(fieldMapping.Target_Field_API_Name__c);
             }
 
             Schema.DescribeFieldResult sourceFieldDescribe = UTIL_Describe.getFieldDescribe(
@@ -715,5 +718,22 @@ public class BDI_ManageAdvancedMappingCtrl {
         }
         List<String> mappedFieldNamesList = new List<String>(mappedFieldNamesSet);
         return mappedFieldNamesList;
+    }
+
+    /*******************************************************************************************************
+    * @description Simple class to contain both the current namespace, and the npsp namespace variable for
+    * use in constructing/modifying urls and schema names in lightning web components. Wrapped in a class
+    * to reduce calls.
+    */
+    public class NamespaceWrapper {
+        @AuraEnabled
+        public String currentNamespace {get;set;}
+        @AuraEnabled
+        public String npspNamespace {get;set;}  
+
+        public NamespaceWrapper(){
+            this.currentNamespace = UTIL_Namespace.getNamespace();
+            this.npspNamespace = UTIL_Namespace.NPSP_NS;
+        }
     }
 }// BDI_ManageAdvancedMappingCtrl

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -496,7 +496,7 @@ public class BDI_ManageAdvancedMappingCtrl {
             String sourceFieldAPIName = fieldMapping.Source_Field_API_Name__c;
             String targetFieldAPIName = fieldMapping.Target_Field_API_Name__c;
 
-            if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
+            if (UTIL_Namespace.shouldAlignNamespace) {
                 objectAPIName =
                     UTIL_Namespace.alignSchemaNSWithEnvironment(
                         fieldMapping.Target_Object_Mapping__r.Object_API_Name__c);
@@ -772,7 +772,7 @@ public class BDI_ManageAdvancedMappingCtrl {
 
         public NamespaceWrapper(){
             this.currentNamespace = UTIL_Namespace.getNamespace();
-            this.npspNamespace = UTIL_Namespace.NPSP_NS;
+            this.npspNamespace = UTIL_Namespace.HARDCODED_NPSP_NAMESPACE;
         }
     }
 }// BDI_ManageAdvancedMappingCtrl

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -45,6 +45,11 @@ public class BDI_ManageAdvancedMappingCtrl {
         return new NamespaceWrapper();
     }
 
+    @AuraEnabled(cacheable=true)
+    public static NamespaceWrapper getNamespacePrefix() {
+        return UTIL_Namespace.getNamespace();
+    }
+
     /*******************************************************************************************************
     * @description Instance of BDI_FieldMappingCustomMetadata
     */

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -46,7 +46,7 @@ public class BDI_ManageAdvancedMappingCtrl {
     }
 
     @AuraEnabled(cacheable=true)
-    public static NamespaceWrapper getNamespacePrefix() {
+    public static String getNamespacePrefix() {
         return UTIL_Namespace.getNamespace();
     }
 

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -259,12 +259,8 @@ public class BDI_ManageAdvancedMappingCtrl {
             DataImportFieldMappingWrapper fieldMappingWrapper =
                 (DataImportFieldMappingWrapper)JSON.deserialize(fieldMappingString, DataImportFieldMappingWrapper.class);
 
-            String diFieldMappingSetFieldName = 'npsp__Data_Import_Field_Mapping_Set__c';
-            String targetObjectMappingFieldName = 'npsp__Target_Object_Mapping__c';
-            if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
-                diFieldMappingSetFieldName = UTIL_Namespace.alignSchemaNSWithEnvironment(diFieldMappingSetFieldName);
-                targetObjectMappingFieldName = UTIL_Namespace.alignSchemaNSWithEnvironment(targetObjectMappingFieldName);
-            }
+            String diFieldMappingSetFieldName = SObjectType.Data_Import_Field_Mapping__mdt.fields.Data_Import_Field_Mapping_Set__c.Name;
+            String targetObjectMappingFieldName = SObjectType.Data_Import_Field_Mapping__mdt.fields.Target_Object_Mapping__c.Name;
 
             //This is a workaround to get the developer name of the Data Import Object Mapping Set into the field since
             //that is what is required for the custom metadata creation.  This can't be done with the normal constructor
@@ -311,10 +307,7 @@ public class BDI_ManageAdvancedMappingCtrl {
             DataImportObjectMappingWrapper objMappingWrapper = 
                 (DataImportObjectMappingWrapper)JSON.deserialize(objectMappingString, DataImportObjectMappingWrapper.class);
 
-            String diObjMappingSetFieldName = 'npsp__Data_Import_Object_Mapping_Set__c';
-            if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
-                diObjMappingSetFieldName = UTIL_Namespace.alignSchemaNSWithEnvironment(diObjMappingSetFieldName);
-            }
+            String diObjMappingSetFieldName = SObjectType.Data_Import_Object_Mapping__mdt.fields.Data_Import_Object_Mapping_Set__c.Name;
 
             //This is a workaround to get the developer name of the Data Import Object Mapping Set into the field since 
             //that is what is required for the custom metadata creation.  This can't be done with the normal constructor
@@ -498,13 +491,12 @@ public class BDI_ManageAdvancedMappingCtrl {
         @AuraEnabled public String Target_Field_Display_Type_Label;
 
         public DataImportFieldMappingWrapper(Data_Import_Field_Mapping__mdt fieldMapping) {
-            String dataImport = 'npsp__DataImport__c';
+            String dataImport = SobjectType.DataImport__c.Name;
             String objectAPIName = fieldMapping.Target_Object_Mapping__r.Object_API_Name__c;
             String sourceFieldAPIName = fieldMapping.Source_Field_API_Name__c;
             String targetFieldAPIName = fieldMapping.Target_Field_API_Name__c;
 
             if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
-                dataImport = 'DataImport__c';
                 objectAPIName =
                     UTIL_Namespace.alignSchemaNSWithEnvironment(
                         fieldMapping.Target_Object_Mapping__r.Object_API_Name__c);

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -45,11 +45,6 @@ public class BDI_ManageAdvancedMappingCtrl {
         return new NamespaceWrapper();
     }
 
-    @AuraEnabled(cacheable=true)
-    public static String getNamespacePrefix() {
-        return UTIL_Namespace.getNamespace();
-    }
-
     /*******************************************************************************************************
     * @description Instance of BDI_FieldMappingCustomMetadata
     */

--- a/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
@@ -113,7 +113,7 @@ private class BDI_ManageAdvancedMappingCtrl_TEST {
         namespace = namespace == '' ? null : namespace;
 
         System.assertEquals(actualNamespace, namespace);
-        System.assertEquals(UTIL_Namespace.NPSP_NS, nsWrapper.npspNamespace);
+        System.assertEquals(UTIL_Namespace.HARDCODED_NPSP_NAMESPACE, nsWrapper.npspNamespace);
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
@@ -97,19 +97,23 @@ private class BDI_ManageAdvancedMappingCtrl_TEST {
         '"Relationship_To_Predecessor":null}';
 
     /*******************************************************************************************************
-    * @description Test that we get the current namespace
+    * @description Test that we get the current namespace and npsp namespace
     */
     @isTest
-    static void shouldReturnCurrentPackageNamespace() {
+    static void shouldReturnNamespaceWrapper() {
         ApexClass controllerClass = [SELECT NamespacePrefix
             FROM ApexClass
             WHERE Name = :'BDI_ManageAdvancedMappingCtrl'];
+
         String actualNamespace = controllerClass.NamespacePrefix;
 
-        String namespace = BDI_ManageAdvancedMappingCtrl.getNamespacePrefix();
+        BDI_ManageAdvancedMappingCtrl.NamespaceWrapper nsWrapper = BDI_ManageAdvancedMappingCtrl.getNamespaceWrapper();
+
+        String namespace = nsWrapper.currentNamespace;
         namespace = namespace == '' ? null : namespace;
 
         System.assertEquals(actualNamespace, namespace);
+        System.assertEquals(UTIL_Namespace.NPSP_NS, nsWrapper.npspNamespace);
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_MigrationMappingHelper.cls
+++ b/src/classes/BDI_MigrationMappingHelper.cls
@@ -175,11 +175,11 @@ public class BDI_MigrationMappingHelper {
         String namespace = UTIL_Namespace.getNamespace();
 
         for (Data_Import_Field_Mapping__mdt fieldMapping : existingFieldMappings) {
-            if (namespace != 'npsp') {
+            if (namespace != UTIL_Namespace.NPSP_NS) {
                 fieldMapping.Source_Field_API_Name__c =
-                    UTIL_Namespace.removeNSPrefixNpspOnly(fieldMapping.Source_Field_API_Name__c);
+                    UTIL_Namespace.alignSchemaNSWithEnvironment(fieldMapping.Source_Field_API_Name__c);
                 fieldMapping.Target_Object_Mapping__r.Object_API_Name__c =
-                    UTIL_Namespace.removeNSPrefixNpspOnly(fieldMapping.Target_Object_Mapping__r.Object_API_Name__c);
+                    UTIL_Namespace.alignSchemaNSWithEnvironment(fieldMapping.Target_Object_Mapping__r.Object_API_Name__c);
             }
             fieldMappingsBySourceFieldName.put(
                 fieldMapping.Target_Object_Mapping__r.Object_API_Name__c

--- a/src/classes/BDI_MigrationMappingHelper.cls
+++ b/src/classes/BDI_MigrationMappingHelper.cls
@@ -175,7 +175,7 @@ public class BDI_MigrationMappingHelper {
         String namespace = UTIL_Namespace.getNamespace();
 
         for (Data_Import_Field_Mapping__mdt fieldMapping : existingFieldMappings) {
-            if (namespace != UTIL_Namespace.NPSP_NS) {
+            if (UTIL_Namespace.shouldAlignNamespace) {
                 fieldMapping.Source_Field_API_Name__c =
                     UTIL_Namespace.alignSchemaNSWithEnvironment(fieldMapping.Source_Field_API_Name__c);
                 fieldMapping.Target_Object_Mapping__r.Object_API_Name__c =

--- a/src/classes/BDI_MigrationMappingUtility.cls
+++ b/src/classes/BDI_MigrationMappingUtility.cls
@@ -758,7 +758,7 @@ public with sharing class BDI_MigrationMappingUtility {
             Map<String, Object> fieldValues;
             if (this.isDeleted != true) {
 
-                if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
+                if (UTIL_Namespace.shouldAlignNamespace) {
                     this.targetFieldAPIName =
                         UTIL_Namespace.alignSchemaNSWithEnvironment(this.targetFieldAPIName);
                 }
@@ -847,7 +847,7 @@ public with sharing class BDI_MigrationMappingUtility {
                     this.dataImportObjectName = String.isNotBlank(parts[0]) ? parts[0] : null;
                     this.targetFieldAPIName = String.isNotBlank(parts[1]) ? parts[1] : null;
 
-                    if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
+                    if (UTIL_Namespace.shouldAlignNamespace) {
                         this.targetFieldAPIName =
                             UTIL_Namespace.alignSchemaNSWithEnvironment(this.targetFieldAPIName);
                     }

--- a/src/classes/BDI_MigrationMappingUtility.cls
+++ b/src/classes/BDI_MigrationMappingUtility.cls
@@ -382,7 +382,7 @@ public with sharing class BDI_MigrationMappingUtility {
         for (HelpTextFieldMapping helpTextFieldMapping : helpTextFieldMappings) {
 
             String unnamespacedDIFieldName =
-                UTIL_Namespace.removeNSPrefixNpspOnly(helpTextFieldMapping.dataImportFieldAPIName.toLowerCase());
+                UTIL_Namespace.alignSchemaNSWithEnvironment(helpTextFieldMapping.dataImportFieldAPIName.toLowerCase());
             Boolean isSkippable = DATA_IMPORT_IMPORT_FIELDS.contains(unnamespacedDIFieldName);
 
             Boolean isException = false;
@@ -758,9 +758,9 @@ public with sharing class BDI_MigrationMappingUtility {
             Map<String, Object> fieldValues;
             if (this.isDeleted != true) {
 
-                if (NAMESPACE != 'npsp') {
+                if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
                     this.targetFieldAPIName =
-                        UTIL_Namespace.removeNSPrefixNpspOnly(this.targetFieldAPIName);
+                        UTIL_Namespace.alignSchemaNSWithEnvironment(this.targetFieldAPIName);
                 }
 
                 fieldValues = new Map<String, Object>{
@@ -847,9 +847,9 @@ public with sharing class BDI_MigrationMappingUtility {
                     this.dataImportObjectName = String.isNotBlank(parts[0]) ? parts[0] : null;
                     this.targetFieldAPIName = String.isNotBlank(parts[1]) ? parts[1] : null;
 
-                    if (NAMESPACE != 'npsp') {
+                    if (NAMESPACE != UTIL_Namespace.NPSP_NS) {
                         this.targetFieldAPIName =
-                            UTIL_Namespace.removeNSPrefixNpspOnly(this.targetFieldAPIName);
+                            UTIL_Namespace.alignSchemaNSWithEnvironment(this.targetFieldAPIName);
                     }
 
                     checkRequiredFields();

--- a/src/classes/BDI_ObjectMappingLogic.cls
+++ b/src/classes/BDI_ObjectMappingLogic.cls
@@ -43,7 +43,7 @@ public with sharing virtual class BDI_ObjectMappingLogic {
             return objWraps;
         }
 
-        Map<String, Schema.DescribeFieldResult> sourceFieldDescribeMap = UTIL_Describe.getAllFieldsDescribe(UTIL_Namespace.adjustNPSPNamespace('npsp__DataImport__c'));
+        Map<String, Schema.DescribeFieldResult> sourceFieldDescribeMap = UTIL_Describe.getAllFieldsDescribe(UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__DataImport__c'));
         
         for (BDI_ObjectWrapper objWrap : objWraps) {
             Map<String, Schema.DescribeFieldResult> targetFieldDescribeMap = UTIL_Describe.getAllFieldsDescribe(objWrap.objMapping.Object_API_Name__c);

--- a/src/classes/ERR_AsyncErrors_TEST.cls
+++ b/src/classes/ERR_AsyncErrors_TEST.cls
@@ -102,14 +102,14 @@ public class ERR_AsyncErrors_TEST {
             Async_Error_Check_Last_Run__c = null
         );
 
-        stub.currentNamespace = UTIL_Namespace.NPSP_NS;
+        stub.currentNamespace = UTIL_Namespace.HARDCODED_NPSP_NAMESPACE;
 
         stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>();
 
         stub.execute(null);
 
         System.assertEquals(
-            UTIL_Namespace.NPSP_NS,
+            UTIL_Namespace.HARDCODED_NPSP_NAMESPACE,
             stub.pendingAsyncJobErrorsNamespace
         );
     }

--- a/src/classes/ERR_AsyncErrors_TEST.cls
+++ b/src/classes/ERR_AsyncErrors_TEST.cls
@@ -102,14 +102,14 @@ public class ERR_AsyncErrors_TEST {
             Async_Error_Check_Last_Run__c = null
         );
 
-        stub.currentNamespace = 'npsp';
+        stub.currentNamespace = UTIL_Namespace.NPSP_NS;
 
         stub.pendingAsyncJobErrors = new List<ERR_AsyncErrors.AsyncApexJobWrapper>();
 
         stub.execute(null);
 
         System.assertEquals(
-            'npsp',
+            UTIL_Namespace.NPSP_NS,
             stub.pendingAsyncJobErrorsNamespace
         );
     }

--- a/src/classes/STG_PanelDataImportAdvancedMapping_CTRL.cls
+++ b/src/classes/STG_PanelDataImportAdvancedMapping_CTRL.cls
@@ -144,13 +144,13 @@ public with sharing class STG_PanelDataImportAdvancedMapping_CTRL extends STG_Pa
         String newPrefix;
 
         //If the namespace being used is not npsp then replace with the current namespace if there is one
-        if (namespace != UTIL_Namespace.NPSP_NS) {
+        if (UTIL_Namespace.shouldAlignNamespace) {
             if (!String.isBlank(namespace)) {
                 newPrefix = namespace;
             } else {
                 newPrefix = 'c';
             }
-            componentUrl = componentUrl.replace(UTIL_Namespace.NPSP_NS + '__', newPrefix + '__');
+            componentUrl = componentUrl.replace(UTIL_Namespace.HARDCODED_NPSP_NAMESPACE + '__', newPrefix + '__');
         }
 
         PageReference advancedMapping = new PageReference(componentUrl);

--- a/src/classes/STG_PanelDataImportAdvancedMapping_CTRL.cls
+++ b/src/classes/STG_PanelDataImportAdvancedMapping_CTRL.cls
@@ -141,9 +141,18 @@ public with sharing class STG_PanelDataImportAdvancedMapping_CTRL extends STG_Pa
     */
     public PageReference navigate() {
         String namespace = UTIL_Namespace.getNamespace();
-        if (namespace != 'npsp') {
-            componentUrl = componentUrl.replace('npsp__','c__');
+        String newPrefix;
+
+        //If the namespace being used is not npsp then replace with the current namespace if there is one
+        if (namespace != UTIL_Namespace.NPSP_NS) {
+            if (!String.isBlank(namespace)) {
+                newPrefix = namespace;
+            } else {
+                newPrefix = 'c';
+            }
+            componentUrl = componentUrl.replace(UTIL_Namespace.NPSP_NS + '__', newPrefix + '__');
         }
+
         PageReference advancedMapping = new PageReference(componentUrl);
         advancedMapping.setRedirect(true);
         return advancedMapping;

--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -41,6 +41,13 @@ public class UTIL_Namespace {
     * @description String helper property for getNamespace() method.
     *******************************************************************************************************/
     private static string plainNamespace;
+
+    /******************************************************************************************************
+    * @description Constant value for the npsp namespace, for use only when necessary in replacing hardcoded
+    * namespace prefixes in field/object name strings Custom Settings/Custom Metadata
+    *******************************************************************************************************/
+    public static final String NPSP_NS = 'npsp';
+
     /*******************************************************************************************************
     * @description Finds the namespace for the current context.
     * @return string The current namespace as a string, or a blank string if we're not in a namespaced context.
@@ -97,23 +104,48 @@ public class UTIL_Namespace {
     * @param str token name 
     * @return token name, with namespace prefix removed, if present.
     ********************************************************************************************************/
-    public static string StrTokenRemoveNSPrefix(string str) {
-        if(str.startsWith('npsp__'))
-            str = str.replaceFirst('npsp__', '');
-        if (getNamespace() != '' && str.startsWith(getNamespace() + '__'))
-            str = str.replaceFirst(getNamespace() + '__', '');
+    public static String StrTokenRemoveNSPrefix(String str) {
+        if (str != null) {
+            if (str.startsWith(NPSP_NS + '__')) {
+                str = str.replaceFirst(NPSP_NS + '__', '');
+            }
+                
+            if(getNamespace() != '' && str.startsWith(getNamespace() + '__')) {
+                str = str.replaceFirst(getNamespace() + '__', '');
+            }
+        }
+            
+        return str;
+    }
+
+    /*******************************************************************************************************
+    * @description Removes NPSP class prefix or dynamically removes current NS prefix.
+    * @param str : the class name to have the namespace removed.
+    * @return str : class name with namespace prefix removed.
+    ********************************************************************************************************/
+    public static String StrTokenRemoveClassNSPrefix(String str) {
+        if (str != null) {
+            if (str.startsWith(NPSP_NS + '.')) {
+                str = str.replaceFirst(NPSP_NS + '.', '');
+            }
+
+            if(getNamespace() != '' && str.startsWith(getNamespace() + '.')) {
+                str = str.replaceFirst(getNamespace() + '.', '');
+            }
+        }
+
         return str;
     }
     
     /*******************************************************************************************************
     * @description Static method that takes a string of a multiple potential field names or object names.  
-    * If it is a custom object or field (name ends with __c, __r or __mdt), it prepends the namespace prefix if required.
+    * If it is a custom object or field (name ends with __c, __r, __mdt, or __e), it prepends the namespace prefix if required.
     * If we are in a managed package, tokens in dynamic SOQL must include the package namespace prefix.
     * If you ever deploy this package as unmanaged, this routine will do nothing!
     * @param str string that contains 0 or more token names 
     * @return same string with token names, namespace prefixed, if required.
     ********************************************************************************************************/
-    public static string StrAllNSPrefix(string str) {
+    public static String StrAllNSPrefix(String str) {
         if (str == null || getNamespace() == '') {
             // There is no current package namespace, or the field is null
             return str;
@@ -122,7 +154,7 @@ public class UTIL_Namespace {
             return str;
         }
 
-        Pattern pat = Pattern.Compile('[a-zA-z0-9]*__(?:c|r|mdt)');
+        Pattern pat = Pattern.Compile('[a-zA-z0-9]*__(?:c|r|mdt|e)');
         Matcher match = pat.matcher(str);
         return match.replaceAll(getNamespace()+'__$0');
     }
@@ -148,34 +180,51 @@ public class UTIL_Namespace {
     }
 
     /*******************************************************************************************************
-    * @description Only remove npsp prefix, don't attempt to remove others
-    * 
-    * @param str token name 
-    * @return token name, with namespace prefix removed, if present.
+    * @description If running in non-namespaced or non-npsp namespaced environment, this method will strip
+    * off the NPSP prefix of a field or object name and replace it with the current namespace of the 
+    * UTIL_Namespace if appropriate.
+    * @param name : the field or object name to have the namespace removed or replaced.
+    * @return name : the field or object name with namespace prefix removed or replaced.
     ********************************************************************************************************/
-    public static string removeNSPrefixNpspOnly(string str) {
-        if (str != null) {
-            if (str.startsWith('npsp__')) {
-                str = str.replaceFirst('npsp__', '');
-            } else if (str.startsWith('npsp.')) {
-                str = str.replaceFirst('npsp.', '');
+    public static String alignSchemaNSWithEnvironment(String name) {
+        String newName;
+
+        if (name != null) {
+
+            newName = StrTokenRemoveNSPrefix(name);
+
+            //If a prefix was removed by StrTokenRemoveNSPrefix then attempt to add the current NS for
+            //UTIL_Namespace (if there is one).
+            if (newName != name) {
+                newName = StrAllNSPrefix(newName);
             }
         }
 
-        return str;
+        return newName;
     }
 
     /*******************************************************************************************************
-    * @description If running in non-npsp namespace environment, then remove npsp from field/object names.
-    * 
-    * @param str token name 
-    * @return token name, with namespace prefix removed, if present.
+    * @description If running in non-namespaced or non-npsp namespaced environment, this method will strip
+    * off the NPSP prefix of a class name and replace it with the current namespace of the 
+    * UTIL_Namespace if appropriate.
+    * @param name : the class name to have the namespace removed or replaced.
+    * @return name : the class name with namespace prefix removed or replaced.
     ********************************************************************************************************/
-    public static String adjustNPSPNamespace(String name) {
-        if (getNamespace() != 'npsp') {
-            name = removeNSPrefixNpspOnly(name);
+    public static String alignClassNSWithEnvironment(String name) {
+        String newName;
+
+        if (name != null) {
+
+            newName = StrTokenRemoveClassNSPrefix(name);
+
+            //If a prefix was removed by StrTokenRemoveClassNSPrefix then attempt to add the current NS for
+            //UTIL_Namespace (if there is one).
+            if (newName != name) {
+                newName = StrTokenNSPrefixDotNotation(newName);
+            }
         }
-        return name;
+
+        return newName;
     }
 
 }

--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -44,9 +44,10 @@ public class UTIL_Namespace {
 
     /******************************************************************************************************
     * @description Constant value for the npsp namespace, for use only when necessary in replacing hardcoded
-    * namespace prefixes in field/object name strings Custom Settings/Custom Metadata
+    * namespace prefixes in field/object name strings Custom Settings/Custom Metadata.  This should not be
+    * modified regardless of which namespace this code is being packaged in.
     *******************************************************************************************************/
-    public static final String NPSP_NS = 'npsp';
+    public static final String HARDCODED_NPSP_NAMESPACE = 'npsp';
 
     /*******************************************************************************************************
     * @description Finds the namespace for the current context.
@@ -106,8 +107,8 @@ public class UTIL_Namespace {
     ********************************************************************************************************/
     public static String StrTokenRemoveNSPrefix(String str) {
         if (str != null) {
-            if (str.startsWith(NPSP_NS + '__')) {
-                str = str.replaceFirst(NPSP_NS + '__', '');
+            if (str.startsWith(HARDCODED_NPSP_NAMESPACE + '__')) {
+                str = str.replaceFirst(HARDCODED_NPSP_NAMESPACE + '__', '');
             }
                 
             if(getNamespace() != '' && str.startsWith(getNamespace() + '__')) {
@@ -125,8 +126,8 @@ public class UTIL_Namespace {
     ********************************************************************************************************/
     public static String StrTokenRemoveClassNSPrefix(String str) {
         if (str != null) {
-            if (str.startsWith(NPSP_NS + '.')) {
-                str = str.replaceFirst(NPSP_NS + '.', '');
+            if (str.startsWith(HARDCODED_NPSP_NAMESPACE + '.')) {
+                str = str.replaceFirst(HARDCODED_NPSP_NAMESPACE + '.', '');
             }
 
             if(getNamespace() != '' && str.startsWith(getNamespace() + '.')) {
@@ -227,4 +228,18 @@ public class UTIL_Namespace {
         return newName;
     }
 
+    /*******************************************************************************************************
+    * @description Will return true if the namespace currently being applied to Util_Namespace is different
+    * from the hardcoded NPSP namespace, which indicates that the namespace on certain field/object and class
+    * names stored in metadata may need to be changed.
+    * @return shouldAlignNamespace Boolean : indicates whether the namespace needs to be aligned
+    ********************************************************************************************************/    
+    public static Boolean shouldAlignNamespace {
+        get {
+            if (shouldAlignNamespace == null) {
+                shouldAlignNamespace = (UTIL_Namespace.getNamespace() != UTIL_Namespace.HARDCODED_NPSP_NAMESPACE);
+            }
+            return shouldAlignNamespace;
+        } set;
+    }
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2987,7 +2987,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Error displayed when Group Name is too long.</shortDescription>
-        <value>Error: Group Name is too long, please shorten to 40 characters or less.</value>
+        <value>Error: Group Name is too long, please shorten to 40 characters or fewer.</value>
     </labels>
     <labels>
         <fullName>bdiOMUIErrorNoUnmappedFieldsPt1</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2982,6 +2982,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Blank or invalid values in one or more fields.</value>
     </labels>
     <labels>
+        <fullName>bdiOMUIErrorLabelNameTooLong</fullName>
+        <categories>Advanced Mapping</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Error displayed when Group Name is too long.</shortDescription>
+        <value>Error: Group Name is too long, please shorten to 40 characters or less.</value>
+    </labels>
+    <labels>
         <fullName>bdiOMUIErrorNoUnmappedFieldsPt1</fullName>
         <categories>Advanced Mapping</categories>
         <language>en_US</language>

--- a/src/lwc/bdiFieldMappings/bdiFieldMappings.js
+++ b/src/lwc/bdiFieldMappings/bdiFieldMappings.js
@@ -136,8 +136,8 @@ export default class bdiFieldMappings extends LightningElement {
 
             // Get all the target object field describes based on the currently
             // selected object mapping
-            let objectAPIName =
-                this.objectMapping.Object_API_Name || this.objectMapping.npsp__Object_API_Name;
+            let objectAPIName = this.objectMapping.Object_API_Name;
+
             this.targetObjectFieldDescribes =
                 await getObjectFieldDescribes({objectName: objectAPIName});
 

--- a/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
+++ b/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
@@ -41,6 +41,7 @@ import bdiOMUIOfGroupHelp from '@salesforce/label/c.bdiOMUIOfGroupHelp';
 import bdiOMUIThroughFieldHelp from '@salesforce/label/c.bdiOMUIThroughFieldHelp';
 import bdiOMUIErrorNoValidThroughThisField from '@salesforce/label/c.bdiOMUIErrorNoValidThroughThisField';
 import bdiOMUIErrorDupeName from '@salesforce/label/c.bdiOMUIErrorDupeName';
+import bdiOMUIErrorLabelNameTooLong from '@salesforce/label/c.bdiOMUIErrorLabelNameTooLong';
 import bdiOMUIErrorInvalidValues from '@salesforce/label/c.bdiOMUIErrorInvalidValues';
 import bdiOMUIErrorNoUnmappedFieldsPt1 from '@salesforce/label/c.bdiOMUIErrorNoUnmappedFieldsPt1';
 import bdiOMUIErrorNoUnmappedFieldsPt2 from '@salesforce/label/c.bdiOMUIErrorNoUnmappedFieldsPt2';
@@ -74,6 +75,7 @@ export default class bdiObjectMappingModal extends LightningElement {
         bdiOMUIThroughFieldHelp,
         bdiOMUIErrorNoValidThroughThisField,
         bdiOMUIErrorDupeName,
+        bdiOMUIErrorLabelNameTooLong,
         bdiOMUIErrorInvalidValues,
         bdiOMUIErrorNoUnmappedFieldsPt1,
         bdiOMUIErrorNoUnmappedFieldsPt2,
@@ -331,22 +333,30 @@ export default class bdiObjectMappingModal extends LightningElement {
 
         let result = [...this.template.querySelectorAll('lightning-combobox,lightning-input')]
         .reduce((validSoFar, inputCmp) => {
-                    //Special validation to make sure label name is not reused within the same Object Mapping set
+                    //Special validation for label name
                     if (inputCmp.name === 'masterLabel' && this.row.MasterLabel && this.objectMappings) {
-                        let dupeFound = false;
+                        let errorFound = false;
 
-                        for (let i = 0; i < this.objectMappings.length; i++) {
-                            let tempObjMapping = this.objectMappings[i];
+                        //Check to see if label name is too long
+                        if (this.row.MasterLabel.length > 40) {
+                            errorFound = true;
+                            inputCmp.setCustomValidity(this.customLabels.bdiOMUIErrorLabelNameTooLong);
+                        } else {
+                            //If the length passes then check whether it is a dupe name.
+                            for (let i = 0; i < this.objectMappings.length; i++) {
+                                let tempObjMapping = this.objectMappings[i];
 
-                            //If the labels are the same, but the Ids are not then throw an error
-                            if (tempObjMapping.MasterLabel === this.row.MasterLabel
-                                && tempObjMapping.Id !== this.row.Id) {
+                                //If the labels are the same, but the Ids are not then throw an error
+                                if (tempObjMapping.MasterLabel === this.row.MasterLabel
+                                    && tempObjMapping.Id !== this.row.Id) {
 
-                                dupeFound = true;
-                                inputCmp.setCustomValidity(this.customLabels.bdiOMUIErrorDupeName);
+                                    errorFound = true;
+                                    inputCmp.setCustomValidity(this.customLabels.bdiOMUIErrorDupeName);
+                                }
                             }
                         }
-                        if(!dupeFound){
+                        //Clear validity if no error found.
+                        if(!errorFound){
                             inputCmp.setCustomValidity('');
                         }
                     }

--- a/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
+++ b/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
@@ -97,6 +97,7 @@ export default class bdiObjectMappingModal extends LightningElement {
     @api objectOptions;
     @api isModalOpen = false;
     @api diObjectMappingSetDevName;
+    @api namespaceWrapper;
 
     @track isLoading;
     @track inSave = false;
@@ -112,8 +113,6 @@ export default class bdiObjectMappingModal extends LightningElement {
     alreadyMappedDIFieldsMap;
     dataImportFieldData;
     dataImportFieldMappingSourceNames;
-
-    @api namespace;
 
     constructor() {
         super();
@@ -566,8 +565,15 @@ export default class bdiObjectMappingModal extends LightningElement {
             for (let i = 0; i < this.excludedDIFields.length; i++) {
                 let field = this.excludedDIFields[i].toLowerCase();
 
-                if (this.namespace !== 'npsp') {
-                    field = field.replace('npsp__','');
+                if (this.namespaceWrapper.currentNamespace !== this.namespaceWrapper.npspNamespace) {
+                    let newPrefix;
+
+                    if (this.namespaceWrapper.currentNamespace) {
+                        newPrefix = this.namespaceWrapper.currentNamespace + '__';
+                    } else {
+                        newPrefix = '';
+                    }
+                    field = field.replace(this.namespaceWrapper.npspNamespace + '__',newPrefix);
                 }
 
                 this.alreadyMappedDIFieldsMap.set(field,'');

--- a/src/lwc/bdiObjectMappings/bdiObjectMappings.html
+++ b/src/lwc/bdiObjectMappings/bdiObjectMappings.html
@@ -6,7 +6,7 @@
             object-options={objectOptions}
             object-mappings={objectMappings}
             di-object-mapping-set-dev-name={diObjectMappingSetDevName}
-            namespace={namespace}>
+            namespace-wrapper={namespaceWrapper}>
         </c-bdi-object-mapping-modal>
 
         <div class="slds-grid slds-wrap slds-m-bottom_small">

--- a/src/package.xml
+++ b/src/package.xml
@@ -1556,6 +1556,7 @@
         <members>bdiOMUIEditModalTitle</members>
         <members>bdiOMUIErrorDupeName</members>
         <members>bdiOMUIErrorInvalidValues</members>
+        <members>bdiOMUIErrorLabelNameTooLong</members>
         <members>bdiOMUIErrorNoUnmappedFieldsPt1</members>
         <members>bdiOMUIErrorNoUnmappedFieldsPt2</members>
         <members>bdiOMUIErrorNoValidThroughThisField</members>


### PR DESCRIPTION
- Updated Data Import code so NPSP related schema and code could be packaged in another namespace without breaking Data Import.
-  Also removed almost all hardcoded references to 'npsp' and replaced them with a reference back to the UTIL_Namespace class.
- Added validation that Object Group name is 40 characters or fewer.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
