### PR TITLE
BDI Advanced Mapping: Include previously absent but required mapping to opp lookup on ASC

### DIFF
--- a/unpackaged/config/qa_bdi_custom_metadata/customMetadata/Data_Import_Field_Mapping.ASC_Opportunity_cac3e1cd0.md
+++ b/unpackaged/config/qa_bdi_custom_metadata/customMetadata/Data_Import_Field_Mapping.ASC_Opportunity_cac3e1cd0.md
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>ASC Opportunity</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">%%%NAMESPACED_ORG%%%DonationImported__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">%%%NAMESPACED_ORG%%%Opportunity__c</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">AccountSoftCredits_ee5babc24</value>
+    </values>
+</CustomMetadata>

--- a/unpackaged/config/qa_bdi_custom_metadata/package.xml
+++ b/unpackaged/config/qa_bdi_custom_metadata/package.xml
@@ -2,6 +2,7 @@
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
         <members>Data_Import_Field_Mapping.ASC_Amount_cac3e1cd0</members>
+        <members>Data_Import_Field_Mapping.ASC_Opportunity_cac3e1cd0</members>
         <members>Data_Import_Field_Mapping.ASC_Role_f8860e39d</members>
         <members>Data_Import_Field_Mapping.CO1_Date_2cb21281d</members>
         <members>Data_Import_Field_Mapping.CO1_Date_37b322bd6</members>


### PR DESCRIPTION
This PR should not impact the package delivered to customer orgs! The work includes a previously missing field mapping for the Account Soft Credit object group that is deployed as part of the qa_org flows to support qa, automated qa, and benchmark testing. 

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
