### PR TITLE
fix bug loading npsp settings when deployment ID is invalid

### DIFF
--- a/src/classes/STG_PanelDataImportAdvancedMapping_CTRL.cls
+++ b/src/classes/STG_PanelDataImportAdvancedMapping_CTRL.cls
@@ -306,8 +306,12 @@ public with sharing class STG_PanelDataImportAdvancedMapping_CTRL extends STG_Pa
     */
     private void setDeploymentStatus() {
         if (dataImportSettings.CMT_Deployment_ID__c != null) {
-            deploymentResult =
-                CMT_MetadataAPI.getDeploymentResult(dataImportSettings.CMT_Deployment_ID__c);
+            try {
+                deploymentResult =
+                    CMT_MetadataAPI.getDeploymentResult(dataImportSettings.CMT_Deployment_ID__c);
+            } catch (Exception e) {
+                deploymentResult = null;
+            }
         }
     }
 


### PR DESCRIPTION
# Critical Changes

Handles errors when attempting to retrieve deployment status from within the NPSP settings page, allowing the settings to load without a blocking error

# Changes

# Issues Closed

4699
4623

# New Metadata

# Deleted Metadata
