### PR TITLE
Advanced Mapping: Prevent non-boolean-style picklists from being mapped to booleans

### DIFF
--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -546,7 +546,7 @@ public class BDI_ManageAdvancedMappingCtrl {
         @AuraEnabled public String[] referenceToObjectList;
         @AuraEnabled public Boolean isBooleanMappable;
         private String[] picklistOptions = new String[]{};
-        private List<List<String>> allowedPicklistValues =
+        private List<List<String>> allowedPicklistOptions =
             new List<List<String>>{
                 new List<String>{'true', 'false'},
                 new List<String>{'yes', 'no'},
@@ -591,10 +591,10 @@ public class BDI_ManageAdvancedMappingCtrl {
 
                 picklistOptions.sort();
 
-                for (String[] allowedVals : allowedPicklistValues) {
-                    allowedVals.sort();
+                for (String[] allowedOptions : allowedPicklistOptions) {
+                    allowedOptions.sort();
 
-                    if (picklistOptions.equals(allowedVals)) {
+                    if (picklistOptions.equals(allowedOptions)) {
                         this.isBooleanMappable = true;
                     }
                 }

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -546,12 +546,11 @@ public class BDI_ManageAdvancedMappingCtrl {
         @AuraEnabled public String[] referenceToObjectList;
         @AuraEnabled public Boolean isBooleanMappable;
         private String[] picklistOptions = new String[]{};
+
+        // Restricting Picklist=>Bool mappings to only picklists with options 'true' and 'false'.
+        // Update BDI_DataImportService.copyDIFieldToDestinationRecord to handle more Picklist=>Bool mappings
         private List<List<String>> allowedPicklistOptions =
-            new List<List<String>>{
-                new List<String>{'true', 'false'},
-                new List<String>{'yes', 'no'},
-                new List<String>{'1', '0'},
-                new List<String>{'checked', 'unchecked'}};
+            new List<List<String>>{new List<String>{'true', 'false'}};
 
         public FieldInfo(DescribeFieldResult dfr) {
             this.value = dfr.getName();

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -544,6 +544,14 @@ public class BDI_ManageAdvancedMappingCtrl {
         @AuraEnabled public String value;
         @AuraEnabled public String displayType;
         @AuraEnabled public String[] referenceToObjectList;
+        @AuraEnabled public Boolean isBooleanMappable;
+        private String[] picklistOptions = new String[]{};
+        private List<List<String>> allowedPicklistValues =
+            new List<List<String>>{
+                new List<String>{'true', 'false'},
+                new List<String>{'yes', 'no'},
+                new List<String>{'1', '0'},
+                new List<String>{'checked', 'unchecked', 'null'}};
 
         public FieldInfo(DescribeFieldResult dfr) {
             this.value = dfr.getName();
@@ -566,6 +574,28 @@ public class BDI_ManageAdvancedMappingCtrl {
                         for (Schema.sObjectType objType : objTypes) {
                             this.referenceToObjectList.add(objType.getDescribe().getName().toLowerCase());
                         }
+                    }
+                }
+            }
+
+            if (dfr.getType() == Schema.DisplayType.PICKLIST) {
+                Set<String> picklistOptionsSet = new Set<String>();
+                Schema.PicklistEntry[] picklistEntry = dfr.getPicklistValues();
+
+                if (picklistEntry != null && picklistEntry.size() > 0) {
+                    for (Schema.PicklistEntry picklistValue : picklistEntry) {
+                        picklistOptionsSet.add(picklistValue.getLabel().toLowerCase());
+                    }
+                    picklistOptions.addAll(picklistOptionsSet);
+                }
+
+                picklistOptions.sort();
+
+                for (String[] allowedVals : allowedPicklistValues) {
+                    allowedVals.sort();
+
+                    if (picklistOptions.equals(allowedVals)) {
+                        this.isBooleanMappable = true;
                     }
                 }
             }

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -551,7 +551,7 @@ public class BDI_ManageAdvancedMappingCtrl {
                 new List<String>{'true', 'false'},
                 new List<String>{'yes', 'no'},
                 new List<String>{'1', '0'},
-                new List<String>{'checked', 'unchecked', 'null'}};
+                new List<String>{'checked', 'unchecked'}};
 
         public FieldInfo(DescribeFieldResult dfr) {
             this.value = dfr.getName();

--- a/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.html
+++ b/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.html
@@ -60,7 +60,7 @@
                                     name="sourceFieldLabel"
                                     search-input-label={customLabels.bdiFMUISearchSourceInputLabel}
                                     combobox-label={customLabels.bdiFMUIFieldLabel}
-                                    selected-field-value={selectedSourceFieldAPIName}
+                                    selected-field-value={fieldMapping.Source_Field_API_Name}
                                     options={sourceFieldLabelOptions}
                                     searchable-options={searchableSourceFieldLabelOptions}
                                     parent-listener-event-name="sourceFieldLabelChange"
@@ -68,13 +68,13 @@
                                     has-errors={hasSourceFieldErrors}>
                                 </c-util-searchable-combobox>
 
-                                <template if:true={selectedSourceFieldAPIName}>
+                                <template if:true={fieldMapping.Source_Field_API_Name}>
                                     <lightning-input
                                         name="source-field-data-type"
                                         label={customLabels.bdiFMUIDataType}
                                         type="text"
                                         read-only="true"
-                                        value={selectedSourceFieldDisplayTypeLabel}
+                                        value={fieldMapping.Source_Field_Display_Type_Label}
                                         class="slds-p-top_x-small"
                                         field-level-help={customLabels.bdiFMUISourceFieldDataTypeHelp}>
                                     </lightning-input>
@@ -102,7 +102,7 @@
                                     name="targetFieldLabel"
                                     search-input-label={customLabels.bdiFMUISearchTargetInputLabel}
                                     combobox-label={customLabels.bdiFMUIFieldLabel}
-                                    selected-field-value={selectedTargetFieldAPIName}
+                                    selected-field-value={fieldMapping.Target_Field_API_Name}
                                     options={targetFieldLabelOptions}
                                     parent-listener-event-name="targetFieldLabelChange"
                                     field-level-help={customLabels.bdiFMUITargetFieldLabelHelp}
@@ -110,13 +110,13 @@
                                     has-errors={hasTargetFieldErrors}>
                                 </c-util-searchable-combobox>
 
-                                <template if:true={selectedTargetFieldAPIName}>
+                                <template if:true={fieldMapping.Target_Field_API_Name}>
                                     <lightning-input
                                         name="target-field-data-type"
                                         label={customLabels.bdiFMUIDataType}
                                         type="text"
                                         read-only="true"
-                                        value={selectedTargetFieldDisplayTypeLabel}
+                                        value={fieldMapping.Target_Field_Display_Type_Label}
                                         class="slds-p-top_x-small"
                                         field-level-help={customLabels.bdiFMUITargetFieldDataTypeHelp}>
                                     </lightning-input>

--- a/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
+++ b/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
@@ -104,7 +104,6 @@ export default class bdiFieldMappingModal extends LightningElement {
         'Multipicklist': ['Multipicklist'],
         'Percent': ['Percent'],
         'Phone': ['Phone', 'String'],
-        // Todo: Add logic to only allow Picklist (True, False, Blank) => Boolean
         'Picklist': ['Picklist', 'Boolean'],
         'Reference': ['Reference', 'String'],
         'String': ['String', 'Picklist'],

--- a/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
+++ b/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
@@ -63,19 +63,19 @@ export default class bdiFieldMappingModal extends LightningElement {
     @track isLoading;
     @track row;
 
-    @track selectedSourceFieldLabel;
-    @track selectedSourceFieldAPIName;
+    @track fieldMapping = {
+        Source_Field_API_Name: undefined,
+        Source_Field_Label: undefined,
+        Source_Field_Display_Type_Label: undefined,
+        Target_Field_API_Name: undefined,
+        Target_Field_Label: undefined,
+        Target_Field_Display_Type_Label: undefined,
+    };
+
     @track sourceFieldLabelOptions;
     @track searchableSourceFieldLabelOptions;
-    @track selectedSourceFieldDisplayType;
-    @track selectedSourceFieldDisplayTypeLabel;
-    @track hasSourceFieldErrors;
-
-    @track selectedTargetFieldLabel;
-    @track selectedTargetFieldAPIName;
     @track targetFieldLabelOptions;
-    @track selectedTargetFieldDisplayType;
-    @track selectedTargetFieldDisplayTypeLabel;
+    @track hasSourceFieldErrors;
     @track hasTargetFieldErrors;
 
     @api diFieldsByAPIName;
@@ -111,7 +111,7 @@ export default class bdiFieldMappingModal extends LightningElement {
         'Textarea': ['Textarea', 'String'],
         'Time': ['Time'],
         'Url': ['Url', 'String']
-    };
+    }
 
     // Map of Labels by Display Type
     labelsByDisplayType = {
@@ -138,10 +138,10 @@ export default class bdiFieldMappingModal extends LightningElement {
         'Textarea': 'Text Area',
         'Time': 'Time',
         'Url': 'URL'
-    };
+    }
 
     get isTargetFieldDisabled() {
-        if ((this.selectedSourceFieldAPIName || this.selectedSourceFieldLabel) &&
+        if ((this.fieldMapping.Source_Field_API_Name || this.fieldMapping.Source_Field_Label) &&
             (this.targetFieldLabelOptions && this.targetFieldLabelOptions.length > 0)) {
             return false;
         }
@@ -212,23 +212,14 @@ export default class bdiFieldMappingModal extends LightningElement {
             this.mappedDiFieldDescribes = event.mappedDiFieldDescribes;
             this.targetObjectFieldDescribes = event.targetObjectFieldDescribes;
 
-            this.row = event.row;
-
-            if (this.row) {
-                // Edit row
+            if (event.row) {
+                // Edit field mapping
                 this.modalMode = 'edit';
-                this.selectedSourceFieldLabel = this.row.Source_Field_Label;
-                this.selectedSourceFieldAPIName = this.row.Source_Field_API_Name;
-                this.selectedTargetFieldAPIName = this.row.Target_Field_API_Name;
-                this.selectedTargetFieldLabel = this.row.Target_Field_Label;
-                this.selectedSourceFieldDisplayType = this.toTitleCase(this.row.Source_Field_Data_Type);
-                this.selectedTargetFieldDisplayType = this.toTitleCase(this.row.Target_Field_Data_Type);
-                this.selectedSourceFieldDisplayTypeLabel = this.row.Source_Field_Display_Type_Label;
-                this.selectedTargetFieldDisplayTypeLabel = this.row.Target_Field_Display_Type_Label;
+                this.fieldMapping = this.parse(event.row);
             } else {
-                // New row
+                // New field mapping
                 this.modalMode = 'new';
-                this.clearSelections();
+                this.fieldMapping = {};
             }
 
             this.getSourceFieldOptions(this.diFieldDescribes);
@@ -266,8 +257,7 @@ export default class bdiFieldMappingModal extends LightningElement {
             for (let i = 0; i < fieldInfos.length; i++) {
                 let labelOption = {
                     label: `${fieldInfos[i].label} (${fieldInfos[i].value})`,
-                    value: fieldInfos[i].value,
-                    displayTypeLabel: fieldInfos[i].displayTypeLabel
+                    value: fieldInfos[i].value
                 }
 
                 this.searchableSourceFieldLabelOptions.push(labelOption);
@@ -276,7 +266,7 @@ export default class bdiFieldMappingModal extends LightningElement {
                 // Include the data import field if it hasn't already been mapped
                 // or if it's the currently selected field (i.e. editing)
                 if (!this.mappedDiFieldDescribes.includes(fieldInfos[i].value.toLowerCase()) ||
-                    this.selectedSourceFieldLabel === fieldInfos[i].label) {
+                    this.fieldMapping.Source_Field_Label === fieldInfos[i].label) {
 
                     this.sourceFieldLabelOptions.push(labelOption);
                 }
@@ -305,7 +295,7 @@ export default class bdiFieldMappingModal extends LightningElement {
                 // Include the data import field if it hasn't already been mapped
                 // or if it's the currently selected field (i.e. editing)
                 if (!this.mappedTargetFieldApiNames.includes(fieldInfos[i].value) ||
-                    this.selectedTargetFieldLabel === fieldInfos[i].label) {
+                    this.fieldMapping.Target_Field_Label === fieldInfos[i].label) {
                     let labelOption = {
                         label: `${fieldInfos[i].label} (${fieldInfos[i].value})`,
                         value: fieldInfos[i].value
@@ -327,26 +317,12 @@ export default class bdiFieldMappingModal extends LightningElement {
             this.targetFieldsByAPIName = targetFieldsByAPIName;
             this.targetFieldsByLabelByDisplayType = targetFieldsByLabelByDisplayType;
 
-            if (this.selectedSourceFieldDisplayType) {
-                this.handleAvailableTargetFieldsBySourceFieldDisplayType(this.selectedSourceFieldDisplayType);
+            if (this.fieldMapping && this.fieldMapping.Source_Field_Display_Type) {
+                this.handleAvailableTargetFieldsBySourceFieldDisplayType(this.fieldMapping);
             }
         } catch(error) {
             this.handleError(error);
         }
-    }
-
-    /*******************************************************************************
-    * @description Clears out all the various "selected" properties
-    */
-    clearSelections() {
-        this.selectedSourceFieldLabel = undefined;
-        this.selectedSourceFieldAPIName = undefined;
-        this.selectedSourceFieldDisplayType = undefined;
-        this.selectedSourceFieldDisplayTypeLabel = undefined;
-        this.selectedTargetFieldLabel = undefined;
-        this.selectedTargetFieldAPIName = undefined;
-        this.selectedTargetFieldDisplayType = undefined;
-        this.selectedTargetFieldDisplayTypeLabel = undefined;
     }
 
     /*******************************************************************************
@@ -377,23 +353,19 @@ export default class bdiFieldMappingModal extends LightningElement {
             if (missingField.length === 0) {
                 let rowDetails;
 
-                if (this.row) {
+                if (this.modalMode === 'edit') {
                     // Set source and target fields
-                    this.row.Source_Field_API_Name =
-                        this.selectedSourceFieldAPIName;
-                    this.row.Target_Field_API_Name =
-                        this.selectedTargetFieldAPIName;
-                    rowDetails = JSON.stringify(this.row);
-                } else {
+                    rowDetails = JSON.stringify(this.fieldMapping);
+                } else if (this.modalMode === 'new') {
                     // New Field Mapping
                     rowDetails = JSON.stringify({
                         DeveloperName: null,
-                        MasterLabel: this.selectedSourceFieldLabel,
+                        MasterLabel: this.fieldMapping.Source_Field_Label,
                         Data_Import_Field_Mapping_Set: this.fieldMappingSetName,
                         Is_Deleted: false,
                         Required: 'No',
-                        Source_Field_API_Name: this.selectedSourceFieldAPIName,
-                        Target_Field_API_Name: this.selectedTargetFieldAPIName,
+                        Source_Field_API_Name: this.fieldMapping.Source_Field_API_Name,
+                        Target_Field_API_Name: this.fieldMapping.Target_Field_API_Name,
                         Target_Object_Mapping: this.objectMapping.DeveloperName
                     });
                 }
@@ -430,12 +402,14 @@ export default class bdiFieldMappingModal extends LightningElement {
         this.hasSourceFieldErrors = false;
         this.hasTargetFieldErrors = false;
 
-        if (!this.selectedSourceFieldAPIName) {
+        if (!this.fieldMapping.Source_Field_API_Name) {
             missingField = 'Source Field';
             this.hasSourceFieldErrors = true;
         }
-        if ((!this.selectedTargetFieldAPIName && !this.isTargetFieldDisabled) ||
-            (!this.selectedTargetFieldAPIName && this.isTargetFieldDisabled && this.selectedSourceFieldAPIName)) {
+        if ((!this.fieldMapping.Target_Field_API_Name && !this.isTargetFieldDisabled) ||
+            (!this.fieldMapping.Target_Field_API_Name &&
+            this.isTargetFieldDisabled &&
+            this.fieldMapping.Source_Field_API_Name)) {
 
             missingField = 'Target Field';
             this.hasTargetFieldErrors = true;
@@ -473,8 +447,9 @@ export default class bdiFieldMappingModal extends LightningElement {
     handleSourceFieldLabelChange(event) {
         if (event) {
             let existsInDiPicklist = this.sourceFieldLabelOptions.find(
-                option => option.value.toLowerCase() == event.detail.value.toLowerCase());
+                option => option.value.toLowerCase() === event.detail.value.toLowerCase());
 
+            // Add searchable option to picklist
             if (existsInDiPicklist === undefined) {
                 this.sourceFieldLabelOptions.push(event.detail);
                 this.sourceFieldLabelOptions = this.sortBy(this.sourceFieldLabelOptions, 'label');
@@ -482,22 +457,19 @@ export default class bdiFieldMappingModal extends LightningElement {
 
             let fieldAPIName = event.detail.value;
             let fieldInfo = this.diFieldsByAPIName[fieldAPIName];
+            let displayType = this.toTitleCase(fieldInfo.displayType);
 
-            this.selectedSourceFieldLabel = fieldInfo.label;
-            this.selectedSourceFieldAPIName = fieldAPIName;
-            this.selectedSourceFieldDisplayType = this.toTitleCase(fieldInfo.displayType);
-            this.selectedSourceFieldDisplayTypeLabel =
-                this.labelsByDisplayType[this.selectedSourceFieldDisplayType];
-            this.selectedTargetFieldAPIName = undefined;
+            this.fieldMapping = {
+                Source_Field_Label: fieldInfo.label,
+                Source_Field_API_Name: fieldAPIName,
+                Source_Field_Display_Type: displayType,
+                Source_Field_Display_Type_Label: this.labelsByDisplayType[displayType],
+                Target_Field_API_Name: undefined,
+            }
+
             this.hasSourceFieldErrors = false;
-        } else {
-            this.selectedSourceFieldAPIName = undefined;
-            this.selectedSourceFieldLabel = undefined;
-            this.selectedTargetFieldAPIName = undefined;
-            this.selectedSourceFieldDisplayType = undefined;
+            this.handleAvailableTargetFieldsBySourceFieldDisplayType(fieldInfo);
         }
-
-        this.handleAvailableTargetFieldsBySourceFieldDisplayType(this.selectedSourceFieldDisplayType);
     }
 
     /*******************************************************************************
@@ -505,9 +477,14 @@ export default class bdiFieldMappingModal extends LightningElement {
     *
     * @param {string} displayType: Display Type of the currently selected source field
     */
-    handleAvailableTargetFieldsBySourceFieldDisplayType(displayType) {
+    handleAvailableTargetFieldsBySourceFieldDisplayType(fieldInfo) {
         this.targetFieldLabelOptions = [];
-        let validTargetTypes = this.validTargetTypesBySourceType[displayType];
+        let validTargetTypes = this.validTargetTypesBySourceType[this.toTitleCase(fieldInfo.displayType)];
+
+        if (fieldInfo.displayType === 'PICKLIST' && !fieldInfo.isBooleanMappable) {
+            let index = validTargetTypes.indexOf('Boolean');
+            validTargetTypes.splice(index, 1);
+        }
 
         for (let i = 0; i < validTargetTypes.length; i++) {
             let validType = validTargetTypes[i];
@@ -527,17 +504,14 @@ export default class bdiFieldMappingModal extends LightningElement {
     */
     handleTargetFieldLabelChange(event) {
         if (event) {
-            this.selectedTargetFieldAPIName = event.detail.value;
-            let fieldInfo = this.targetFieldsByAPIName[this.selectedTargetFieldAPIName];
-            this.selectedTargetFieldLabel = fieldInfo.label;
-            this.selectedTargetFieldDisplayType = this.toTitleCase(fieldInfo.displayType);
-            this.selectedTargetFieldDisplayTypeLabel =
-                this.labelsByDisplayType[this.selectedTargetFieldDisplayType];
-            this.hasTargetFieldErrors = false;
-        } else {
-            this.selectedTargetFieldAPIName = undefined;
-            this.selectedTargetFieldLabel = undefined;
-            this.selectedTargetFieldDisplayType = undefined;
+            this.fieldMapping.Target_Field_API_Name = event.detail.value;
+            let fieldInfo = this.targetFieldsByAPIName[this.fieldMapping.Target_Field_API_Name];
+
+            this.fieldMapping.Target_Field_Label = fieldInfo.label;
+            this.fieldMapping.Target_Field_Display_Type = this.toTitleCase(fieldInfo.displayType);
+            this.fieldMapping.Target_Field_Display_Type_Label =
+                this.labelsByDisplayType[this.fieldMapping.Target_Field_Display_Type];
+            this.hasTargetFieldErrors = false
         }
     }
 


### PR DESCRIPTION
- Restrict picklist to boolean mappings. Allow only if the picklist options match one of the following sets: true, false OR yes, no OR 1, 0 OR checked, unchecked, null.

# Critical Changes

# Changes
## NPSP Data Import Enhancements
- We updated Field Mapping in Advanced Mapping so an NPSP Data Import picklist must have boolean values if it’s mapping to a checkbox field. When a user selects a picklist as the NPSP Data Import field that maps to a checkbox on the target object, the picklist options must be True or False.

# Issues Closed

# New Metadata

# Deleted Metadata
