### PR TITLE
Advanced Mapping: Fix reciprocal relationship bug when BDI DI import fires relationship triggers

### DIFF
--- a/src/classes/BDI_TargetFields.cls
+++ b/src/classes/BDI_TargetFields.cls
@@ -49,7 +49,7 @@ public class BDI_TargetFields {
         SObjectField fieldToken;
 
         objectToken = UTIL_Describe.getObjectDescribe(objName).getSObjectType();
-        fieldToken = UTIL_Describe.getFieldDescribe(objName, fieldName).getSobjectField();
+        fieldToken = UTIL_Describe.getFieldDescribe(objName, fieldName.toLowerCase()).getSobjectField();
 
         if (targetFieldsByTargetObject.get(objectToken) == null) {
             targetFieldsByTargetObject.put(objectToken, new Set<SObjectField>{fieldToken});


### PR DESCRIPTION
Fixes a bug where the system created reciprocal relationship record would have the contact and related contact fields point to the same contact when the first relationship record was created via the BDI import process.

# Critical Changes

# Changes
- Lowercase string when using UTIL_Describe to get field describe details
# Issues Closed

# New Metadata

# Deleted Metadata
