### PR TITLE
Corrected spelling error

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -7070,7 +7070,7 @@ Once the process is 100% complete, you can safely leave or refresh this page.</v
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>stgHelpErrorNotifyOn</shortDescription>
-        <value>When selected, NPSP will display notifications for certain types of errrors.</value>
+        <value>When selected, NPSP will display notifications for certain types of errors.</value>
     </labels>
     <labels>
         <fullName>stgHelpErrorNotifyTo</fullName>


### PR DESCRIPTION
Corrected a spelling error in custom labels. Error was in NPSP Settings > System Tools > Error Notifications > Error Notification checkbox description: "When selected, NPSP will display notifications for certain types of **errrors**"

# Critical Changes

# Changes

 - We corrected a checkbox description spelling error in NPSP Settings > System Tools > Error Notifications.

# Issues Closed

# New Metadata

# Deleted Metadata
