### PR TITLE
Accounts should be households so they match.

### DIFF
--- a/datasets/bdi_benchmark/mapping.yml
+++ b/datasets/bdi_benchmark/mapping.yml
@@ -1,12 +1,12 @@
-Accounts:
+Households:
     sf_object: Account
-    table: accounts
+    table: households
     fields:
         Name: name
         BillingStreet: BillingStreet
         BillingCountry: BillingCountry
         description: description
-    record_type: Organization
+    record_type: HH_Account
 Contacts:
     sf_object: Contact
     table: contacts

--- a/tasks/generate_bdi_data.py
+++ b/tasks/generate_bdi_data.py
@@ -77,9 +77,12 @@ class GenerateBDIData(ModuleDataFactory):
         )
 
 
+# Households for matching
 class AccountFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
-        model = Models.accounts
+        model = Models.households
+
+    record_type = "HH_Account"
 
 
 class ContactFactory(factory.alchemy.SQLAlchemyModelFactory):


### PR DESCRIPTION
I remember now that the reason that the Accounts should not be Organizations is because they are intended to match during the BDI import process. I don't know for sure that it demands that all matching Accounts be Households, but it is certainly the most common case for the matching code.