### PR TITLE
Advanced Mapping: Disable toggle on migration

### DIFF
--- a/src/pages/STG_PanelDataImportAdvancedMapping.page
+++ b/src/pages/STG_PanelDataImportAdvancedMapping.page
@@ -161,7 +161,9 @@
 
         <script type="text/javascript">
             function toggle() {
-                if (document.getElementById('{!$Component.form.enableDIFMToggle}').checked) {
+                let toggle = document.getElementById('{!$Component.form.enableDIFMToggle}');
+                if (toggle.checked) {
+                    toggle.setAttribute('disabled', 'true');
                     enableDataImportFieldMapping();
                 } else {
                     disableDataImportFieldMapping();


### PR DESCRIPTION
# Critical Changes

# Changes
- Immediately disable migration toggle on-click to prevent multiple deployments from being queued.

# Issues Closed

# New Metadata

# Deleted Metadata
