### PR TITLE
Feature/gift entry  rename bdi classes and create wrappers

### DIFF
--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -41,7 +41,7 @@ public with sharing class BDI_AdditionalObjectService {
     * @description the data import service we are invoked from
     */
     private BDI_DataImportService dataImportService;
-    private BDI_FieldMappingCustomMetadata fieldMappingCustomMetadata;
+    private BDI_MappingServiceAdvanced fieldMappingCustomMetadata;
 
     private Map<Integer,Map<String,Data_Import_Object_Mapping__mdt>> objMappingsByTier = new Map<Integer,Map<String,Data_Import_Object_Mapping__mdt>>();
     private Map<String,Map<String,Data_Import_Object_Mapping__mdt>> successorObjMappingsByPredecessorName = new Map<String,Map<String,Data_Import_Object_Mapping__mdt>>();
@@ -55,7 +55,7 @@ public with sharing class BDI_AdditionalObjectService {
     */
     public BDI_AdditionalObjectService(BDI_DataImportService dataImportService) {
         this.dataImportService = dataImportService;
-        this.fieldMappingCustomMetadata = BDI_FieldMappingCustomMetadata.getInstance();
+        this.fieldMappingCustomMetadata = BDI_MappingServiceAdvanced.getInstance();
     }
 
 

--- a/src/classes/BDI_AdditionalObjectService_TEST.cls
+++ b/src/classes/BDI_AdditionalObjectService_TEST.cls
@@ -214,7 +214,7 @@ private class BDI_AdditionalObjectService_TEST {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c = 
-            BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+            BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
         Test.StartTest();
@@ -379,7 +379,7 @@ private class BDI_AdditionalObjectService_TEST {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c = 
-            BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+            BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
         DataImport__c testDataImportA;
@@ -526,12 +526,12 @@ private class BDI_AdditionalObjectService_TEST {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c = 
-                                    BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+                                    BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
         DataImport__c[] diRecords = Database.query(BDI_DataImportService.strSoqlForBatchProcess(null));
 
-        BDI_DataImportService bdiDIS = new BDI_DataImportService(false, BDI_DataImportService.getDefaultFieldMapping());
+        BDI_DataImportService bdiDIS = new BDI_DataImportService(false, BDI_DataImportService.getDefaultMappingService());
         bdiDIS.process(null, dis, diRecords);
         
         DataImport__c testDataImportAResult;
@@ -766,14 +766,14 @@ private class BDI_AdditionalObjectService_TEST {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c = 
-            BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+            BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
         DataImport__c[] diRecords = Database.query(BDI_DataImportService.strSoqlForBatchProcess(null));
 
-        BDI_DataImportService bdiDIS = new BDI_DataImportService(false, BDI_DataImportService.getDefaultFieldMapping());
+        BDI_DataImportService bdiDIS = new BDI_DataImportService(false, BDI_DataImportService.getDefaultMappingService());
         
-        BDI_FieldMappingCustomMetadata bdiFMCM = BDI_FieldMappingCustomMetadata.getInstance();
+        BDI_MappingServiceAdvanced bdiFMCM = BDI_MappingServiceAdvanced.getInstance();
 
         String[] objMappingNames = new List<String>(bdiFMCM.objMappingsByDevName.keySet());
         Data_Import_Object_Mapping__mdt predecessorObjMapping = bdiFMCM.objMappingsByDevName.get('Opportunity');
@@ -975,7 +975,7 @@ private class BDI_AdditionalObjectService_TEST {
         BDI_DataImportService dataImportService =
                 new BDI_DataImportService(
                         false,
-                        BDI_FieldMappingCustomMetadata.getInstance());
+                        BDI_MappingServiceAdvanced.getInstance());
 
         BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);
 
@@ -1020,7 +1020,7 @@ private class BDI_AdditionalObjectService_TEST {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c =
-                BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+                BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         dis.Donation_Matching_Behavior__c = BDI_DataImport_API.ExactMatchOrCreate;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
@@ -1118,7 +1118,7 @@ private class BDI_AdditionalObjectService_TEST {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c =
-                BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+                BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         dis.Donation_Matching_Behavior__c = BDI_DataImport_API.ExactMatchOrCreate;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
@@ -1217,7 +1217,7 @@ private class BDI_AdditionalObjectService_TEST {
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c =
-                BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+                BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         dis.Donation_Matching_Behavior__c = BDI_DataImport_API.ExactMatchOrCreate;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 

--- a/src/classes/BDI_DataImportFLSService.cls
+++ b/src/classes/BDI_DataImportFLSService.cls
@@ -49,10 +49,10 @@ public class BDI_DataImportFLSService {
     }
 
     public BDI_DataImportFLSService(List<DataImport__c> dataImports,
-            BDI_FieldMapping fieldMapping,
+            BDI_MappingService mappingService,
             Set<AccessLevel> accessLevels){
         this.accessLevels = accessLevels;
-        this.targetFieldsBySObjectFields = fieldMapping.getTargetFieldsBySourceField();
+        this.targetFieldsBySObjectFields = mappingService.getTargetFieldsBySourceField();
         this.dataImportsValidated = new List<DataImport__c>();
         this.dataImportsInvalidated = new List<DataImport__c>();
         this.invalidFieldsByDataImportId = new Map<Id, List<SObjectFieldWrapper>>();

--- a/src/classes/BDI_DataImportFLSService_TEST.cls
+++ b/src/classes/BDI_DataImportFLSService_TEST.cls
@@ -54,7 +54,7 @@ private class BDI_DataImportFLSService_TEST {
                 new List<DataImport__c>{
                         dataImport
                 },
-                BDI_FieldMappingCustomMetadata.getInstance(),
+                BDI_MappingServiceAdvanced.getInstance(),
                 accessLevels
         );
 
@@ -83,7 +83,7 @@ private class BDI_DataImportFLSService_TEST {
                     new List<DataImport__c>{
                             dataImport
                     },
-                    BDI_FieldMappingCustomMetadata.getInstance(),
+                    BDI_MappingServiceAdvanced.getInstance(),
                     accessLevels
             );
 
@@ -125,7 +125,7 @@ private class BDI_DataImportFLSService_TEST {
         //Process the Data Import record
         BDI_DataImportService dataImportService = new BDI_DataImportService(
                 false,
-                BDI_DataImportService.getDefaultFieldMapping());
+                BDI_DataImportService.getDefaultMappingService());
         dataImportService.process(
                 null,
                 BDI_DataImportService.loadSettings(null),

--- a/src/classes/BDI_DataImportService.cls
+++ b/src/classes/BDI_DataImportService.cls
@@ -41,18 +41,18 @@ global with sharing class BDI_DataImportService {
     public static final String FM_HELP_TEXT = 'Help Text';
     public static final String FM_DATA_IMPORT_FIELD_MAPPING = 'Data Import Field Mapping';
 
-    public BDI_FieldMapping fieldMapper;
+    public BDI_MappingService mappingService;
 
     /*******************************************************************************************************
     * @description constructor
     * @param isDryRun whether to run in Dry Run mode or commit records.
     */
-    public BDI_DataImportService(Boolean isDryRun, BDI_FieldMapping fieldMapper) {
+    public BDI_DataImportService(Boolean isDryRun, BDI_MappingService mappingService) {
         this.isDryRun = isDryRun;
-        this.fieldMapper = fieldMapper;
+        this.mappingService = mappingService;
 
         contactService = new BDI_ContactService(this);
-        if (fieldMapper instanceof BDI_FieldMappingCustomMetadata){
+        if (mappingService instanceof BDI_MappingServiceAdvanced){
             additionalObjectService = new BDI_AdditionalObjectService(this);
         }
     }
@@ -61,15 +61,15 @@ global with sharing class BDI_DataImportService {
     * @description queries the Data Import Settings custom setting to determine what type of field mapping to
     * use.
     */
-    public static BDI_FieldMapping getDefaultFieldMapping() {
-        BDI_FieldMapping bdiFm;
+    public static BDI_MappingService getDefaultMappingService() {
+        BDI_MappingService bdiMS;
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         if (dis.Field_Mapping_Method__c == FM_HELP_TEXT) {
-            bdiFm = BDI_FieldMappingHelpText.getInstance();
+            bdiMS = BDI_MappingServiceHelpText.getInstance();
         }else if (dis.Field_Mapping_Method__c == FM_DATA_IMPORT_FIELD_MAPPING) {
-            bdiFm = BDI_FieldMappingCustomMetadata.getInstance();
+            bdiMS = BDI_MappingServiceAdvanced.getInstance();
         }
-        return bdiFm;
+        return bdiMS;
     }
 
     /*******************************************************************************************************
@@ -531,7 +531,7 @@ global with sharing class BDI_DataImportService {
 
             this.flsService = new BDI_DataImportFLSService(
                     dataImports,
-                    fieldMapper,
+                    mappingService,
                     getFieldAccessLevelsToValidate()
             );
 
@@ -808,7 +808,7 @@ global with sharing class BDI_DataImportService {
                 String targetObjectName, 
                 List<String> dataImportFields) {
         
-        BDI_DataImportService bdi = new BDI_DataImportService(true, BDI_DataImportService.getDefaultFieldMapping());
+        BDI_DataImportService bdi = new BDI_DataImportService(true, BDI_DataImportService.getDefaultMappingService());
         return bdi.mapDataImportFields(dataImportObjectName, targetObjectName, dataImportFields);
     }
 
@@ -825,7 +825,7 @@ global with sharing class BDI_DataImportService {
                 String targetObjectName, 
                 List<String> dataImportFields) {
         
-        Map<String, String> targetFieldByDIField = fieldMapper.getFieldMap(dataImportObjectName, targetObjectName, dataImportFields);
+        Map<String, String> targetFieldByDIField = mappingService.getFieldMap(dataImportObjectName, targetObjectName, dataImportFields);
 
         return targetFieldByDIField;
     }    

--- a/src/classes/BDI_DataImportService_TEST.cls
+++ b/src/classes/BDI_DataImportService_TEST.cls
@@ -74,7 +74,7 @@ private with sharing class BDI_DataImportService_TEST {
         diSettings.Run_Opportunity_Rollups_while_Processing__c = true;
 
         Boolean isDryRun = false;
-        BDI_DataImportService service = new BDI_DataImportService(isDryRun, BDI_FieldMappingHelpText.getInstance());
+        BDI_DataImportService service = new BDI_DataImportService(isDryRun, BDI_MappingServiceHelpText.getInstance());
         service.injectDataImportSettings(diSettings);
 
         List<Trigger_Handler__c> expectedHandlers = TDTM_Config_API.getCachedRecords();
@@ -94,7 +94,7 @@ private with sharing class BDI_DataImportService_TEST {
         diSettings.Run_Opportunity_Rollups_while_Processing__c = false;
 
         Boolean isDryRun = false;
-        BDI_DataImportService service = new BDI_DataImportService(isDryRun, BDI_FieldMappingHelpText.getInstance());
+        BDI_DataImportService service = new BDI_DataImportService(isDryRun, BDI_MappingServiceHelpText.getInstance());
         service.injectDataImportSettings(diSettings);
 
         Map<String, Trigger_Handler__c> handlerByKey = new Map<String, Trigger_Handler__c>();

--- a/src/classes/BDI_DataImport_API.cls
+++ b/src/classes/BDI_DataImport_API.cls
@@ -120,7 +120,7 @@ global with sharing class BDI_DataImport_API {
     */
     global static void processDataImportRecords(Data_Import_Settings__c diSettings, List<DataImport__c> listDI, Boolean isDryRun) {
         BDI_DataImportService bdi = new BDI_DataImportService(isDryRun, 
-            BDI_DataImportService.getDefaultFieldMapping());
+            BDI_DataImportService.getDefaultMappingService());
         bdi.process(null, diSettings, listDI);
     }
 

--- a/src/classes/BDI_DataImport_BATCH.cls
+++ b/src/classes/BDI_DataImport_BATCH.cls
@@ -82,7 +82,7 @@ public class BDI_DataImport_BATCH implements Database.Batchable<sObject> {
     * @param isDryRun whether to run in Dry Run mode or commit records.
     */
     public BDI_DataImport_BATCH(ID batchId, Boolean isDryRun) {
-        this(batchId, new BDI_DataImportService(isDryRun, BDI_DataImportService.getDefaultFieldMapping()));
+        this(batchId, new BDI_DataImportService(isDryRun, BDI_DataImportService.getDefaultMappingService()));
     }
 
     /*******************************************************************************************************

--- a/src/classes/BDI_DataImport_TEST.cls
+++ b/src/classes/BDI_DataImport_TEST.cls
@@ -1350,7 +1350,7 @@ public with sharing class BDI_DataImport_TEST {
         //run batch data import
         Test.StartTest();
         BDI_DataImportService dataImportService = 
-            new BDI_DataImportService(true, BDI_FieldMappingHelpText.getInstance());
+            new BDI_DataImportService(true, BDI_MappingServiceHelpText.getInstance());
 
         BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);
         ID ApexJobId = Database.executeBatch(bdi, 10);
@@ -1459,7 +1459,7 @@ public with sharing class BDI_DataImport_TEST {
         //run batch data import
         Test.StartTest();
         BDI_DataImportService dataImportService = 
-            new BDI_DataImportService(true, BDI_FieldMappingHelpText.getInstance());
+            new BDI_DataImportService(true, BDI_MappingServiceHelpText.getInstance());
 
         BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);
         ID ApexJobId = Database.executeBatch(bdi, 10);
@@ -1507,13 +1507,13 @@ public with sharing class BDI_DataImport_TEST {
 
         // create import service for dry run
         BDI_DataImportService dataImportService = 
-            new BDI_DataImportService(true, BDI_FieldMappingHelpText.getInstance());
+            new BDI_DataImportService(true, BDI_MappingServiceHelpText.getInstance());
 
         BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);
         ID ApexJobId = Database.executeBatch(bdi, 10);
         
         // create import service without dry run
-        dataImportService = new BDI_DataImportService(false, BDI_FieldMappingHelpText.getInstance());
+        dataImportService = new BDI_DataImportService(false, BDI_MappingServiceHelpText.getInstance());
         bdi = new BDI_DataImport_BATCH(dataImportService);
         ID ApexJobId2 = Database.executeBatch(bdi, 10);
         Test.stopTest();

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -1397,7 +1397,7 @@ private with sharing class BDI_DataImport_TEST2 {
         System.runAs(readOnlyUser) {
             //run batch data import
             Test.StartTest();
-            BDI_FieldMapping fieldMapper = BDI_FieldMappingHelpText.getInstance();
+            BDI_MappingService fieldMapper = BDI_MappingServiceHelpText.getInstance();
             BDI_DataImportService dataImportService =
                     new BDI_DataImportService(false, fieldMapper);
             BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);
@@ -1435,7 +1435,7 @@ private with sharing class BDI_DataImport_TEST2 {
         System.runAs(readOnlyUser) {
             //run batch data import
             Test.StartTest();
-            BDI_FieldMapping fieldMapper = BDI_FieldMappingCustomMetadata.getInstance();
+            BDI_MappingService fieldMapper = BDI_MappingServiceAdvanced.getInstance();
             BDI_DataImportService dataImportService =
                     new BDI_DataImportService(false, fieldMapper);
             BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);

--- a/src/classes/BDI_Donations_TEST.cls
+++ b/src/classes/BDI_Donations_TEST.cls
@@ -108,7 +108,7 @@ public with sharing class BDI_Donations_TEST {
         diSettings.Donation_Matching_Behavior__c = BDI_DataImport_API.RequireNoMatch;
         diSettings.Run_Opportunity_Rollups_while_Processing__c = true;
 
-        BDI_FieldMappingHelpText fieldMapper = BDI_FieldMappingHelpText.getInstance();
+        BDI_MappingServiceHelpText fieldMapper = BDI_MappingServiceHelpText.getInstance();
 
         // manually insert checkbox field mapping
         fieldMapper.addMappedField('Opportunity', 
@@ -200,7 +200,7 @@ public with sharing class BDI_Donations_TEST {
         diSettings.Donation_Matching_Behavior__c = BDI_DataImport_API.RequireNoMatch;
         diSettings.Run_Opportunity_Rollups_while_Processing__c = true;
 
-        BDI_FieldMappingHelpText fieldMapper = BDI_FieldMappingHelpText.getInstance();
+        BDI_MappingServiceHelpText fieldMapper = BDI_MappingServiceHelpText.getInstance();
 
         // manually insert checkbox field mapping
         fieldMapper.addMappedField('Opportunity', 

--- a/src/classes/BDI_FieldMapping.cls
+++ b/src/classes/BDI_FieldMapping.cls
@@ -1,10 +1,10 @@
 /*
     Copyright (c) 2019 Salesforce.org
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -13,18 +13,18 @@
     * Neither the name of Salesforce.org nor the names of
       its contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 */
 /**
@@ -32,27 +32,54 @@
 * @date 2019
 * @group Batch Data Import
 * @group-content ../../ApexDocContent/BatchDataImport.htm
-* @description define behaviors of field mapping classes
+* @description Wrapper class to hold data related to the field mapping 
 */
+public with sharing class BDI_FieldMapping {
+    @AuraEnabled public String DeveloperName;
+    @AuraEnabled public String MasterLabel;
+    @AuraEnabled public String Source_Field_Label;
+    @AuraEnabled public String Source_Field_API_Name;
+    @AuraEnabled public String Source_Field_Data_Type;
+    @AuraEnabled public String Target_Field_Label;
+    @AuraEnabled public String Target_Field_API_Name;
+    @AuraEnabled public String Target_Field_Data_Type;
+    @AuraEnabled public String Data_Import_Field_Mapping_Set;
+    @AuraEnabled public String Target_Object_Mapping_Dev_Name;
+    @AuraEnabled public String Required;
+    @AuraEnabled public Boolean Is_Deleted;
+    @AuraEnabled public String Source_Field_Display_Type_Label;
+    @AuraEnabled public String Target_Field_Display_Type_Label;
 
-public interface BDI_FieldMapping {
+    public BDI_FieldMapping(Data_Import_Field_Mapping__mdt fieldMapping) {
+        String dataImport = SobjectType.DataImport__c.Name;
+        String objectAPIName = fieldMapping.Target_Object_Mapping__r.Object_API_Name__c;
+        String sourceFieldAPIName = fieldMapping.Source_Field_API_Name__c;
+        String targetFieldAPIName = fieldMapping.Target_Field_API_Name__c;
 
-    /*******************************************************************************************************
-    * @description For the provided fields (in the form DIObject.developerfieldname) and target object, 
-    * return a map of DI field (key) to mapped field name on the destination record (value). 
-    *
-    * @param dataImportObjectName the bdi object we care about (Contact1, Contact2, Account1, etc)
-    * @param targetObjectName the underlying object the bdi object is (ie, Contact, Account, etc)
-    * @param dataImportFields the DataImport fields to consider
-    * @return Map<String, String> a map of DataImport fields to underlying object fields (eg, Donation_Amount__c => Amount)
-    */ 
-    Map<String,String> getFieldMap(String dataImportObjectName, 
-            String targetObjectName, 
-            List<String> dataImportFields);
+        Schema.DescribeFieldResult sourceFieldDescribe = UTIL_Describe.getFieldDescribe(
+            dataImport,
+            sourceFieldAPIName);
 
-    /*******************************************************************************************************
-    * @description Produces a map of fields to target field wrappers that contain mapped target fields
-    * with target object data.
-    */
-    Map<SObjectField, BDI_TargetFields> getTargetFieldsBySourceField();
+        Schema.DescribeFieldResult targetFieldDescribe = UTIL_Describe.getFieldDescribe(
+            objectAPIName,
+            targetFieldAPIName);
+
+        this.DeveloperName = fieldMapping.DeveloperName;
+        this.MasterLabel = fieldMapping.MasterLabel;
+
+        this.Source_Field_Label = sourceFieldDescribe.label;
+        this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name__c;
+        this.Source_Field_Data_Type = String.valueOf(sourceFieldDescribe.type);
+        this.Source_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Source_Field_Data_Type);
+
+        this.Target_Field_Label = targetFieldDescribe.label;
+        this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name__c;
+        this.Target_Field_Data_Type = String.valueOf(targetFieldDescribe.type);
+        this.Target_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Target_Field_Data_Type);
+
+        this.Data_Import_Field_Mapping_Set = fieldMapping.Data_Import_Field_Mapping_Set__r.DeveloperName;
+        this.Target_Object_Mapping_Dev_Name = fieldMapping.Target_Object_Mapping__r.DeveloperName;
+        this.Required = fieldMapping.Required__c;
+        this.Is_Deleted = fieldMapping.Is_Deleted__c;
+    }
 }

--- a/src/classes/BDI_FieldMapping.cls
+++ b/src/classes/BDI_FieldMapping.cls
@@ -70,12 +70,12 @@ public with sharing class BDI_FieldMapping {
         this.Source_Field_Label = sourceFieldDescribe.label;
         this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name__c;
         this.Source_Field_Data_Type = String.valueOf(sourceFieldDescribe.type);
-        this.Source_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Source_Field_Data_Type);
+        this.Source_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Source_Field_Data_Type);
 
         this.Target_Field_Label = targetFieldDescribe.label;
         this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name__c;
         this.Target_Field_Data_Type = String.valueOf(targetFieldDescribe.type);
-        this.Target_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Target_Field_Data_Type);
+        this.Target_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Target_Field_Data_Type);
 
         this.Data_Import_Field_Mapping_Set = fieldMapping.Data_Import_Field_Mapping_Set__r.DeveloperName;
         this.Target_Object_Mapping_Dev_Name = fieldMapping.Target_Object_Mapping__r.DeveloperName;

--- a/src/classes/BDI_FieldMappingSet.cls
+++ b/src/classes/BDI_FieldMappingSet.cls
@@ -1,0 +1,74 @@
+/*
+    Copyright (c) 2019 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2019
+* @group Batch Data Import
+* @group-content ../../ApexDocContent/BatchDataImport.htm
+* @description Wrapper class to hold data related to the field mapping set.
+*/
+public with sharing class BDI_FieldMappingSet {
+    @AuraEnabled public String DeveloperName;
+    @AuraEnabled public String MasterLabel;
+    @AuraEnabled public Id Id;
+    @AuraEnabled public String Data_Import_Object_Mapping_Group_Dev_Name;
+
+    @AuraEnabled public Map<String,BDI_ObjectMapping> objectMappingByDevName = new Map<String,BDI_ObjectMapping>();
+    @AuraEnabled public Map<String,BDI_FieldMapping> fieldMappingByDevName = new Map<String,BDI_FieldMapping>();
+    @AuraEnabled public Map<String,BDI_FieldMapping[]> fieldMappingsByObjMappingDevName = new Map<String,BDI_FieldMapping[]>();
+
+    public BDI_FieldMappingSet(Data_Import_Field_Mapping_Set__mdt fieldMappingSet, 
+                                Data_Import_Object_Mapping__mdt[] diObjectMappings,
+                                Data_Import_Field_Mapping__mdt[] diFieldMappings) {
+
+        this.DeveloperName = fieldMappingSet.DeveloperName;
+        this.MasterLabel = fieldMappingSet.MasterLabel;
+        this.Id = fieldMappingSet.Id;
+        this.Data_Import_Object_Mapping_Group_Dev_Name = fieldMappingSet.Data_Import_Object_Mapping_Set__r.DeveloperName;
+
+        for (Data_Import_Object_Mapping__mdt diObjectMapping : diObjectMappings) {
+            BDI_ObjectMapping objectMapping = new BDI_ObjectMapping(diObjectMapping);
+            this.objectMappingByDevName.put(objectMapping.DeveloperName,objectMapping);
+        }
+
+        for (Data_Import_Field_Mapping__mdt diFieldMapping : diFieldMappings) {
+            BDI_FieldMapping fieldMapping = new BDI_FieldMapping(diFieldMapping);
+            this.fieldMappingByDevName.put(fieldMapping.DeveloperName,fieldMapping);
+
+            BDI_FieldMapping[] fieldMappings = new BDI_FieldMapping[]{};
+            if (this.fieldMappingsByObjMappingDevName.get(fieldMapping.Target_Object_Mapping_Dev_Name) != null){
+                fieldMappings = this.fieldMappingsByObjMappingDevName.get(fieldMapping.Target_Object_Mapping_Dev_Name);
+            }
+            fieldMappings.add(fieldMapping);
+            this.fieldMappingsByObjMappingDevName.put(fieldMapping.Target_Object_Mapping_Dev_Name,fieldMappings);
+        }
+
+    }
+}

--- a/src/classes/BDI_FieldMappingSet.cls-meta.xml
+++ b/src/classes/BDI_FieldMappingSet.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="BDI_FieldMappingSet">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -543,12 +543,12 @@ public class BDI_ManageAdvancedMappingCtrl {
             this.Source_Field_Label = sourceFieldDescribe.label;
             this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name__c;
             this.Source_Field_Data_Type = String.valueOf(sourceFieldDescribe.type);
-            this.Source_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Source_Field_Data_Type);
+            this.Source_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Source_Field_Data_Type);
 
             this.Target_Field_Label = targetFieldDescribe.label;
             this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name__c;
             this.Target_Field_Data_Type = String.valueOf(targetFieldDescribe.type);
-            this.Target_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Target_Field_Data_Type);
+            this.Target_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Target_Field_Data_Type);
 
             this.Maps_To_Icon = UTILITY_FORWARD_SLDS_ICON;
 

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -46,9 +46,9 @@ public class BDI_ManageAdvancedMappingCtrl {
     }
 
     /*******************************************************************************************************
-    * @description Instance of BDI_FieldMappingCustomMetadata
+    * @description Instance of BDI_MappingServiceAdvanced
     */
-    private static BDI_FieldMappingCustomMetadata bdiCMT = BDI_FieldMappingCustomMetadata.getInstance();
+    private static BDI_MappingServiceAdvanced bdiCMT = BDI_MappingServiceAdvanced.getInstance();
 
     /*******************************************************************************************************
     * @description Current package namespace
@@ -68,35 +68,6 @@ public class BDI_ManageAdvancedMappingCtrl {
         'label',
         'qualifiedapiname',
         'id'};
-
-    /*******************************************************************************************************
-    * @description Map of labels by display types used in the field mapping UI
-    */
-    private static final Map<String, String> LABELS_BY_DISPLAY_TYPE = new Map<String, String> {
-        'ADDRESS' => 'Address',
-        'BASE64' => 'Base64',
-        'BOOLEAN' => 'Checkbox',
-        'COMBOBOX' => 'Picklist',
-        'CURRENCY' => 'Currency',
-        'DATACATEGORYGROUPREFERENCE' => 'DataCategoryGroupReference',
-        'DATE' => 'Date',
-        'DATETIME' => 'Date/Time',
-        'DOUBLE' => 'Number',
-        'EMAIL' => 'Email',
-        'ENCRYPTEDSTRING' => 'Text (Encrypted)',
-        'ID' => 'Id',
-        'INTEGER' => 'Number',
-        'LONG' => 'Text Area (Long)',
-        'MULTIPICKLIST' => 'Picklist (Multi-Select)',
-        'PERCENT' => 'Percent',
-        'PHONE' => 'Phone',
-        'PICKLIST' => 'Picklist',
-        'REFERENCE' => 'Lookup Relationship',
-        'STRING' => 'Text',
-        'TEXTAREA' => 'Text Area',
-        'TIME' => 'Time',
-        'URL' => 'URL'
-    };
 
     /*******************************************************************************************************
     * @description This is a list of the standard objects we will let users choose from (plus custom objects) 
@@ -572,12 +543,12 @@ public class BDI_ManageAdvancedMappingCtrl {
             this.Source_Field_Label = sourceFieldDescribe.label;
             this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name__c;
             this.Source_Field_Data_Type = String.valueOf(sourceFieldDescribe.type);
-            this.Source_Field_Display_Type_Label = LABELS_BY_DISPLAY_TYPE.get(this.Source_Field_Data_Type);
+            this.Source_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Source_Field_Data_Type);
 
             this.Target_Field_Label = targetFieldDescribe.label;
             this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name__c;
             this.Target_Field_Data_Type = String.valueOf(targetFieldDescribe.type);
-            this.Target_Field_Display_Type_Label = LABELS_BY_DISPLAY_TYPE.get(this.Target_Field_Data_Type);
+            this.Target_Field_Display_Type_Label = UTIL_Describe.LABELS_BY_DISPLAY_TYPE.get(this.Target_Field_Data_Type);
 
             this.Maps_To_Icon = UTILITY_FORWARD_SLDS_ICON;
 

--- a/src/classes/BDI_MappingService.cls
+++ b/src/classes/BDI_MappingService.cls
@@ -1,0 +1,58 @@
+/*
+    Copyright (c) 2019 Salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+ 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2019
+* @group Batch Data Import
+* @group-content ../../ApexDocContent/BatchDataImport.htm
+* @description define behaviors of field mapping classes
+*/
+
+public interface BDI_MappingService {
+
+    /*******************************************************************************************************
+    * @description For the provided fields (in the form DIObject.developerfieldname) and target object, 
+    * return a map of DI field (key) to mapped field name on the destination record (value). 
+    *
+    * @param dataImportObjectName the bdi object we care about (Contact1, Contact2, Account1, etc)
+    * @param targetObjectName the underlying object the bdi object is (ie, Contact, Account, etc)
+    * @param dataImportFields the DataImport fields to consider
+    * @return Map<String, String> a map of DataImport fields to underlying object fields (eg, Donation_Amount__c => Amount)
+    */ 
+    Map<String,String> getFieldMap(String dataImportObjectName, 
+            String targetObjectName, 
+            List<String> dataImportFields);
+
+    /*******************************************************************************************************
+    * @description Produces a map of fields to target field wrappers that contain mapped target fields
+    * with target object data.
+    */
+    Map<SObjectField, BDI_TargetFields> getTargetFieldsBySourceField();
+}

--- a/src/classes/BDI_MappingService.cls-meta.xml
+++ b/src/classes/BDI_MappingService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="BDI_MappingService">
     <apiVersion>46.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDI_MappingServiceAdvanced.cls
+++ b/src/classes/BDI_MappingServiceAdvanced.cls
@@ -35,7 +35,9 @@
 * @description Implement field mapping behavior for mapping with custom metadata types
 */
 
-public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMapping {
+public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingService {
+
+    public class MappingServiceException extends Exception{}
 
     public static final String DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME = 'Default_Field_Mapping_Set';
 
@@ -49,7 +51,10 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
     public Map<String,Data_Import_Field_Mapping__mdt[]> fieldMappingsByObjMappingLegacyName =
         new Map<String,Data_Import_Field_Mapping__mdt[]>();
 
-    private static BDI_FieldMappingCustomMetadata fieldMappingInstance = null;
+    
+    public BDI_FieldMappingSet fieldMappingSet;
+
+    private static BDI_MappingServiceAdvanced fieldMappingInstance = null;
 
     /**
     * @description Reads Data_Import_Field_Mapping__mdt field mappings and produces a map of source field
@@ -95,23 +100,27 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
     /*******************************************************************************************************
     * @description return singleton instance of the class
     */
-    public static BDI_FieldMappingCustomMetadata getInstance() {
+    public static BDI_MappingServiceAdvanced getInstance() {
         if (fieldMappingInstance == null) {
-            fieldMappingInstance = new BDI_FieldMappingCustomMetadata();
-            fieldMappingInstance.getFieldMappingSetName();
+            fieldMappingInstance = new BDI_MappingServiceAdvanced();
+            fieldMappingInstance.setFieldMappingSetName(null);
             fieldMappingInstance.retrieveCustMetadata();
         }
         return fieldMappingInstance;
     }
 
     /*******************************************************************************************************
-    * @description return singleton instance of the class
+    * @description return singleton instance of the class using specified field mapping set dev name
     */
-    public static BDI_FieldMappingCustomMetadata retrieveInstance(String fieldMappingSetName) {
+    public static BDI_MappingServiceAdvanced getInstance(String fieldMappingSetDevName) {
+
         if (fieldMappingInstance == null) {
-            fieldMappingInstance = new BDI_FieldMappingCustomMetadata();
-            fieldMappingInstance.fieldMappingSetName = fieldMappingSetName;
+            fieldMappingInstance = new BDI_MappingServiceAdvanced();
+            fieldMappingInstance.setFieldMappingSetName(fieldMappingSetDevName);
             fieldMappingInstance.retrieveCustMetadata();
+        } else if(fieldMappingInstance.diFieldMappingSet.DeveloperName != fieldMappingSetDevName) {
+            throw new MappingServiceException('Error: Field Mapping Set may not be changed after '+ 
+                                                'initial instantiation');
         }
         return fieldMappingInstance;
     }
@@ -142,24 +151,26 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
         return targetFieldByDataImportField;
     }
 
-    private String getFieldMappingSetName(){
-        if (fieldMappingSetName == null) {
+    private void setFieldMappingSetName(String fieldMappingSetDevName){
+        if (fieldMappingSetDevName != null) {
+            fieldMappingSetName = fieldMappingSetDevName;
+        } else if (fieldMappingSetName == null) {
             //Retreive the Data Import Settings to determine the default field mapping set.
             Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
 
             fieldMappingSetName = UTIL_Namespace.alignSchemaNSWithEnvironment(dis.Default_Data_Import_Field_Mapping_Set__c);
         }
-
-        return fieldMappingSetName;
     }
 
     private void retrieveCustMetadata(){
         //If the code is not in the npsp namespace, then the npsp field prefixes will need to be systematically removed.
         Boolean removeNPSPNamespace = (UTIL_Namespace.shouldAlignNamespace);
 
-        diFieldMappingSet = [SELECT id, DeveloperName, 
-                        Data_Import_Object_Mapping_Set__c,
-                        Data_Import_Object_Mapping_Set__r.DeveloperName    
+        diFieldMappingSet = [SELECT id, 
+                                MasterLabel, 
+                                DeveloperName, 
+                                Data_Import_Object_Mapping_Set__c,
+                                Data_Import_Object_Mapping_Set__r.DeveloperName    
                     FROM Data_Import_Field_Mapping_Set__mdt
                     WHERE DeveloperName =: fieldMappingSetName LIMIT 1];
                     
@@ -225,6 +236,8 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
 
                 // Removing the npsp namespace since the code is not currently packaged.
                 if (removeNPSPNamespace) {
+                   difm.Target_Object_Mapping__r.Object_API_Name__c = 
+                       UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Target_Object_Mapping__r.Object_API_Name__c);
                    difm.Source_Field_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Source_Field_API_Name__c);
                    difm.Target_Field_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Target_Field_API_Name__c);
                 }
@@ -242,5 +255,7 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
                     tempDifms);
             }
         }
+
+        fieldMappingSet = new BDI_FieldMappingSet(diFieldMappingSet,objMappingsByDevName.values(),fieldMappings);
     }
 }

--- a/src/classes/BDI_MappingServiceAdvanced.cls-meta.xml
+++ b/src/classes/BDI_MappingServiceAdvanced.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="BDI_MappingServiceAdvanced">
     <apiVersion>46.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDI_MappingServiceAdvanced_TEST.cls
+++ b/src/classes/BDI_MappingServiceAdvanced_TEST.cls
@@ -35,27 +35,31 @@
 * @description Unit tests to cover changes made to support custom metadata mapping for BDI.
 */
 @isTest
-private class BDI_FieldMappingCustomMetadata_TEST {
+private class BDI_MappingServiceAdvanced_TEST {
     /*******************************************************************************************************
-    * @description Tests that the BDI_FieldMappingCustomMetadata class can be instantiated correctly based on the custom setting value
-    *  and that it will return a string map for a core object when called (using the default set of field mappings).
+    * @description Tests that the BDI_MappingServiceAdvanced class can be instantiated correctly 
+    *  based on the custom setting value and that it will return a string map for a core object 
+    *  when called (using the default set of field mappings).
     */
     @isTest static void shouldReturnMapOfFieldsForCoreObject() {
 
         //Set the custom setting for Data import to use Data Import Field Mappings (eg Custom Metadata Type Mapping)
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
-        dis.Default_Data_Import_Field_Mapping_Set__c = BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+        dis.Default_Data_Import_Field_Mapping_Set__c = 
+            BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dis);
 
-        //Retrieve a field mapping using the getDefaultFieldMapping method and confirm it is the custom metadata implementation
-        BDI_FieldMapping bdiFM= BDI_DataImportService.getDefaultFieldMapping();
-        String className = String.valueOf(bdiFM).split(':')[0];
-        System.assertEquals('BDI_FieldMappingCustomMetadata',className);
+        //Retrieve a mapping service instance using the getDefaultMappingService method 
+        //and confirm it is the custom metadata implementation
+        BDI_MappingService bdiMS = BDI_DataImportService.getDefaultMappingService();
+        String className = String.valueOf(bdiMS).split(':')[0];
+        System.assertEquals('BDI_MappingServiceAdvanced',className);
 
         //Instantiate and call the data import service with the field mapping specified
-        BDI_DataImportService bdiDis = new BDI_DataImportService(false, bdiFM);
-        Map<String,String> accountFieldMapping = bdiDis.mapDataImportFields('Account1','Account',BDI_DataImportService.listStrDataImportFields);
+        BDI_DataImportService bdiDis = new BDI_DataImportService(false, bdiMS);
+        Map<String,String> accountFieldMapping = 
+            bdiDis.mapDataImportFields('Account1','Account',BDI_DataImportService.listStrDataImportFields);
         System.assertNotEquals(null,accountFieldMapping);
         //Confirm that there are at least 8 records
         System.assert(accountFieldMapping.size() >= 8);
@@ -85,8 +89,28 @@ private class BDI_FieldMappingCustomMetadata_TEST {
         Data_Import_Settings__c dis2 = UTIL_CustomSettingsFacade.getDataImportSettings();
 
         System.assertEquals(BDI_DataImportService.FM_HELP_TEXT,dis2.Field_Mapping_Method__c);
-        System.assertEquals(BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME,dis2.Default_Data_Import_Field_Mapping_Set__c);
+        System.assertEquals(BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME,dis2.Default_Data_Import_Field_Mapping_Set__c);
 
+    }
+
+    /*******************************************************************************************************
+    * @description Tests that the BDI_FieldMappingSet is properly constructed when getting an instance 
+    * of the mapping service.
+    */
+    @isTest static void shouldReturnPopulatedBDIFieldMappingSet() {
+        //Set the custom setting for Data import to use Data Import Field Mappings (eg Custom Metadata Type Mapping)
+        Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
+        dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
+        dis.Default_Data_Import_Field_Mapping_Set__c = BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+        UTIL_CustomSettingsFacade.setDataImportSettings(dis);
+
+        //Retrieve a mapping service instance
+        BDI_MappingServiceAdvanced bdiMSAdv = BDI_MappingServiceAdvanced.getInstance();
+
+        System.assert(bdiMSAdv.fieldMappingSet != null);
+        System.assert(bdiMSAdv.fieldMappingSet.objectMappingByDevName.size() > 0);
+        System.assert(bdiMSAdv.fieldMappingSet.fieldMappingByDevName.size() > 0);
+        System.assert(bdiMSAdv.fieldMappingSet.fieldMappingsByObjMappingDevName.size() > 0);
     }
     
 }

--- a/src/classes/BDI_MappingServiceAdvanced_TEST.cls-meta.xml
+++ b/src/classes/BDI_MappingServiceAdvanced_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="BDI_MappingServiceAdvanced_TEST">
     <apiVersion>46.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDI_MappingServiceHelpText.cls
+++ b/src/classes/BDI_MappingServiceHelpText.cls
@@ -35,9 +35,10 @@
 * @description Implement field mapping behavior for help text mapping scheme
 */
 
-public with sharing class BDI_FieldMappingHelpText implements BDI_FieldMapping {
+public with sharing class BDI_MappingServiceHelpText implements BDI_MappingService {
 
-    private static BDI_FieldMappingHelpText fieldMappingInstance = null;
+
+    private static BDI_MappingServiceHelpText fieldMappingInstance = null;
     private final UTIL_Describe describeService = UTIL_Describe.getInstance();
 
     /*******************************************************************************************************
@@ -48,9 +49,9 @@ public with sharing class BDI_FieldMappingHelpText implements BDI_FieldMapping {
     /*******************************************************************************************************
     * @description return singleton instance of the class
     */
-    public static BDI_FieldMappingHelpText getInstance() {
+    public static BDI_MappingServiceHelpText getInstance() {
         if(fieldMappingInstance == null) {
-            fieldMappingInstance = new BDI_FieldMappingHelpText();
+            fieldMappingInstance = new BDI_MappingServiceHelpText();
         }
         return fieldMappingInstance;
     }

--- a/src/classes/BDI_MappingServiceHelpText.cls-meta.xml
+++ b/src/classes/BDI_MappingServiceHelpText.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="BDI_MappingServiceHelpText">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_MappingServiceHelpText_TEST.cls
+++ b/src/classes/BDI_MappingServiceHelpText_TEST.cls
@@ -35,7 +35,7 @@
 * @description Unit tests to cover help text mapping for BDI.
 */
 @IsTest
-private class BDI_FieldMappingHelpText_TEST {
+private class BDI_MappingServiceHelpText_TEST {
 
     @TestSetup
     private static void configureHelpTextMapping() {

--- a/src/classes/BDI_MappingServiceHelpText_TEST.cls-meta.xml
+++ b/src/classes/BDI_MappingServiceHelpText_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="BDI_MappingServiceHelpText_TEST">
     <apiVersion>46.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/BDI_MigrationMappingUtility.cls
+++ b/src/classes/BDI_MigrationMappingUtility.cls
@@ -165,7 +165,7 @@ public with sharing class BDI_MigrationMappingUtility {
     }
 
     /*******************************************************************************************************
-    * @description List of BDI_FieldMappingHelpText.DataImportFieldMappings built from good help text mappings
+    * @description List of BDI_MappingServiceHelpText.DataImportFieldMappings built from good help text mappings
     */
     public List<DataImportFieldMapping> dataImportFieldMappings = new List<DataImportFieldMapping>();
 

--- a/src/classes/BDI_ObjectMapping.cls
+++ b/src/classes/BDI_ObjectMapping.cls
@@ -1,0 +1,68 @@
+/*
+    Copyright (c) 2019 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2019
+* @group Batch Data Import
+* @group-content ../../ApexDocContent/BatchDataImport.htm
+* @description Wrapper class to hold data related to the object mapping 
+*/
+public with sharing class BDI_ObjectMapping {
+    @AuraEnabled public Id Id;
+    @AuraEnabled public String DeveloperName;
+    @AuraEnabled public String MasterLabel;
+    @AuraEnabled public String Custom_Mapping_Logic_Class;
+    @AuraEnabled public String Data_Import_Object_Mapping_Set;
+    @AuraEnabled public String Data_Import_Object_Mapping_Set_Dev_Name;
+    @AuraEnabled public String Imported_Record_Field_Name;
+    @AuraEnabled public String Imported_Record_Status_Field_Name;
+    @AuraEnabled public Boolean Is_Deleted;
+    @AuraEnabled public String Object_API_Name;
+    @AuraEnabled public String Predecessor;
+    @AuraEnabled public String Predecessor_Label_Name;
+    @AuraEnabled public String Relationship_Field;
+    @AuraEnabled public String Relationship_To_Predecessor;
+
+    public BDI_ObjectMapping(Data_Import_Object_Mapping__mdt objectMapping) {
+        this.Id = objectMapping.Id;
+        this.MasterLabel = objectMapping.MasterLabel;
+        this.DeveloperName = objectMapping.DeveloperName;
+        this.Custom_Mapping_Logic_Class = objectMapping.Custom_Mapping_Logic_Class__c;
+        this.Data_Import_Object_Mapping_Set = objectMapping.Data_Import_Object_Mapping_Set__c;
+        this.Data_Import_Object_Mapping_Set_Dev_Name = objectMapping.Data_Import_Object_Mapping_Set__r.DeveloperName;
+        this.Imported_Record_Field_Name = objectMapping.Imported_Record_Field_Name__c;
+        this.Imported_Record_Status_Field_Name = objectMapping.Imported_Record_Status_Field_Name__c;
+        this.Is_Deleted = objectMapping.Is_Deleted__c;
+        this.Object_API_Name = objectMapping.Object_API_Name__c;
+        this.Predecessor = objectMapping.Predecessor__c;
+        this.Relationship_Field = objectMapping.Relationship_Field__c;
+        this.Relationship_To_Predecessor = objectMapping.Relationship_To_Predecessor__c;
+    }
+}

--- a/src/classes/BDI_ObjectMapping.cls-meta.xml
+++ b/src/classes/BDI_ObjectMapping.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="BDI_ObjectMapping">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_SettingsUI_CTRL.cls
+++ b/src/classes/BDI_SettingsUI_CTRL.cls
@@ -94,7 +94,7 @@ public with sharing class BDI_SettingsUI_CTRL {
 
                 // this UI is specific to help text settings in current state
                 BDI_Donations donationImportHandler = 
-                    new BDI_Donations(new BDI_DataImportService(true, BDI_FieldMappingHelpText.getInstance()));
+                    new BDI_Donations(new BDI_DataImportService(true, BDI_MappingServiceHelpText.getInstance()));
 
                 setFields.addAll(donationImportHandler.dataImportFieldToOpportunityField.keySet());
                 setFields.addAll(donationImportHandler.dataImportFieldToPaymentField.keySet());

--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -58,7 +58,7 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     * @description Provides field mapping configuration used by BGE
     */
     public static Map<SObjectField, BDI_TargetFields> targetFieldsBySourceField = 
-        BDI_DataImportService.getDefaultFieldMapping().getTargetFieldsBySourceField();
+        BDI_DataImportService.getDefaultMappingService().getTargetFieldsBySourceField();
 
     /*******************************************************************************************************
     * @description returns a list of DataImport__c fields the Batch Gift Entry UI needs in SOQL

--- a/src/classes/GE_TemplateBuilderCtrl.cls
+++ b/src/classes/GE_TemplateBuilderCtrl.cls
@@ -38,9 +38,9 @@
 public with sharing class GE_TemplateBuilderCtrl {
 
     /*******************************************************************************************************
-    * @description Instance of BDI_FieldMappingCustomMetadata
+    * @description Instance of BDI_MappingServiceAdvanced
     */
-    private static BDI_FieldMappingCustomMetadata bdiCMT;
+    private static BDI_MappingServiceAdvanced bdiMSAdv;
 
     /*******************************************************************************************************
     * @description Template version
@@ -82,17 +82,17 @@ public with sharing class GE_TemplateBuilderCtrl {
     }
 
     /*******************************************************************************************************
-    * @description Method collects object mappings and field mappings using BDI_FieldMappingCustomMetadata
+    * @description Method collects object mappings and field mappings using BDI_MappingServiceAdvanced
     * based on a field mapping set developer name. Creates ObjectMappingWrappers and CheckboxWrappers out
     * of the object mapping and field mappings respectively. These wrappers are easier to use in the UI. No
     * need to worry about namespaces in the fields.
     */
     @AuraEnabled
     public static ObjectMappingWrapper[] getFieldAndObjectMappingsByFieldMappingSetName(String fieldMappingSetName) {
-        bdiCMT = BDI_FieldMappingCustomMetadata.retrieveInstance(fieldMappingSetName);
+        bdiMSAdv = BDI_MappingServiceAdvanced.getInstance(fieldMappingSetName);
         ObjectMappingWrapper[] objectWrappers = new ObjectMappingWrapper[]{};
 
-        for (Data_Import_Object_Mapping__mdt objectMapping : bdiCMT.objMappingsByDevName.values()) {
+        for (Data_Import_Object_Mapping__mdt objectMapping : bdiMSAdv.objMappingsByDevName.values()) {
             ObjectMappingWrapper omw = new ObjectMappingWrapper(objectMapping);
 
             if (objectMapping.Data_Import_Field_Mappings__r != null) {

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -665,7 +665,7 @@ public without sharing class UTIL_CustomSettingsFacade {
             dis.Donation_Date_Range__c = 0;
         }
         if (dis.Default_Data_Import_Field_Mapping_Set__c == null) {
-            dis.Default_Data_Import_Field_Mapping_Set__c = BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+            dis.Default_Data_Import_Field_Mapping_Set__c = BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         }
         if (dis.Field_Mapping_Method__c  == null) {
             dis.Field_Mapping_Method__c  = BDI_DataImportService.FM_HELP_TEXT;

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -73,6 +73,35 @@ public class UTIL_Describe {
     private static void setInstance(UTIL_Describe utilDescribe){
         utilDescribeInstance = utilDescribe;
     }
+    
+    /*******************************************************************************************************
+    * @description Map display types to a friendly user-readable label.
+    */
+    public static final Map<String, String> LABELS_BY_DISPLAY_TYPE = new Map<String, String> {
+        'ADDRESS' => 'Address',
+        'BASE64' => 'Base64',
+        'BOOLEAN' => 'Checkbox',
+        'COMBOBOX' => 'Picklist',
+        'CURRENCY' => 'Currency',
+        'DATACATEGORYGROUPREFERENCE' => 'DataCategoryGroupReference',
+        'DATE' => 'Date',
+        'DATETIME' => 'Date/Time',
+        'DOUBLE' => 'Number',
+        'EMAIL' => 'Email',
+        'ENCRYPTEDSTRING' => 'Text (Encrypted)',
+        'ID' => 'Id',
+        'INTEGER' => 'Number',
+        'LONG' => 'Text Area (Long)',
+        'MULTIPICKLIST' => 'Picklist (Multi-Select)',
+        'PERCENT' => 'Percent',
+        'PHONE' => 'Phone',
+        'PICKLIST' => 'Picklist',
+        'REFERENCE' => 'Lookup Relationship',
+        'STRING' => 'Text',
+        'TEXTAREA' => 'Text Area',
+        'TIME' => 'Time',
+        'URL' => 'URL'
+    };
 
     /*******************************************
     * Gets describe maps for a new object

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -77,7 +77,7 @@ public class UTIL_Describe {
     /*******************************************************************************************************
     * @description Map display types to a friendly user-readable label.
     */
-    public static final Map<String, String> LABELS_BY_DISPLAY_TYPE = new Map<String, String> {
+    private static final Map<String, String> LABELS_BY_DISPLAY_TYPE = new Map<String, String> {
         'ADDRESS' => 'Address',
         'BASE64' => 'Base64',
         'BOOLEAN' => 'Checkbox',
@@ -107,6 +107,8 @@ public class UTIL_Describe {
     * Gets describe maps for a new object
     ********************************************/
     static void fillMapsForObject(string objectName) {
+        objectName = objectName.toLowerCase();
+
         // get the object map the first time
         if (gd == null) {
             gd = Schema.getGlobalDescribe();
@@ -150,6 +152,8 @@ public class UTIL_Describe {
     * Gets all field maps for a new object
     ********************************************/
     static void fillFieldMapsForObject(string objectName) {
+        objectName = objectName.toLowerCase();
+
         // get the object map the first time
         fillMapsForObject(objectName);
 
@@ -176,6 +180,7 @@ public class UTIL_Describe {
     * @return the new SObject
     */
     public static SObject getPrototypeObject(String objectName) {
+        objectName = objectName.toLowerCase();
         // make sure we have this object's schema mapped
         if (!objectDescribes.containsKey(objectName))
             fillMapsForObject(objectName);
@@ -189,6 +194,7 @@ public class UTIL_Describe {
     * @return the Label of the object
     */
     public static string getObjectLabel(String objectName) {
+        objectName = objectName.toLowerCase();
         // make sure we have this object's schema mapped
         if (!objectDescribes.containsKey(objectName))
             fillMapsForObject(objectName);
@@ -202,6 +208,7 @@ public class UTIL_Describe {
     * @return Schema.DescribeSObjectResult of the object
     */
     public static Schema.DescribeSObjectResult getObjectDescribe(String objectName) {
+        objectName = objectName.toLowerCase();
         // make sure we have this object's schema mapped
         if (!objectDescribes.containsKey(objectName))
             fillMapsForObject(objectName);
@@ -230,6 +237,8 @@ public class UTIL_Describe {
     * @return true if the Id is for the given object type, false otherwise.
     */
     public static boolean isObjectIdThisType(Id salesforceId, String objectName) {
+        objectName = objectName.toLowerCase();
+
         // make sure we have this object's schema mapped
         if (!objectDescribes.containsKey(objectName))
             fillMapsForObject(objectName);
@@ -250,6 +259,7 @@ public class UTIL_Describe {
     * @return Map<String, Schema.DescribeFieldResult> a map of field api names to describe file results.
     */
     public static Map<String, Schema.DescribeFieldResult> getAllFieldsDescribe(String objectName) {
+        objectName = objectName.toLowerCase();
 
         // make sure we have this object's schema mapped
         fillFieldMapsForObject(objectName);
@@ -265,6 +275,7 @@ public class UTIL_Describe {
     */
     public static String getNameField(String objectName) {
         String nameField = 'Name';
+        objectName = objectName.toLowerCase();
 
         Map<String, Schema.DescribeFieldResult> mapObjectFields = getAllFieldsDescribe(objectName);
 
@@ -284,10 +295,13 @@ public class UTIL_Describe {
     * @description Gives field type name - ID, STRING, TEXTAREA, DATE, DATETIME, BOOLEAN, REFERENCE,
     * PICKLIST, MULTIPICKLIST, CURRENCY, DOUBLE, INTEGER, PERCENT, PHONE, EMAIL
     * @param objectName the name of the object to look up
-    * @param fieldName the name of the field to look up -- LOWERCASE
+    * @param fieldName the name of the field to look up
     * @return string the name of the of the field's type
     */
     public static string getFieldType(String objectName, String fieldName) {
+        objectName = objectName.toLowerCase();
+        fieldName = fieldName.toLowerCase();
+
         // make sure we have this field's schema mapped
         if (!fieldDescribes.containsKey(objectName) || !fieldDescribes.get(objectName).containsKey(fieldName))
             fillFieldMapsForObject(objectName, fieldName);
@@ -300,10 +314,13 @@ public class UTIL_Describe {
     * @description Gives field type name - ID, STRING, TEXTAREA, DATE, DATETIME, BOOLEAN, REFERENCE,
     * PICKLIST, MULTIPICKLIST, CURRENCY, DOUBLE, INTEGER, PERCENT, PHONE, EMAIL
     * @param objectName the name of the object to look up
-    * @param fieldName the name of the field to look up -- LOWERCASE
+    * @param fieldName the name of the field to look up
     * @return Displaytype the Displaytype of the field
     */
     public static Schema.Displaytype getFieldDisplaytype(String objectName, String fieldName) {
+        objectName = objectName.toLowerCase();
+        fieldName = fieldName.toLowerCase();
+
         // make sure we have this field's schema mapped
         if (!fieldDescribes.containsKey(objectName) || !fieldDescribes.get(objectName).containsKey(fieldName))
             fillFieldMapsForObject(objectName, fieldName);
@@ -325,10 +342,13 @@ public class UTIL_Describe {
     /*******************************************************************************************************
     * @description Returns field describe data
     * @param objectName the name of the object to look up
-    * @param fieldName the name of the field to look up -- LOWERCASE
+    * @param fieldName the name of the field to look up
     * @return Schema.DescribeFieldResult the describe field result for the given field
     */
     public static Schema.DescribeFieldResult getFieldDescribe(String objectName, String fieldName) {
+        objectName = objectName.toLowerCase();
+        fieldName = fieldName.toLowerCase();
+
         // make sure we have this field's schema mapped
         if (!fieldDescribes.containsKey(objectName) || !fieldDescribes.get(objectName).containsKey(fieldName)) {
             fillFieldMapsForObject(objectName, fieldName);
@@ -341,10 +361,13 @@ public class UTIL_Describe {
     /*******************************************************************************************************
     * @description Gives field friendly name
     * @param objectName the name of the object to look up
-    * @param fieldName the name of the field to look up -- LOWERCASE
+    * @param fieldName the name of the field to look up
     * @return string the label of the field
     */
     public static string getFieldLabel(String objectName, String fieldName) {
+        objectName = objectName.toLowerCase();
+        fieldName = fieldName.toLowerCase();
+
         // make sure we have this field's schema mapped
         if (!fieldDescribes.containsKey(objectName) || !fieldDescribes.get(objectName).containsKey(fieldName))
             fillFieldMapsForObject(objectName, fieldName);
@@ -396,10 +419,13 @@ public class UTIL_Describe {
     /*******************************************************************************************************
     * @description checks whether the field exists
     * @param objectName the name of the object to look up
-    * @param fieldName the name of the field to look up -- LOWERCASE
+    * @param fieldName the name of the field to look up
     * @return boolean whether the field exists
     */
     public static boolean isValidField(String objectName, String fieldName) {
+        objectName = objectName.toLowerCase();
+        fieldName = fieldName.toLowerCase();
+
         // make sure we have this field's schema mapped
         try {
             if (!fieldDescribes.containsKey(objectName) || !fieldDescribes.get(objectName).containsKey(fieldName))
@@ -524,12 +550,13 @@ public class UTIL_Describe {
 
     /** @description Returns a list of SelectOptions for a given object and picklist field name.
     * @param objectName The name of the object.
-    * @param fieldName The name of the field. -- LOWERCASE
+    * @param fieldName The name of the field.
     * @return List<SelectOption> The select options for this picklist field.
     */
 
     public static List<SelectOption> getSelectOptions(String objectName, String fieldName) {
         Schema.DescribeFieldResult describeField = UTIL_Describe.getFieldDescribe(objectName, fieldName);
+
         List<SelectOption> result = new List<SelectOption>();
         if (describeField.getType() == Schema.DisplayType.PICKLIST) {
             for (Schema.PicklistEntry entry : describeField.getPicklistValues()) {
@@ -543,11 +570,12 @@ public class UTIL_Describe {
 
     /** @description Returns the default SelectOption for a given object and picklist field name.
     * @param objectName The name of the object.
-    * @param fieldName The name of the field. -- LOWERCASE
+    * @param fieldName The name of the field.
     * @return String The default select option for this picklist field.
     */
     public static String getDefaultSelectOption(String objectName, String fieldName) {
         Schema.DescribeFieldResult describeField = getFieldDescribe(objectName, fieldName);
+
         if (describeField.getType() == Schema.DisplayType.PICKLIST) {
             for (Schema.PicklistEntry entry : describeField.getPicklistValues()) {
                 if (entry.isDefaultValue()) {
@@ -565,8 +593,8 @@ public class UTIL_Describe {
     * @return List<Map<String, String>> The options for this picklist field formatted for use in Lightning Components
     */
     public static List<Map<String, String>> getLightningSelectOptions(String objectName, String fieldName) {
-        fieldName = fieldName.toLowerCase();
         List<SelectOption> picklistOptions = UTIL_Describe.getSelectOptions(objectName,fieldName);
+
         List<Map<String, String>> options = new List<Map<String, String>>();
         for (SelectOption opt : picklistOptions) {
             if (opt.getDisabled() == false) {
@@ -582,6 +610,7 @@ public class UTIL_Describe {
     /** @description For a given object and field, verifies that the field is accessible and updateable
      * throwing an exception if it isn't.*/
     public static void checkFieldFLS(String objectName, String fieldName) {
+
         DescribeFieldResult dfr = getFieldDescribe(
             UTIL_Namespace.StrTokenNSPrefix(objectName), 
             fieldName.endsWith('__c')?UTIL_Namespace.StrTokenNSPrefix(fieldName):fieldName
@@ -627,5 +656,12 @@ public class UTIL_Describe {
 
     /** @description our exception object for Field Level & Object Security errors. */
     private class permsException extends Exception {}
-    
+
+    /** @description Returns a friendlier label name for a given display type
+    * @param displayType The all caps version of the display type provided from a field describe
+    * @return String the friendly label name for the display type
+    */
+    public static String getLabelForDisplayType(String displayType) {   
+        return LABELS_BY_DISPLAY_TYPE.get(displayType);
+    }
 }

--- a/src/package.xml
+++ b/src/package.xml
@@ -83,19 +83,22 @@
         <members>BDI_Donations_TEST</members>
         <members>BDI_DryRun_TEST</members>
         <members>BDI_FieldMapping</members>
-        <members>BDI_FieldMappingCustomMetadata</members>
-        <members>BDI_FieldMappingCustomMetadata_TEST</members>
-        <members>BDI_FieldMappingHelpText</members>
-        <members>BDI_FieldMappingHelpText_TEST</members>
+        <members>BDI_FieldMappingSet</members>
         <members>BDI_IMatchDonations</members>
         <members>BDI_IPostProcess</members>
         <members>BDI_ManageAdvancedMappingCtrl</members>
         <members>BDI_ManageAdvancedMappingCtrl_TEST</members>
+        <members>BDI_MappingService</members>
+        <members>BDI_MappingServiceAdvanced</members>
+        <members>BDI_MappingServiceAdvanced_TEST</members>
+        <members>BDI_MappingServiceHelpText</members>
+        <members>BDI_MappingServiceHelpText_TEST</members>
         <members>BDI_MatchDonations</members>
         <members>BDI_MigrationMappingHelper</members>
         <members>BDI_MigrationMappingHelper_TEST</members>
         <members>BDI_MigrationMappingUtility</members>
         <members>BDI_MigrationMappingUtility_TEST</members>
+        <members>BDI_ObjectMapping</members>
         <members>BDI_ObjectMappingLogic</members>
         <members>BDI_ObjectWrapper</members>
         <members>BDI_PerfLogger</members>
@@ -220,10 +223,10 @@
         <members>CRLP_VRollupHandler</members>
         <members>CallableApiParameters</members>
         <members>CallableApiParameters_TEST</members>
-        <members>Callable_API</members>
-        <members>Callable_API_TEST</members>
         <members>CallableDispatchService_ERR</members>
         <members>CallableDispatchService_ERR_TEST</members>
+        <members>Callable_API</members>
+        <members>Callable_API_TEST</members>
         <members>EP_EngagementPlanTaskValidation_TDTM</members>
         <members>EP_EngagementPlanTaskValidation_TEST</members>
         <members>EP_EngagementPlans_TDTM</members>
@@ -1047,9 +1050,9 @@
         <members>Error__c.Related_Record_ID__c</members>
         <members>Error__c.Retry_Pending__c</members>
         <members>Error__c.Stack_Trace__c</members>
+        <members>Form_Template__c.Description__c</members>
         <members>Form_Template__c.Format_Version__c</members>
         <members>Form_Template__c.Template_JSON__c</members>
-        <members>Form_Template__c.Description__c</members>
         <members>General_Accounting_Unit__c.Active__c</members>
         <members>General_Accounting_Unit__c.Average_Allocation__c</members>
         <members>General_Accounting_Unit__c.Description__c</members>
@@ -1720,9 +1723,9 @@
         <members>campaignMemberStatusResponded</members>
         <members>conFailedAccountCreate</members>
         <members>conMergeBtnLabel</members>
+        <members>conMergeErrNoPersonAccounts</members>
         <members>conMergeErrorNoDeleteObjPermission</members>
         <members>conMergeErrorNoDeleteRecAccess</members>
-        <members>conMergeErrNoPersonAccounts</members>
         <members>conMergeFoundContacts</members>
         <members>conMergePageTitle</members>
         <members>conMergePageTitleDetail</members>


### PR DESCRIPTION
This PR includes renaming the following classes and updating all references:

- BDI_FieldMapping to BDI_MappingService
- BDI_FieldMappingHelpText to BDI_MappingServiceHelpText
- BDI_FieldMappingHelpText_Test to BDI_MappingServiceHelpText_Test
- BDI_FieldMappingCustomMetadata to BDI_MappingServiceAdvanced
- BDI_FieldMappingCustomMetadata_Test to BDI_MappingServiceAdvanced_Test

It also includes creating the following wrapper classes to old data from the Data Import CMT records:

- BDI_FIeldMapping
- BDI_ObjectMapping
- BDI_FieldMappingSet


# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
