### PR TITLE
RD2: Unit Test fix for LmoToSubscriber Feature Parameter

### DIFF
--- a/src/classes/UTIL_FeatureManagement_TEST.cls
+++ b/src/classes/UTIL_FeatureManagement_TEST.cls
@@ -80,12 +80,12 @@ public with sharing class UTIL_FeatureManagement_TEST {
     private static void shouldCallCheckPackageBooleanValue() {
         UTIL_FeatureManagement featureMgt = new UTIL_FeatureManagement();
 
-        featureMgt.setPackageBooleanValue( UTIL_FeatureEnablement.FeatureName.PilotEnabled.name(),
+        featureMgt.setPackageBooleanValue( UTIL_OrgTelemetry_SVC.TelemetryParameterName.IsEnabled_AddressVerification.name(),
             true
         );
 
         System.assertEquals(true,
-            new UTIL_FeatureEnablement().isEnabled(UTIL_FeatureEnablement.FeatureName.PilotEnabled.name()));
+            new UTIL_FeatureEnablement().isEnabled(UTIL_OrgTelemetry_SVC.TelemetryParameterName.IsEnabled_AddressVerification.name()));
     }
 
     /*******************************************************************************************************************

--- a/src/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls
@@ -33,7 +33,7 @@
 * @group Utilities
 * @description Unit Tests related to the org telemetry class
 */
-@IsTest(IsParallel=true)
+@IsTest
 private class UTIL_OrgTelemetry_TEST {
 
     private static UTIL_FeatureManagement_TEST.Mock featureManagementMock = new UTIL_FeatureManagement_TEST.Mock();


### PR DESCRIPTION
Because `IsPilotEnabled` is an LmoToSubscriber var it's not possible to set the feature parameter from within the managed package. It _should_ be possible to use the checkFeatureParameterBoolean() on a SubscriberToLmo feature parameter though. Only one real way to find out.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
