### PR TITLE
#1795 - OldList searialized.

### DIFF
--- a/src/classes/ERR_SerializeOldListForAsync_TEST.cls
+++ b/src/classes/ERR_SerializeOldListForAsync_TEST.cls
@@ -1,0 +1,64 @@
+/*
+    Copyright (c) 2013, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2019
+* @description test trigger handler on Contact to throw an exception for error handling tests
+* @group ErrorHandling
+*/
+@isTest
+public with sharing class ERR_SerializeOldListForAsync_TEST extends TDTM_Runnable {
+
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
+            TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
+
+        DmlWrapper dmlWrapper = new DmlWrapper();
+
+        //Querying the name in the parent account is only necessary if we are in a future.
+        //It is necessary here because we are calling this class from TDTM_Runnable_TEST.
+        if(System.isFuture()) {
+            List<Id> parentAccIds = new List<Id>();
+            integer index = -1;
+            for(SObject o : newlist) {
+                index++;
+                Contact contact = (Contact)o;
+                if(contact.FirstName != ((Contact)oldlist[index]).FirstName){
+                    parentAccIds.add(contact.AccountId);
+                }
+            }
+            List<Account> parentAccs = [select Id, Name from Account where Id in :parentAccIds];
+            for(Account acc : parentAccs) {
+                acc.Name = 'New Acc Name';
+                dmlWrapper.objectsToUpdate.add(acc);
+            }
+        }
+        return dmlWrapper;
+    }
+}

