### PR TITLE
Feature/bdi support formulas as source fields

### DIFF
--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -202,9 +202,9 @@ public class BDI_ManageAdvancedMappingCtrl {
 
         for (String key : fieldDescribes.keySet()) {
 
-            //Only include fields that are createable by the current user
-            //This will filter out System / formula fields
-            if (fieldDescribes.get(key).isCreateable()) {
+            //Only include fields that are createable by the current user or formula fields.
+            //Formula fields can be selectively excluded later by the calling component.
+            if (fieldDescribes.get(key).isCreateable() || fieldDescribes.get(key).isCalculated()) {
                 fieldInfos.add(new FieldInfo(fieldDescribes.get(key),includeReferenceToObjectList));
             }
         }
@@ -545,6 +545,7 @@ public class BDI_ManageAdvancedMappingCtrl {
         @AuraEnabled public String displayType;
         @AuraEnabled public String[] referenceToObjectList;
         @AuraEnabled public Boolean isBooleanMappable;
+        @AuraEnabled public Boolean isFormula;
         private String[] picklistOptions = new String[]{};
 
         // Restricting Picklist=>Bool mappings to only picklists with options 'true' and 'false'.
@@ -556,12 +557,14 @@ public class BDI_ManageAdvancedMappingCtrl {
             this.value = dfr.getName();
             this.label = dfr.getLabel();
             this.displayType = dfr.getType().name();
+            this.isFormula = dfr.isCalculated();
         }
 
         public FieldInfo(DescribeFieldResult dfr, Boolean includeReferenceToObjectList) {
             this.value = dfr.getName();
             this.label = dfr.getLabel();
             this.displayType = dfr.getType().name();
+            this.isFormula = dfr.isCalculated();
 
             if (includeReferenceToObjectList) {
                 this.referenceToObjectList = new String[]{};

--- a/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
@@ -358,7 +358,7 @@ private class BDI_ManageAdvancedMappingCtrl_TEST {
         if (fieldMap != null) {
             for (Schema.SObjectField ft : fieldMap.values()) {
                 Schema.DescribeFieldResult fieldDescribe = ft.getDescribe();
-                if (fieldDescribe.isCreateable()) {
+                if (fieldDescribe.isCreateable() || fieldDescribe.isCalculated()) {
                     creatableFields.add(fieldDescribe.getName());
                 }
             }

--- a/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
+++ b/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
@@ -291,10 +291,11 @@ export default class bdiFieldMappingModal extends LightningElement {
 
             for (let i = 0; i < fieldInfos.length; i++) {
 
-                // Include the data import field if it hasn't already been mapped
+                // Include the data import field if it isn't a formula and hasn't already been mapped
                 // or if it's the currently selected field (i.e. editing)
-                if (!this.mappedTargetFieldApiNames.includes(fieldInfos[i].value) ||
-                    this.fieldMapping.Target_Field_Label === fieldInfos[i].label) {
+                if (!fieldInfos[i].isFormula && 
+                    (!this.mappedTargetFieldApiNames.includes(fieldInfos[i].value) ||
+                    this.fieldMapping.Target_Field_Label === fieldInfos[i].label)) {
                     let labelOption = {
                         label: `${fieldInfos[i].label} (${fieldInfos[i].value})`,
                         value: fieldInfos[i].value

--- a/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
+++ b/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
@@ -534,7 +534,8 @@ export default class bdiObjectMappingModal extends LightningElement {
             for (let i = 0; i < this.dataImportFieldData.length; i++) {
                 let fieldData = this.dataImportFieldData[i];
 
-                if (!fieldsToExclude.has(fieldData.value.toLowerCase())) {
+                //Exclude formula fields and any field which is explicitly excluded.
+                if (!fieldsToExclude.has(fieldData.value.toLowerCase()) && !fieldData.isFormula) {
                     let labelOption = {
                         label: fieldData.label + ' (' + fieldData.value + ')',
                         value: fieldData.value


### PR DESCRIPTION
Made a change in the controller to allow fields with isCalculated = true into the field describe results, then added an attribute to the fieldinfo class so they could be identified.  Also explicitly excluded formula fields from making it into the list for target field options, or any of the object group field selection.

# Critical Changes

# Changes

- In Advanced Mapping, we added the ability to use formula fields as the source field on the NPSP Data Import object. A formula source field can be mapped to a writable target field.

# Issues Closed

# New Metadata

# Deleted Metadata
