### PR TITLE
Reverts prior change to make $0 Opportunity Amount behave like null Opportunity Amount

### DIFF
--- a/src/classes/ALLO_Allocations_TDTM.cls
+++ b/src/classes/ALLO_Allocations_TDTM.cls
@@ -152,7 +152,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
             //INSERT case: Verify associated Campaign and Recurring Donations to auto create allocations
             if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
                 //don't do anything on insert if we don't have an amount
-                if (opp.Amount == null || opp.Amount == 0) {
+                if (opp.Amount == null) {
                     continue;
                 //if this new opportunity has a Campaign or RD, add to list for processing
                 } else if (opp.CampaignId != null || opp.npe03__Recurring_Donation__c != null)
@@ -167,9 +167,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
             if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
                 Decimal oldAmount = (Decimal) oldlist[i].get('Amount');
 
-                if (oldAmount == null && opp.Amount == 0) {
-                    continue;
-                } else if (oldAmount == null && opp.Amount != null) {
+                if (oldAmount == null && opp.Amount != null) {
                     oppsWithNullOldAmount.add(opp);
 
                 } else if (opp.Amount != oldAmount) {
@@ -552,7 +550,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
                     wrap = mapWrapper.get((Id)sObj.get('npe01__Opportunity__c'));
                     isPaymentAllocation = true;
                 }
-                    
+
                 //get wrapper for parent object, preferring recurring donation over campaign allocations if they exist
                 else if (sObj.get('npe03__Recurring_Donation__c') != null && mapWrapper.containsKey((Id)sObj.get('npe03__Recurring_Donation__c')))
                     wrap = mapWrapper.get((Id)sObj.get('npe03__Recurring_Donation__c'));
@@ -564,7 +562,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
                 //add only allocations to active GAUs
                 for (Allocation__c allo : wrap.listAllo.deepclone()) {
 
-                    // If it's a payment, don't filter out the active allocations. 
+                    // If it's a payment, don't filter out the active allocations.
                     if (sObj instanceof npe01__OppPayment__c) {
                         listAlloForInsert.add(allo);
                     } else {
@@ -579,7 +577,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
 
                 //reparent the cloned allocation to the opportunity
                 for (Allocation__c allo : listAlloForInsert) {
-                    Allocation__c alloInMap; 
+                    Allocation__c alloInMap;
 
                     if (isPaymentAllocation == true && GAUtoAlloMapping.containsKey(allo.General_Accounting_Unit__c)) {
                         alloInMap = GAUtoAlloMapping.get(allo.General_Accounting_Unit__c);
@@ -596,7 +594,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
 
                     if (allo.Percent__c != null) {
                         allo.Amount__c = (amount * allo.Percent__c * .01).setScale(2);
-                        
+
                     }
 
                     //Calculate proportional amount for non-percentage based Payment allocations
@@ -636,13 +634,13 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
                 }
 
                 // Only set the percentages and update the list to insert to the consolidated list
-                // when it's a payment. 
+                // when it's a payment.
                 if (isPaymentAllocation == true) {
                     List<Allocation__c> consolidatedAllocationList = GAUtoAlloMapping.values();
 
 
                     // Only set the percentage if it is a payment or an opportunity that isn't tied to a campaign or a recurring donation.
-                    // At this point, only the amounts on each allocation is correct, not the percentage. 
+                    // At this point, only the amounts on each allocation is correct, not the percentage.
                     // Go through the allocation and adjust the percentage so it is correct.
                     for (Allocation__c consolidatedAllocation : consolidatedAllocationList) {
                         consolidatedAllocation.Percent__c = consolidatedAllocation.Amount__c / amount * 100;
@@ -651,7 +649,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
                     // Set the consolidated list as the list to insert
                     listAlloForInsert = consolidatedAllocationList;
                 }
-                
+
 
                 //if our remainder is negative, only create percentage based allocations
                 if ((amount >= 0 && remainder < 0)||(amount < 0 && remainder > 0)) {

--- a/src/classes/ALLO_Allocations_TEST.cls
+++ b/src/classes/ALLO_Allocations_TEST.cls
@@ -799,6 +799,238 @@ private with sharing class ALLO_Allocations_TEST {
         system.assertEquals(8, queryAllo[0].Amount__c, 'The default allocation should be of the total amount of the Opportunity.');
     }
 
+    /*******************************************************************************************************
+    * @description Tests that the default Allocation is created with a zero amount when default
+    * Allocations are created and the Opportunity Amount is 0 via ALLO_ALLOCATION_TDTM trigger
+    ********************************************************************************************************/
+    @isTest
+    private static void defaultAllocationsForZeroAmountOpportunityShouldRemainOnCreate() {
+        General_Accounting_Unit__c defaultGau = new General_Accounting_Unit__c(Name='General');
+        insert defaultGau;
+
+        General_Accounting_Unit__c otherGau = new General_Accounting_Unit__c(Name='Other');
+        insert otherGau;
+
+        setupSettings(new Allocations_Settings__c(Default_Allocations_Enabled__c = true, Default__c = defaultGau.id));
+
+        List<Account> accs = UTIL_UnitTestData_TEST.createMultipleTestAccounts(1, null);
+
+        insert accs;
+
+        List<Opportunity> opps = UTIL_UnitTestData_TEST.oppsForAccountList(accs, null, UTIL_UnitTestData_TEST.getClosedWonStage(), System.today(), 0, null, null);
+
+        Test.startTest();
+
+        insert opps;
+
+        Test.stopTest();
+
+        list<Allocation__c>  allos = getAllocationsOrderByAmount();
+        System.assertEquals(1, allos.size(), 'One allocation should be present.');
+        system.assertEquals(0, allos[0].Amount__c, 'Allocation Amount');
+        System.assertEquals(defaultGau.Id, allos[0].General_Accounting_Unit__c, 'Allocation should be for the default');
+        System.assertEquals(opps[0].Id, allos[0].Opportunity__c, 'Opportunity');
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that $0 Allocations (Percentage based and fixed Amount) can be added for a $0
+    * Opportunity
+    ********************************************************************************************************/
+    @isTest
+    private static void createZeroAmountAllocationsForZeroAmountOpportunity() {
+        List<General_Accounting_Unit__c> gaus = new List<General_Accounting_Unit__c>();
+
+        General_Accounting_Unit__c defaultGau = new General_Accounting_Unit__c(Name='General');
+        gaus.add(defaultGAU);
+        General_Accounting_Unit__c gau1 = new General_Accounting_Unit__c(Name = 'GAU 1');
+        gaus.add(gau1);
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(Name = 'GAU 2');
+        gaus.add(gau2);
+        General_Accounting_Unit__c gau3 = new General_Accounting_Unit__c(Name = 'GAU 3');
+        gaus.add(gau3);
+
+        insert gaus;
+
+        setupSettings(new Allocations_Settings__c(Default_Allocations_Enabled__c = true, Default__c = defaultGau.id));
+
+        List<Account> accs = UTIL_UnitTestData_TEST.createMultipleTestAccounts(1, null);
+
+        insert accs;
+
+        List<Opportunity> opps = UTIL_UnitTestData_TEST.oppsForAccountList(accs, null, UTIL_UnitTestData_TEST.getClosedWonStage(), System.today(), 0, null, null);
+
+        insert opps;
+
+        Test.startTest();
+
+        List<Allocation__c> newAllos = new List<Allocation__c>();
+
+        // Percentaage Allocation for 50% to GAU 1
+        newAllos.add(
+            new Allocation__c(
+                General_Accounting_Unit__c = gau1.Id,
+                Percent__c = 50,
+                Opportunity__c = opps[0].Id
+            )
+        );
+
+        // Fix Amount Allocation for $0 to GAU 2
+        newAllos.add(
+            new Allocation__c(
+                General_Accounting_Unit__c = gau2.Id,
+                Amount__c = 0,
+                Opportunity__c = opps[0].Id
+            )
+        );
+
+        insert newAllos;
+
+        Test.stopTest();
+
+        List<Allocation__c> allos = getAllocationsOrderByPercent(opps[0].Id);
+        System.assertEquals (2, allos.size(), '# of Allocations');
+        System.assertEquals (gau1.Name, allos[1].General_Accounting_Unit__r.Name, 'Allocation 1 - GAU');
+        System.assertEquals (0, allos[1].Amount__c, 'Allocation 1 - Amount');
+        System.assertEquals (50, allos[1].Percent__c, 'Allocation 1 - Percent');
+        System.assertEquals (gau2.Name, allos[0].General_Accounting_Unit__r.Name, 'Allocation 0 - GAU');
+        System.assertEquals (0, allos[0].Amount__c, 'Allocation 0 - Amount');
+        System.assertEquals (null, allos[0].Percent__c, 'Allocation 0 - Percent');
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that Allocations are updated and preserved when changing an Opportunity from a
+    * non zero to a zero amount
+    ********************************************************************************************************/
+    @isTest
+    private static void chamgeOpportunityAmountFromNonZeroToZero() {
+        List<General_Accounting_Unit__c> gaus = new List<General_Accounting_Unit__c>();
+
+        General_Accounting_Unit__c defaultGau = new General_Accounting_Unit__c(Name='General');
+        gaus.add(defaultGAU);
+        General_Accounting_Unit__c gau1 = new General_Accounting_Unit__c(Name = 'GAU 1');
+        gaus.add(gau1);
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(Name = 'GAU 2');
+        gaus.add(gau2);
+        General_Accounting_Unit__c gau3 = new General_Accounting_Unit__c(Name = 'GAU 3');
+        gaus.add(gau3);
+
+        insert gaus;
+
+        setupSettings(new Allocations_Settings__c(Default_Allocations_Enabled__c = true, Default__c = defaultGau.id));
+
+        List<Account> accs = UTIL_UnitTestData_TEST.createMultipleTestAccounts(1, null);
+
+        insert accs;
+
+        List<Opportunity> opps = UTIL_UnitTestData_TEST.oppsForAccountList(accs, null, UTIL_UnitTestData_TEST.getClosedWonStage(), System.today(), 10, null, null);
+
+        insert opps;
+
+        List<Allocation__c> newAllos = new List<Allocation__c>();
+
+        // Percentaage Allocation for 50% to GAU 1
+        newAllos.add(
+            new Allocation__c(
+                General_Accounting_Unit__c = gau1.Id,
+                Percent__c = 50,
+                Opportunity__c = opps[0].Id
+            )
+        );
+
+        // Fix Amount Allocation for $0 to GAU 2
+        newAllos.add(
+            new Allocation__c(
+                General_Accounting_Unit__c = gau2.Id,
+                Amount__c = 0,
+                Opportunity__c = opps[0].Id
+            )
+        );
+
+        insert newAllos;
+
+        Test.startTest();
+
+        for (Opportunity opp : opps) {
+            opp.Amount = 0;
+        }
+
+        update opps;
+
+        Test.stopTest();
+
+        List<Allocation__c> allos = getAllocationsOrderByPercent(opps[0].Id);
+        System.assertEquals (2, allos.size(), '# of Allocations');
+        System.assertEquals (gau1.Name, allos[1].General_Accounting_Unit__r.Name, 'Allocation 1 - GAU');
+        System.assertEquals (0, allos[1].Amount__c, 'Allocation 1 - Amount');
+        System.assertEquals (50, allos[1].Percent__c, 'Allocation 1 - Percent');
+        System.assertEquals (gau2.Name, allos[0].General_Accounting_Unit__r.Name, 'Allocation 0 - GAU');
+        System.assertEquals (0, allos[0].Amount__c, 'Allocation 0 - Amount');
+        System.assertEquals (null, allos[0].Percent__c, 'Allocation 0 - Percent');
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that an error is generated if Opportunity Amount is 0 and a non zero fixed
+    * Amount Allocation is added
+    ********************************************************************************************************/
+    @isTest
+    private static void generateErrorForNonZeroFixedAmountAllocationIfOpportunityAmountIsZero() {
+        List<General_Accounting_Unit__c> gaus = new List<General_Accounting_Unit__c>();
+
+        General_Accounting_Unit__c defaultGau = new General_Accounting_Unit__c(Name='General');
+        gaus.add(defaultGAU);
+        General_Accounting_Unit__c gau1 = new General_Accounting_Unit__c(Name = 'GAU 1');
+        gaus.add(gau1);
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(Name = 'GAU 2');
+        gaus.add(gau2);
+        General_Accounting_Unit__c gau3 = new General_Accounting_Unit__c(Name = 'GAU 3');
+        gaus.add(gau3);
+
+        insert gaus;
+
+        setupSettings(new Allocations_Settings__c(Default_Allocations_Enabled__c = true, Default__c = defaultGau.id));
+
+        List<Account> accs = UTIL_UnitTestData_TEST.createMultipleTestAccounts(1, null);
+
+        insert accs;
+
+        List<Opportunity> opps = UTIL_UnitTestData_TEST.oppsForAccountList(accs, null, UTIL_UnitTestData_TEST.getClosedWonStage(), System.today(), 0, null, null);
+
+        insert opps;
+
+        Test.startTest();
+
+        List<Allocation__c> newAllos = new List<Allocation__c>();
+
+        // Percentaage Allocation for 50% to GAU 1
+        newAllos.add(
+            new Allocation__c(
+                General_Accounting_Unit__c = gau1.Id,
+                Percent__c = 50,
+                Opportunity__c = opps[0].Id
+            )
+        );
+
+        // Fix Amount Allocation for $0 to GAU 2
+        newAllos.add(
+            new Allocation__c(
+                General_Accounting_Unit__c = gau2.Id,
+                Amount__c = 10,
+                Opportunity__c = opps[0].Id
+            )
+        );
+
+        try{
+            insert newAllos;
+            System.assert(false, 'Expected an exception due to Opportunity being Overallocated.');
+        } catch (Exception e) {
+            System.assert(e.getMessage().contains(Label.alloTotalExceedsOppAmt), 'Expected Exception Text: ' + Label.alloExceedsOppAmount + '; Actual: ' + e.getMessage());
+        }
+
+        Test.stopTest();
+    }
+
+
+
     // Helpers
     ////////////
 

--- a/src/classes/ALLO_PaymentSync_TEST.cls
+++ b/src/classes/ALLO_PaymentSync_TEST.cls
@@ -457,7 +457,12 @@ private with sharing  class ALLO_PaymentSync_TEST {
                                         where Opportunity__c in :oppIds
         ];
 
-        System.assertEquals(0, allocs.size(), 'No allocations should be present.');
+        System.assertEquals(1, allocs.size(), 'One allocation should be present.');
+
+        for (Allocation__c alloc : allocs) {
+            assertAllocation(alloc, 0, defaultGau.Id, true);
+            System.assertEquals (opp.Id, alloc.Opportunity__c, 'Allocation Opportunity');
+        }
 
         for (Integer i = 0; i < opps.size(); i++) {
             opps[i].Amount = 1000;
@@ -477,6 +482,8 @@ private with sharing  class ALLO_PaymentSync_TEST {
 
         System.assertEquals (2, allocs.size(), 'Default Allocs for Opportunity should now be present.');
 
+        //TODO: Restore this part of the test once the modifications for Payment Allocations, in terms of $0 Payments Amounts is corrected so the Default Allocation will still be present for $0 Amounts (if no other allocations are present)
+        /*
         opps[0].Amount = 0;
         opps[1].Amount = null;
         update opps;
@@ -492,8 +499,13 @@ private with sharing  class ALLO_PaymentSync_TEST {
                   where Opportunity__c in :oppIds
         ];
 
-        System.assertEquals(0, allocs.size(), 'No allocations should be present');
+        System.assertEquals(1, allocs.size(), 'One allocation should be present');
 
+        for (Allocation__c alloc : allocs) {
+            assertAllocation(alloc, 0, defaultGau.Id, true);
+            System.assertEquals (opp.Id, alloc.Opportunity__c, 'Allocation Opportunity');
+        }
+        */
     }
 
     /*******************************************************************************************************
@@ -968,4 +980,5 @@ private with sharing  class ALLO_PaymentSync_TEST {
             })
             .withFrom('Allocation__c');
     }
+
 }


### PR DESCRIPTION
- Reverts prior change to handling of $0 Opportunity Amounts concerning Allocations.
- It will create a default $0 Allocation if Default Allocations are enabled/configured, and the Opportunity Amount is $0.
- It will preserve percentage and fixed amount ($0) allocations if amount is changed from a non zero to a zero amount.
- New Opportunities with a null amount, will not have a default allocation, even if enabled.
- Updating an Opportunity Amount to null, will clear the Opportunities Allocations

# Critical Changes
## GAU Allocations
- We reverted the change made in [Release 3.157](https://github.com/SalesforceFoundation/Cumulus/releases/tag/rel%2F3.157) to GAU Allocation behavior for Opportunities with $0 in the Amount field. If your organization doesn’t create $0 Opportunities, or use GAU Allocations, this change won’t affect your org. If NPSP automatically created any $0 GAU Allocations in your org before the 3.157 release was implemented in Production orgs (July 3), your data may be inconsistent. To check your data, run an Opportunity report with the following filters:
  - Amount = $0
  - Cross Filter for Opportunities **without** GAU Allocations

# Changes

# Issues Closed
- Fixes #4384
# New Metadata

# Deleted Metadata