--- a/src/classes/ERR_SerializeOldListForAsync_TEST.cls-meta.xml
+++ b/src/classes/ERR_SerializeOldListForAsync_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TDTM_Runnable.cls
+++ b/src/classes/TDTM_Runnable.cls
@@ -57,63 +57,63 @@ global abstract class TDTM_Runnable {
      * @description Calls the run method of the class, as a future. To be called dynamically from TDTM_TriggerHandler. 
      * We need this method because Apex won't let us call a non-static method from a separate object instance.
      * @param newIds The IDs of the records that were passed to the trigger as trigger.new.
-     * @param oldIds The IDs of the records that were passed to the trigger as trigger.old.
+     * @param serializedOldList The list of serialized records that were passed to the trigger as trigger.old.
      * @param action The event (before insert, after insert,...) that caused the class to run.
      * @param objectName The name of the SObject the class runs for.
      * @param classToRunName The name of the class to run.
      * @return void
      */
-    public void runFutureNonStatic(Set<Id> newIds, Set<Id> oldIds, String action, String objectName, String classToRunName) {
-        runFuture(newIds, oldIds, action, objectName, classToRunName);
+    public void runFutureNonStatic(Set<Id> newIds, List<String> serializedOldList, String action, String objectName, String classToRunName) {
+        runFuture(newIds, serializedOldList, action, objectName, classToRunName);
     }
     
     /*******************************************************************************************************
      * @description Calls the run method of the class, as a future.
      * @param newIds The IDs of the records that were passed to the trigger as trigger.new.
-     * @param oldIds The IDs of the records that were passed to the trigger as trigger.old.
+     * @param serializedOldList The list of serialized records that were passed to the trigger as trigger.old..
      * @param action The event (before insert, after insert,...) that caused the class to run.
      * @param objectName The name of the SObject the class runs for.
      * @param classToRunName The name of the class to run.
      * @return void
      */
     @future
-    public static void runFuture(Set<Id> newIds, Set<Id> oldIds, String action, String objectName, String classToRunName) {
-        
+    public static void runFuture(Set<Id> newIds, List<String> serializedOldList, String action, String objectName, String classToRunName) {
+
         Schema.DescribeSObjectResult objResult = UTIL_Describe.getObjectDescribe(objectName);
         TDTM_Runnable.Action triggerAction = TDTM_TriggerActionHelper.getTriggerActionFromName(action);
-        
+
         //Get all fields for the object
         List<Schema.SObjectField> allFields = objResult.fields.getMap().values();
-        
+
         //Getting the records the IDs refer to
-        String qn = 'SELECT ';
-        for (Integer i = 0; i < allFields.size() - 1; i++) { //add all fields, except last, to query
+        String qn = 'select ';
+        for(Integer i = 0; i < allFields.size() - 1; i++) //add all fields, except last, to query
             qn += ' ' + allFields[i] + ', ';
-        }
         qn += ' ' + allFields[allFields.size() - 1]; //add last field to query
-        qn += ' FROM ' + objectName + ' WHERE Id IN ';
+        qn += ' from ' + objectName + ' where id IN ';
 
-        List<SObject> newList;
-        if (newIds != null) {
-            newList = Database.query(qn + ':newIds ORDER BY Id');
+        List<SObject> newlist;
+        if (newIds != null)
+            newlist = Database.query(qn + ':newIds order by Id');
+        List<SObject> oldlist;
+        if (serializedOldList != null){
+            //we dont need to sort old list here as it is already sorted
+            oldlist = new List<SObject>();
+            for(String oldRecord : serializedOldList){
+                oldlist.add((sObject) JSON.deserialize(oldRecord, sObject.class));
+            }
         }
-        List<SObject> oldList;
-        if (oldIds != null) {
-            oldList = Database.query(qn + ':oldIds ORDER BY Id');
-        }
-
         //Call the non-future method
         Type classType = Type.forName(classToRunName);
-        Object classInstance; 
-        if (classType != null) {
+        Object classInstance;
+        if(classType != null)
             classInstance = classType.newInstance();
-        }
-        if (classInstance instanceof TDTM_Runnable) {
+        if(classInstance instanceof TDTM_Runnable) {
             TDTM_Runnable runnable = (TDTM_Runnable) classInstance;
             //WARNING: we have queried all the fields that would be available in the records themselves, but NOT the fields
             //from related (parent or child) records. Those would need to be queried independently in the class itself (see
             //ERR_ParentAccountUpdater2_TEST class for an example on how to do that).
-            DmlWrapper dmlWrapper = runnable.run(newList, oldList, triggerAction, objResult);
+            DmlWrapper dmlWrapper = runnable.run(newlist, oldlist, triggerAction, objResult);
 
             //Process the result. In this case we cannot pass the original Trigger.new and Trigger.old, since we are
             //in a future

--- a/src/classes/TDTM_Runnable_TEST.cls
+++ b/src/classes/TDTM_Runnable_TEST.cls
@@ -150,7 +150,37 @@ private with sharing class TDTM_Runnable_TEST {
 
         insert dmlWrapper.objectsToInsert;
     }
+	
+	 /***************************************************************************
+    * @description This test verifies that the old list (Trigger.old) is getting serialized properly for runFuture method of the TDTM_Runnable
+    **/
+    @isTest
+    private static void testSerializeOldListForAsyncMethods() {
+        String runFutureAccountName = 'New Acc Name';
 
+        insert new Trigger_Handler__c(
+                Active__c = true,
+                Asynchronous__c = true,
+                Class__c = 'ERR_SerializeOldListForAsync_TEST',
+                Load_Order__c = 1,
+                Object__c = 'Contact',
+                Trigger_Action__c = 'AfterUpdate;'
+        );
+
+        Contact contact = [SELECT Name, AccountId FROM Contact LIMIT 1][0];
+        contact.FirstName = 'New First Name';
+
+        Account acc = [SELECT Name FROM Account WHERE Id = :contact.AccountId LIMIT 1][0];
+        System.assertNotEquals(runFutureAccountName, acc.Name, 'Account name must not be: "New Account Name"');
+
+        Test.startTest();
+        update contact;
+        Test.stopTest();
+        Account actualAccount = [SELECT Name FROM Account WHERE Id = :acc.Id];
+
+        // Ensure 'ERR_SerializeOldListForAsync_TEST' trigger handler future method processing has been applied
+        System.assertEquals(runFutureAccountName, actualAccount.Name, 'Account name must be: "New Account Name"');
+    }
 
     // Helpers
     //////////////

--- a/src/classes/TDTM_TriggerHandler.cls
+++ b/src/classes/TDTM_TriggerHandler.cls
@@ -219,22 +219,25 @@ public class TDTM_TriggerHandler {
      * @param thisAction Trigger Event (Insert, Update, Delete, ...)
      * @param describeObj SObjectDescribe of the target object
      */
-    private static void runAsync(TDTM_Runnable classToRun, String classToRunName, List<SObject> newList,
-            List<SObject> oldList, TDTM_Runnable.Action thisAction, Schema.DescribeSObjectResult describeObj) {
-
-       Set<Id> setNewId;
-       if (newList != null) {
-           Map<Id,SObject> nm = new Map<Id,SObject>(newList);
-           setNewId = new Set<Id>(nm.keySet());
-       }
-       
-       Set<Id> setOldId;
-       if (oldList != null) {
-           Map<Id,SObject> om = new Map<Id,SObject>(oldList);
-           setOldId = new Set<Id>(om.keySet());
-       }
-       
-       classToRun.runFutureNonStatic(setNewId, setOldId, thisAction.name(), describeObj.getName(), classToRunName);
+    private static void runAsync(TDTM_Runnable classToRun, String classToRunName, List<Sobject> newList,
+            List<Sobject> oldList, TDTM_Runnable.Action thisAction, Schema.DescribeSobjectResult describeObj) {
+        set<Id> setNewId;
+        if(newlist != null) {
+            Map<Id,Sobject> nm = new Map<Id,Sobject>(newlist);
+            setNewId = new set<Id>(nm.keySet());
+        }
+        //Only serializing old list not new list (to prevent any accidental overwriting in future method)
+        List<String> serializedOldList;
+        if(oldlist != null) {
+            serializedOldList = new List<String>();
+            Map<Id,Sobject> om = new Map<Id,SObject>(oldlist);
+            List <Id> listOldId = new List<Id>(om.keySet());
+            listOldId.sort();
+            for(Id recordId : listOldId){
+                serializedOldList.add(JSON.serialize(om.get(recordId)));
+            }
+        }
+        classToRun.runFutureNonStatic(setNewId, serializedOldList, thisAction.name(), describeObj.getName(), classToRunName);
     }
 
     /**


### PR DESCRIPTION
# Critical Changes

# Changes
In this fix I am serializing oldList for classes that are called in future context using TDTM framework. Also, I am not serializing newList to prevent unintentional overwriting of fields on the passed sObject. Followed by writing new test cases to check the new functionality.

Updated following files:
src\classes\TDTM_Runnable.cls
src\classes\TDTM_Runnable_TEST.cls
src\classes\TDTM_TriggerHandler.cls

Added following files:
src\classes\ERR_SerializeOldListForAsync_TEST.cls
src\classes\ERR_SerializeOldListForAsync_TEST.cls-meta.xml

# Issues Closed
#1795

# New Metadata
ERR_SerializeOldListForAsync_TEST.cls

# Deleted Metadata
