### PR TITLE
Refactoring Additional object code to use wrappers

### DIFF
--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -41,10 +41,10 @@ public with sharing class BDI_AdditionalObjectService {
     * @description the data import service we are invoked from
     */
     private BDI_DataImportService dataImportService;
-    private BDI_MappingServiceAdvanced fieldMappingCustomMetadata;
+    private BDI_MappingServiceAdvanced mappingServiceAdvanced;
 
-    private Map<Integer,Map<String,Data_Import_Object_Mapping__mdt>> objMappingsByTier = new Map<Integer,Map<String,Data_Import_Object_Mapping__mdt>>();
-    private Map<String,Map<String,Data_Import_Object_Mapping__mdt>> successorObjMappingsByPredecessorName = new Map<String,Map<String,Data_Import_Object_Mapping__mdt>>();
+    private Map<Integer,Map<String,BDI_ObjectMapping>> objMappingsByTier = new Map<Integer,Map<String,BDI_ObjectMapping>>();
+    private Map<String,Map<String,BDI_ObjectMapping>> successorObjMappingsByPredecessorName = new Map<String,Map<String,BDI_ObjectMapping>>();
     private Set<String> importedRecordFieldNames = new Set<String>();
 
     public Set<String> objMappingDevNames = new Set<String>();
@@ -55,7 +55,7 @@ public with sharing class BDI_AdditionalObjectService {
     */
     public BDI_AdditionalObjectService(BDI_DataImportService dataImportService) {
         this.dataImportService = dataImportService;
-        this.fieldMappingCustomMetadata = BDI_MappingServiceAdvanced.getInstance();
+        this.mappingServiceAdvanced = BDI_MappingServiceAdvanced.getInstance();
     }
 
 
@@ -65,13 +65,13 @@ public with sharing class BDI_AdditionalObjectService {
     public void importAdditionalObjects(){
 
         generateTiersOfObjectMappings();
-        createSetOfImportedRecordFieldNames(fieldMappingCustomMetadata.objMappingsByDevName.values());
+        createSetOfImportedRecordFieldNames(mappingServiceAdvanced.objectMappingByDevName.values());
 
         //Iterate through the map of tiers, starting with the first tier that actually has a predecessor 
         //(ie 2nd tier), and validate and create each object as appropriate.
         for (Integer i = 1; i < objMappingsByTier.size(); i++) {
 
-            Map<String,Data_Import_Object_Mapping__mdt> currentTier = objMappingsByTier.get(i);
+            Map<String,BDI_ObjectMapping> currentTier = objMappingsByTier.get(i);
 
             DataImport__c[] disWithoutFailure = new DataImport__c[]{};
 
@@ -102,20 +102,20 @@ public with sharing class BDI_AdditionalObjectService {
     */
 
     private Map<String,BDI_ObjectWrapper[]> prepareObjectWrappers (
-        Map<String,Data_Import_Object_Mapping__mdt> currentTierOfObjMappings, 
+        Map<String,BDI_ObjectMapping> currentTierOfObjMappings, 
         DataImport__c[] dataImportRecords) {
 
         Map<String,BDI_ObjectWrapper[]> objAPINameToObjWraps = new Map<String,BDI_ObjectWrapper[]>();
 
         if (currentTierOfObjMappings != null) {
-            for (Data_Import_Object_Mapping__mdt objMapping : currentTierOfObjMappings.values()) {
+            for (BDI_ObjectMapping objMapping : currentTierOfObjMappings.values()) {
 
                 BDI_ObjectMappingLogic objMappingLogic = getObjectMappingLogicClass(objMapping);
 
-                Data_Import_Object_Mapping__mdt predecessor = 
-                    fieldMappingCustomMetadata.objMappingsByDevName.get(objMapping.Predecessor__c);
-                Data_Import_Field_Mapping__mdt[] fieldMappings = 
-                    fieldMappingCustomMetadata.fieldMappingsByObjMappingDevName.get(objMapping.DeveloperName);
+                BDI_ObjectMapping predecessor = 
+                    mappingServiceAdvanced.objectMappingByDevName.get(objMapping.Predecessor);
+                BDI_FieldMapping[] fieldMappings = 
+                    mappingServiceAdvanced.fieldMappingsByObjMappingDevName.get(objMapping.DeveloperName);
 
                 //Only proceed if at least one field mapping exists
                 if (fieldMappings != null && fieldMappings.size() > 0) {
@@ -127,11 +127,11 @@ public with sharing class BDI_AdditionalObjectService {
                             dataImport,objMapping,fieldMappings,predecessor);
 
                         //null out any existing value in the status field for this object mapping
-                        dataImport.put(objMapping.Imported_Record_Status_Field_Name__c,'');
+                        dataImport.put(objMapping.Imported_Record_Status_Field_Name,'');
 
                         //If the imported record field for the object is not populated then create a new SObject, 
                         //otherwise update existing.
-                        if (dataImport.get(objMapping.Imported_Record_Field_Name__c) == null) {
+                        if (dataImport.get(objMapping.Imported_Record_Field_Name) == null) {
 
                             //If there are no fields populated or required fields are not populated for this object 
                             //mapping then ignore this dataImport and continue.
@@ -149,7 +149,7 @@ public with sharing class BDI_AdditionalObjectService {
 
                             //If there is an existing record then we don't need to perform the normal validation 
                             // and can proceed to populating the record with any non-null values.
-                            objWrap.existingSObjectId = (Id)dataImport.get(objMapping.Imported_Record_Field_Name__c);
+                            objWrap.existingSObjectId = (Id)dataImport.get(objMapping.Imported_Record_Field_Name);
 
                         }
 
@@ -165,10 +165,10 @@ public with sharing class BDI_AdditionalObjectService {
                             // SObject type to upsert. They are grouped by object api name so that we only need to 
                             // do one upsert per object per tier.
                             if (objWrap.sObj != null) {
-                                if (objAPINameToObjWraps.get(objMapping.Object_API_Name__c) != null) {
-                                    objAPINameToObjWraps.get(objMapping.Object_API_Name__c).add(objWrap);
+                                if (objAPINameToObjWraps.get(objMapping.Object_API_Name) != null) {
+                                    objAPINameToObjWraps.get(objMapping.Object_API_Name).add(objWrap);
                                 } else {
-                                    objAPINameToObjWraps.put(objMapping.Object_API_Name__c,
+                                    objAPINameToObjWraps.put(objMapping.Object_API_Name,
                                         new BDI_ObjectWrapper[]{objWrap});
                                 }
                             }
@@ -263,7 +263,7 @@ public with sharing class BDI_AdditionalObjectService {
                         BDI_ObjectWrapper objWrap = objWrapsForUpdate[t];
 
                         if (result.isSuccess()) {
-                            objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Status_Field_Name__c,
+                            objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Status_Field_Name,
                                 System.label.bdiUpdated);
                         } else {
                             logError(objWrap, result.getErrors()[0].getMessage());
@@ -289,14 +289,14 @@ public with sharing class BDI_AdditionalObjectService {
                         BDI_ObjectWrapper objWrap = objWrapsForInsert[t];
 
                         if (result.isSuccess()) {
-                            objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Status_Field_Name__c,
+                            objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Status_Field_Name,
                                 System.Label.bdiCreated);
-                            objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Field_Name__c,
+                            objWrap.dataImport.put(objWrap.objMapping.Imported_Record_Field_Name,
                                 objWrap.sObj.Id);
 
                             // If the newly created sobject is a parent to its predecesssor, then
                             // add it to a list for updating child predcessors.
-                            if (objWrap.objMapping.Relationship_To_Predecessor__c == 'Parent') { 
+                            if (objWrap.objMapping.Relationship_To_Predecessor == 'Parent') { 
                                 objWrapsForChildPredecessorUpdate.add(objWrap);
                             }
                         } else {
@@ -318,12 +318,12 @@ public with sharing class BDI_AdditionalObjectService {
     * mapping class.
     * @param objMapping The Data Import Object Mapping to look for a custom mapping logic class on.
     */
-    private BDI_ObjectMappingLogic getObjectMappingLogicClass (Data_Import_Object_Mapping__mdt objMapping) {
+    private BDI_ObjectMappingLogic getObjectMappingLogicClass (BDI_ObjectMapping objMapping) {
         BDI_ObjectMappingLogic objMappingLogicClass;
 
-        if (objMapping.Custom_Mapping_Logic_Class__c != null) {
+        if (objMapping.Custom_Mapping_Logic_Class != null) {
             Type custLogicClassType = Type.forName(
-                UTIL_Namespace.alignClassNSWithEnvironment(objMapping.Custom_Mapping_Logic_Class__c));
+                UTIL_Namespace.alignClassNSWithEnvironment(objMapping.Custom_Mapping_Logic_Class));
             objMappingLogicClass = (BDI_ObjectMappingLogic)custLogicClassType.newInstance();
         } else {
             objMappingLogicClass = new BDI_ObjectMappingLogic();
@@ -345,13 +345,13 @@ public with sharing class BDI_AdditionalObjectService {
 
         for (BDI_ObjectWrapper objWrap : objWrapsForChildPredecessorUpdate) {
 
-            Id predecessorId = (Id)objWrap.dataImport.get(objWrap.predecessorObjMapping.Imported_Record_Field_Name__c);
+            Id predecessorId = (Id)objWrap.dataImport.get(objWrap.predecessorObjMapping.Imported_Record_Field_Name);
             SObject sObjForUpdate;
 
             Map<Id,SObject> sObjectById = new Map<Id,SObject>();
 
-            if (childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name__c) != null) {
-                sObjectById = childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name__c);
+            if (childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name) != null) {
+                sObjectById = childSObjectMapByObjectAPIName.get(objWrap.predecessorObjMapping.Object_API_Name);
             }
 
             // Attempt to find if the predecessor sobject if it is already in the map for update and update 
@@ -359,18 +359,18 @@ public with sharing class BDI_AdditionalObjectService {
             if (sObjectById.size() > 0 && sObjectById.get(predecessorId) != null) {
                 sObjForUpdate = sObjectById.get(predecessorId);
             } else {
-                sObjForUpdate = UTIL_Describe.getPrototypeObject(objWrap.predecessorObjMapping.Object_API_Name__c);
+                sObjForUpdate = UTIL_Describe.getPrototypeObject(objWrap.predecessorObjMapping.Object_API_Name);
             }
 
             // Set the id of the sobject to the predecessors record id
             sObjForUpdate.put('Id',predecessorId);
 
             // Place the Id of the newly created SObject into the appropriate relationship field on the child.
-            sObjForUpdate.put(objWrap.objMapping.Relationship_Field__c,objWrap.sObj.Id);
+            sObjForUpdate.put(objWrap.objMapping.Relationship_Field,objWrap.sObj.Id);
 
             // Put the SObject back into the enclosing maps.
             sObjectById.put(predecessorId, sObjForUpdate);
-            childSObjectMapByObjectAPIName.put(objWrap.predecessorObjMapping.Object_API_Name__c,sObjectById);
+            childSObjectMapByObjectAPIName.put(objWrap.predecessorObjMapping.Object_API_Name,sObjectById);
 
             // Store the successor object wraps by their predecessor id for later use in recording errors.
             if (successorObjWrapsByPredecessorId.get(predecessorId) != null) {
@@ -437,9 +437,9 @@ public with sharing class BDI_AdditionalObjectService {
     * @param predecessor The Data Import Object Mapping for which the imported field can be checked to see 
     *  if it exists.
     */
-    private Boolean predecessorExists(BDI_ObjectWrapper objWrap, Data_Import_Object_Mapping__mdt predecessor){
+    private Boolean predecessorExists(BDI_ObjectWrapper objWrap, BDI_ObjectMapping predecessor){
         Boolean result = true;
-        if (objWrap.dataImport.get(predecessor.Imported_Record_Field_Name__c) == null) {
+        if (objWrap.dataImport.get(predecessor.Imported_Record_Field_Name) == null) {
             result = false;
             String error = String.format(
                 System.Label.bdiAdditionalObjPredNotFound,
@@ -467,10 +467,10 @@ public with sharing class BDI_AdditionalObjectService {
         // First determine if there is at least one field populated that was not automatically populated by 
         // the import of another object. This is done to ensure that the user actually intended to attempt 
         // the creation of this object.
-        for (Data_Import_Field_Mapping__mdt fieldMapping : objWrap.fieldMappings) {
+        for (BDI_FieldMapping fieldMapping : objWrap.fieldMappings) {
 
-            if (!importedRecordFieldNames.contains(fieldMapping.Source_Field_API_Name__c.toLowerCase())
-                && objWrap.dataImport.get(fieldMapping.Source_Field_API_Name__c) != null) {        
+            if (!importedRecordFieldNames.contains(fieldMapping.Source_Field_API_Name.toLowerCase())
+                && objWrap.dataImport.get(fieldMapping.Source_Field_API_Name) != null) {        
                 anyNonImportedRecordFieldsPopulated = true;
             }
         }
@@ -479,14 +479,14 @@ public with sharing class BDI_AdditionalObjectService {
         // user is trying to create the object and continue with record validation.
         if (anyNonImportedRecordFieldsPopulated) {
 
-            for (Data_Import_Field_Mapping__mdt fieldMapping : objWrap.fieldMappings) {
+            for (BDI_FieldMapping fieldMapping : objWrap.fieldMappings) {
 
-                if (objWrap.dataImport.get(fieldMapping.Source_Field_API_Name__c) == null) {
+                if (objWrap.dataImport.get(fieldMapping.Source_Field_API_Name) == null) {
 
-                    if (fieldMapping.Required__c == 'Yes') {
+                    if (fieldMapping.Required == 'Yes') {
 
                         allRequiredFieldsPopulated = false;
-                        requiredFieldErrorMsg += fieldMapping.Source_Field_API_Name__c + '; ';
+                        requiredFieldErrorMsg += fieldMapping.Source_Field_API_Name + '; ';
                     }
                 }
             }
@@ -514,30 +514,30 @@ public with sharing class BDI_AdditionalObjectService {
     */
     public void generateTiersOfObjectMappings() {
 
-        if (fieldMappingCustomMetadata.objMappingsByDevName != null 
-            && fieldMappingCustomMetadata.objMappingsByDevName.size() > 0) {
+        if (mappingServiceAdvanced.objectMappingByDevName != null 
+            && mappingServiceAdvanced.objectMappingByDevName.size() > 0) {
 
             // Creates a map of predecessor dev name to successor and also identifies 
         // the base level objects with no predecessor defined.
-            for (Data_Import_Object_Mapping__mdt objMapping : fieldMappingCustomMetadata.objMappingsByDevName.values()) {
+            for (BDI_ObjectMapping objMapping : mappingServiceAdvanced.objectMappingByDevName.values()) {
 
-                if (objMapping.Predecessor__c != null && objMapping.Relationship_Field__c != null 
-            && objMapping.Relationship_To_Predecessor__c != null) {
+                if (objMapping.Predecessor != null && objMapping.Relationship_Field != null 
+            && objMapping.Relationship_To_Predecessor != null) {
 
                     objMappingDevNames.add(objMapping.DeveloperName);
 
-                    if (successorObjMappingsByPredecessorName.get(objMapping.Predecessor__c) != null) {
-                        successorObjMappingsByPredecessorName.get(objMapping.Predecessor__c).put(objMapping.DeveloperName,objMapping);
+                    if (successorObjMappingsByPredecessorName.get(objMapping.Predecessor) != null) {
+                        successorObjMappingsByPredecessorName.get(objMapping.Predecessor).put(objMapping.DeveloperName,objMapping);
                     } else {
-                        successorObjMappingsByPredecessorName.put(objMapping.Predecessor__c,
-                            new Map<String,Data_Import_Object_Mapping__mdt>{objMapping.DeveloperName => objMapping});
+                        successorObjMappingsByPredecessorName.put(objMapping.Predecessor,
+                            new Map<String,BDI_ObjectMapping>{objMapping.DeveloperName => objMapping});
                     }
                 } else {
 
                     if (objMappingsByTier.get(0) != null) {
                         objMappingsByTier.get(0).put(objMapping.DeveloperName,objMapping);
                     } else {
-                        objMappingsByTier.put(0,new Map<String,Data_Import_Object_Mapping__mdt>{
+                        objMappingsByTier.put(0,new Map<String,BDI_ObjectMapping>{
                             objMapping.DeveloperName => objMapping
                         });
                     }
@@ -547,10 +547,10 @@ public with sharing class BDI_AdditionalObjectService {
             //Iterates through the tier list and builds out each tier starting with the objects with no predecessor.
             for (Integer i = 0; i < objMappingsByTier.size(); i++) {
 
-                Map<String,Data_Import_Object_Mapping__mdt> currentTier = 
-                    new Map<String,Data_Import_Object_Mapping__mdt>();
-                Map<String,Data_Import_Object_Mapping__mdt> nextTier = 
-                    new Map<String,Data_Import_Object_Mapping__mdt>();
+                Map<String,BDI_ObjectMapping> currentTier = 
+                    new Map<String,BDI_ObjectMapping>();
+                Map<String,BDI_ObjectMapping> nextTier = 
+                    new Map<String,BDI_ObjectMapping>();
 
                 if (objMappingsByTier.get(i) != null) {
                     currentTier = objMappingsByTier.get(i);
@@ -576,13 +576,13 @@ public with sharing class BDI_AdditionalObjectService {
     *  for use in field validation.
     * @param objMappings the Data Import Object Mappings that the set should be built from.
     */
-    private Set<String> createSetOfImportedRecordFieldNames(Data_Import_Object_Mapping__mdt[] objMappings) {
+    private Set<String> createSetOfImportedRecordFieldNames(BDI_ObjectMapping[] objMappings) {
         importedRecordFieldNames = new Set<String>();
 
-        for (Data_Import_Object_Mapping__mdt objMapping : objMappings) {
+        for (BDI_ObjectMapping objMapping : objMappings) {
 
-            if (objMapping.Imported_Record_Field_Name__c != null) {
-                importedRecordFieldNames.add(objMapping.Imported_Record_Field_Name__c.toLowerCase());
+            if (objMapping.Imported_Record_Field_Name != null) {
+                importedRecordFieldNames.add(objMapping.Imported_Record_Field_Name.toLowerCase());
             }
             
         }
@@ -634,9 +634,9 @@ public with sharing class BDI_AdditionalObjectService {
             String errorMessage) {
 
         String errorMessageToAppend;
-        if (objectWrapper.objMapping.Imported_Record_Status_Field_Name__c != null) {
+        if (objectWrapper.objMapping.Imported_Record_Status_Field_Name != null) {
 
-            String importedRecordStatusField = objectWrapper.objMapping.Imported_Record_Status_Field_Name__c;
+            String importedRecordStatusField = objectWrapper.objMapping.Imported_Record_Status_Field_Name;
 
             String importedRecordStatusFieldLabel = UTIL_Describe.getFieldDescribe(
                     DataImport__c.SObjectType.getDescribe().getName(),

--- a/src/classes/BDI_AdditionalObjectService_TEST.cls
+++ b/src/classes/BDI_AdditionalObjectService_TEST.cls
@@ -773,44 +773,49 @@ private class BDI_AdditionalObjectService_TEST {
 
         BDI_DataImportService bdiDIS = new BDI_DataImportService(false, BDI_DataImportService.getDefaultMappingService());
         
-        BDI_MappingServiceAdvanced bdiFMCM = BDI_MappingServiceAdvanced.getInstance();
+        BDI_MappingServiceAdvanced bdiMsAdv = BDI_MappingServiceAdvanced.getInstance();
 
-        String[] objMappingNames = new List<String>(bdiFMCM.objMappingsByDevName.keySet());
-        Data_Import_Object_Mapping__mdt predecessorObjMapping = bdiFMCM.objMappingsByDevName.get('Opportunity');
-        Data_Import_Field_Mapping__mdt[] opptFieldMappings = bdiFMCM.fieldMappingsByObjMappingDevName.get('Opportunity'); 
+        String[] objMappingNames = new List<String>(bdiMsAdv.objectMappingByDevName.keySet());
+        BDI_ObjectMapping predecessorObjMapping = bdiMsAdv.objectMappingByDevName.get('Opportunity');
+        BDI_FieldMapping[] opptFieldMappings = bdiMsAdv.fieldMappingsByObjMappingDevName.get('Opportunity'); 
 
 
         Data_Import_Object_Mapping__mdt diom = 
             new Data_Import_Object_Mapping__mdt(DeveloperName = 'TestTestHonoree324',
                             MasterLabel = 'Honoree',
-                            Data_Import_Object_Mapping_Set__c = predecessorObjMapping.Data_Import_Object_Mapping_Set__c,
+                            Data_Import_Object_Mapping_Set__c = predecessorObjMapping.Data_Import_Object_Mapping_Set,
                             Object_API_Name__c = 'Contact',
                             Predecessor__c = predecessorObjMapping.DeveloperName,
                             Imported_Record_Field_Name__c = 'Contact1_Title__c',
                             Imported_Record_Status_Field_Name__c = 'Contact1ImportStatus__c',
                             Relationship_Field__c = 'Honoree_Contact__c',
                             Relationship_To_Predecessor__c = 'Parent');
-        Data_Import_Field_Mapping__mdt honoreeLastName = 
-            new Data_Import_Field_Mapping__mdt(DeveloperName = 'fakeHonoreeLastNameSFDOTest34',
-                            MasterLabel = 'fakeHonoreeLastNameSFDOTest34',
-                            Data_Import_Field_Mapping_Set__c = opptFieldMappings[0].Data_Import_Field_Mapping_Set__c,
-                            Required__c = 'Yes',
-                            Source_Field_API_Name__c = DataImport__c.Contact1_Alternate_Email__c.getDescribe().getName(),
-                            Target_Field_API_Name__c = 'LastName' );
 
-        Data_Import_Field_Mapping__mdt honoreeAccountId = 
-            new Data_Import_Field_Mapping__mdt(DeveloperName = 'fakeHonoreeAcctSFDOTest34',
-                            MasterLabel = 'fakeHonoreeAcctSFDOTest34',
-                            Data_Import_Field_Mapping_Set__c = opptFieldMappings[0].Data_Import_Field_Mapping_Set__c,
-                            Required__c = 'No',
-                            Source_Field_API_Name__c = DataImport__c.Account1Imported__c.getDescribe().getName(),
-                            Target_Field_API_Name__c = 'AccountId' );
+        BDI_ObjectMapping testObjMapping = new BDI_ObjectMapping(diom);
 
-        Data_Import_Field_Mapping__mdt[] honoreeFieldMappings = 
-            new Data_Import_Field_Mapping__mdt[]{honoreeLastName,honoreeAccountId};
+        BDI_FieldMapping testFM1 = new BDI_FieldMapping();
+        testFM1.MasterLabel = 'fakeHonoreeLastNameSFDOTest34';
+        testFM1.DeveloperName = 'fakeHonoreeLastNameSFDOTest34';
+        testFM1.Target_Object_API_Name = 'Contact';
+        testFM1.Data_Import_Field_Mapping_Set = opptFieldMappings[0].Data_Import_Field_Mapping_Set;
+        testFM1.Required = 'Yes';
+        testFM1.Source_Field_API_Name = DataImport__c.Contact1_Alternate_Email__c.getDescribe().getName();
+        testFM1.Target_Field_API_Name = 'LastName';
 
-        bdiFMCM.objMappingsByDevName.put(diom.DeveloperName,diom);
-        bdiFMCM.fieldMappingsByObjMappingDevName.put(diom.DeveloperName,honoreeFieldMappings);
+        BDI_FieldMapping testFM2 = new BDI_FieldMapping();
+        testFM2.MasterLabel = 'fakeHonoreeAcctSFDOTest34';
+        testFM2.DeveloperName = 'fakeHonoreeAcctSFDOTest34';
+        testFM2.Target_Object_API_Name = 'Contact';
+        testFM2.Data_Import_Field_Mapping_Set = opptFieldMappings[0].Data_Import_Field_Mapping_Set;
+        testFM2.Required = 'No';
+        testFM2.Source_Field_API_Name = DataImport__c.Account1Imported__c.getDescribe().getName();
+        testFM2.Target_Field_API_Name = 'AccountId';
+
+        BDI_FieldMapping[] honoreeFieldMappings = 
+            new BDI_FieldMapping[]{testFM1,testFM2};
+
+        bdiMsAdv.objectMappingByDevName.put(testObjMapping.DeveloperName,testObjMapping);
+        bdiMsAdv.fieldMappingsByObjMappingDevName.put(testObjMapping.DeveloperName,honoreeFieldMappings);
 
         bdiDIS.process(null, dis, diRecords);
         

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -45,7 +45,7 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
         String PAYMENT_FIELDNAME = SObjectType.Allocation__c.fields.Payment__c.Name;
         String OPPORTUNITY_FIELDNAME = SObjectType.Allocation__c.fields.Opportunity__c.Name;
 
-        String sourceObjName = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__DataImport__c');
+        String sourceObjName = SObjectType.DataImport__c.getName();
 
         for (BDI_ObjectWrapper objWrap : objWraps) {
 

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -42,15 +42,14 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
 
         Allocations_Settings__c settings = UTIL_CustomSettingsFacade.getAllocationsSettings();
 
-        Map<String, Schema.DescribeFieldResult> sourceFieldDescByFieldName = UTIL_Describe.getAllFieldsDescribe(SObjectType.DataImport__c.getName());
-
         String PAYMENT_FIELDNAME = SObjectType.Allocation__c.fields.Payment__c.Name;
         String OPPORTUNITY_FIELDNAME = SObjectType.Allocation__c.fields.Opportunity__c.Name;
 
-        for (BDI_ObjectWrapper objWrap : objWraps) {
-            Map<String, Schema.DescribeFieldResult> targetFieldDescByFieldName = UTIL_Describe.getAllFieldsDescribe(objWrap.objMapping.Object_API_Name__c);
+        String sourceObjName = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__DataImport__c');
 
-            objWrap.sObj = UTIL_Describe.getPrototypeObject(objWrap.objMapping.Object_API_Name__c);
+        for (BDI_ObjectWrapper objWrap : objWraps) {
+
+            objWrap.sObj = UTIL_Describe.getPrototypeObject(objWrap.objMapping.Object_API_Name);
 
             if (objWrap.existingSObjectId != null) {
                 objWrap.sObj.put('Id', objWrap.existingSObjectId);
@@ -59,23 +58,23 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
             Object paymentIdValue;
             Object opportunityIdValue;
 
-            for (Data_Import_Field_Mapping__mdt fieldMapping : objWrap.fieldMappings) {
-                String sourceFieldName = fieldMapping.Source_Field_API_Name__c;
-                String targetFieldName = fieldMapping.Target_Field_API_Name__c;
+            for (BDI_FieldMapping fieldMapping : objWrap.fieldMappings) {
+                String sourceFieldName = fieldMapping.Source_Field_API_Name;
+                String targetFieldName = fieldMapping.Target_Field_API_Name;
 
                 Object value = objWrap.dataImport.get(sourceFieldName);
 
-                Schema.DescribeFieldResult sourceFieldDescribe = sourceFieldDescByFieldName.get(sourceFieldName.toLowerCase());
-                Schema.DescribeFieldResult targetFieldDescribe = targetFieldDescByFieldName.get(targetFieldName.toLowerCase());
+                Schema.DescribeFieldResult sourceFieldDescribe = UTIL_Describe.getFieldDescribe(sourceObjName, sourceFieldName);
+                Schema.DescribeFieldResult targetFieldDescribe = UTIL_Describe.getFieldDescribe(objWrap.objMapping.Object_API_Name, targetFieldName);
 
                 //Confirm that it is real field, and that it is accessible to the running user.
                 if (targetFieldDescribe != null && targetFieldDescribe.isAccessible()) {
                     //Confirm that either the sObj Id is null (ie new record) or that the field is updatable if it is not new.
                     if (objWrap.sObj.Id == null || targetFieldDescribe.isUpdateable()) {
                         // If the target field mapping is one of the key parent objects, then extract the values for later logic
-                        if (fieldMapping.Target_Field_API_Name__c == PAYMENT_FIELDNAME) {
+                        if (fieldMapping.Target_Field_API_Name == PAYMENT_FIELDNAME) {
                             paymentIdValue = value;
-                        } else if (fieldMapping.Target_Field_API_Name__c == OPPORTUNITY_FIELDNAME) {
+                        } else if (fieldMapping.Target_Field_API_Name == OPPORTUNITY_FIELDNAME) {
                             opportunityIdValue = value;
                         } else {
                             castAndCopyField(objWrap, sourceFieldName, sourceFieldDescribe, targetFieldName, targetFieldDescribe);

--- a/src/classes/BDI_DataImport_TEST2.cls
+++ b/src/classes/BDI_DataImport_TEST2.cls
@@ -1593,8 +1593,6 @@ private with sharing class BDI_DataImport_TEST2 {
         Test.stopTest();
 
         listDI = getDIs();
-        
-        System.debug(listDI); 
 
         // The first import fails, because there would be two new 1x1 Contacts under the same Account
         System.assertEquals(label.bdiErrorOneToOneMultiContact, listDI[0].Contact1ImportStatus__c);

--- a/src/classes/BDI_FieldMapping.cls
+++ b/src/classes/BDI_FieldMapping.cls
@@ -51,10 +51,18 @@ public virtual with sharing class BDI_FieldMapping {
     @AuraEnabled public String Source_Field_Display_Type_Label;
     @AuraEnabled public String Target_Field_Display_Type_Label;
 
+
+    /*******************************************************************************************************
+    * @description No parameter constructor to enable use as virtual class.
+    */
     public BDI_FieldMapping() {
 
     }
 
+    /*******************************************************************************************************
+    * @description Constructor that populates the wrapper with data from a Data_Import_Field_Mapping__mdt record.
+    * @param fieldMapping the Data_Import_Field_Mapping__mdt to populate from.
+    */
     public BDI_FieldMapping(Data_Import_Field_Mapping__mdt fieldMapping) {
         String dataImport = SobjectType.DataImport__c.Name;
 

--- a/src/classes/BDI_FieldMapping.cls
+++ b/src/classes/BDI_FieldMapping.cls
@@ -34,7 +34,7 @@
 * @group-content ../../ApexDocContent/BatchDataImport.htm
 * @description Wrapper class to hold data related to the field mapping 
 */
-public with sharing class BDI_FieldMapping {
+public virtual with sharing class BDI_FieldMapping {
     @AuraEnabled public String DeveloperName;
     @AuraEnabled public String MasterLabel;
     @AuraEnabled public String Source_Field_Label;
@@ -45,35 +45,49 @@ public with sharing class BDI_FieldMapping {
     @AuraEnabled public String Target_Field_Data_Type;
     @AuraEnabled public String Data_Import_Field_Mapping_Set;
     @AuraEnabled public String Target_Object_Mapping_Dev_Name;
+    @AuraEnabled public String Target_Object_API_Name;
     @AuraEnabled public String Required;
     @AuraEnabled public Boolean Is_Deleted;
     @AuraEnabled public String Source_Field_Display_Type_Label;
     @AuraEnabled public String Target_Field_Display_Type_Label;
 
+    public BDI_FieldMapping() {
+
+    }
+
     public BDI_FieldMapping(Data_Import_Field_Mapping__mdt fieldMapping) {
         String dataImport = SobjectType.DataImport__c.Name;
-        String objectAPIName = fieldMapping.Target_Object_Mapping__r.Object_API_Name__c;
-        String sourceFieldAPIName = fieldMapping.Source_Field_API_Name__c;
-        String targetFieldAPIName = fieldMapping.Target_Field_API_Name__c;
+
+        this.Target_Object_API_Name = fieldMapping.Target_Object_Mapping__r.Object_API_Name__c;
+        this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name__c;
+        this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name__c;
+
+        // Removing the npsp namespace since the code is not currently packaged.
+        if (UTIL_Namespace.shouldAlignNamespace) {
+            this.Target_Object_API_Name = 
+                UTIL_Namespace.alignSchemaNSWithEnvironment(this.Target_Object_API_Name);
+            this.Source_Field_API_Name = 
+                UTIL_Namespace.alignSchemaNSWithEnvironment(this.Source_Field_API_Name);
+            this.Target_Field_API_Name =
+                 UTIL_Namespace.alignSchemaNSWithEnvironment(this.Target_Field_API_Name);
+        }
 
         Schema.DescribeFieldResult sourceFieldDescribe = UTIL_Describe.getFieldDescribe(
             dataImport,
-            sourceFieldAPIName);
+            this.Source_Field_API_Name);
 
         Schema.DescribeFieldResult targetFieldDescribe = UTIL_Describe.getFieldDescribe(
-            objectAPIName,
-            targetFieldAPIName);
+            this.Target_Object_API_Name,
+            this.Target_Field_API_Name);
 
         this.DeveloperName = fieldMapping.DeveloperName;
         this.MasterLabel = fieldMapping.MasterLabel;
 
         this.Source_Field_Label = sourceFieldDescribe.label;
-        this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name__c;
         this.Source_Field_Data_Type = String.valueOf(sourceFieldDescribe.type);
         this.Source_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Source_Field_Data_Type);
 
         this.Target_Field_Label = targetFieldDescribe.label;
-        this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name__c;
         this.Target_Field_Data_Type = String.valueOf(targetFieldDescribe.type);
         this.Target_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Target_Field_Data_Type);
 

--- a/src/classes/BDI_FieldMappingSet.cls
+++ b/src/classes/BDI_FieldMappingSet.cls
@@ -43,6 +43,14 @@ public with sharing class BDI_FieldMappingSet {
     @AuraEnabled public Map<String,BDI_ObjectMapping> objectMappingByDevName = new Map<String,BDI_ObjectMapping>();
     @AuraEnabled public Map<String,BDI_FieldMapping> fieldMappingByDevName = new Map<String,BDI_FieldMapping>();
 
+
+    /*******************************************************************************************************
+    * @description Constructor that wraps together the field mapping set info using already constructed
+    * BDI_ObjectMapping and BDI_FieldMapping objects and a Data_Import_Field_Mapping_Set__mdt record.
+    * @param fieldMappingSet
+    * @param objectMappingByDevName
+    * @param fieldMappingByDevName
+    */
     public BDI_FieldMappingSet(Data_Import_Field_Mapping_Set__mdt fieldMappingSet, 
                                 Map<String,BDI_ObjectMapping> objectMappingByDevName,
                                 Map<String,BDI_FieldMapping>  fieldMappingByDevName) {

--- a/src/classes/BDI_FieldMappingSet.cls
+++ b/src/classes/BDI_FieldMappingSet.cls
@@ -42,33 +42,17 @@ public with sharing class BDI_FieldMappingSet {
 
     @AuraEnabled public Map<String,BDI_ObjectMapping> objectMappingByDevName = new Map<String,BDI_ObjectMapping>();
     @AuraEnabled public Map<String,BDI_FieldMapping> fieldMappingByDevName = new Map<String,BDI_FieldMapping>();
-    @AuraEnabled public Map<String,BDI_FieldMapping[]> fieldMappingsByObjMappingDevName = new Map<String,BDI_FieldMapping[]>();
 
     public BDI_FieldMappingSet(Data_Import_Field_Mapping_Set__mdt fieldMappingSet, 
-                                Data_Import_Object_Mapping__mdt[] diObjectMappings,
-                                Data_Import_Field_Mapping__mdt[] diFieldMappings) {
+                                Map<String,BDI_ObjectMapping> objectMappingByDevName,
+                                Map<String,BDI_FieldMapping>  fieldMappingByDevName) {
 
         this.DeveloperName = fieldMappingSet.DeveloperName;
         this.MasterLabel = fieldMappingSet.MasterLabel;
         this.Id = fieldMappingSet.Id;
         this.Data_Import_Object_Mapping_Group_Dev_Name = fieldMappingSet.Data_Import_Object_Mapping_Set__r.DeveloperName;
 
-        for (Data_Import_Object_Mapping__mdt diObjectMapping : diObjectMappings) {
-            BDI_ObjectMapping objectMapping = new BDI_ObjectMapping(diObjectMapping);
-            this.objectMappingByDevName.put(objectMapping.DeveloperName,objectMapping);
-        }
-
-        for (Data_Import_Field_Mapping__mdt diFieldMapping : diFieldMappings) {
-            BDI_FieldMapping fieldMapping = new BDI_FieldMapping(diFieldMapping);
-            this.fieldMappingByDevName.put(fieldMapping.DeveloperName,fieldMapping);
-
-            BDI_FieldMapping[] fieldMappings = new BDI_FieldMapping[]{};
-            if (this.fieldMappingsByObjMappingDevName.get(fieldMapping.Target_Object_Mapping_Dev_Name) != null){
-                fieldMappings = this.fieldMappingsByObjMappingDevName.get(fieldMapping.Target_Object_Mapping_Dev_Name);
-            }
-            fieldMappings.add(fieldMapping);
-            this.fieldMappingsByObjMappingDevName.put(fieldMapping.Target_Object_Mapping_Dev_Name,fieldMappings);
-        }
-
+        this.objectMappingByDevName = objectMappingByDevName;
+        this.fieldMappingByDevName = fieldMappingByDevName;
     }
 }

--- a/src/classes/BDI_ManageAdvancedMappingCtrl.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl.cls
@@ -48,7 +48,7 @@ public class BDI_ManageAdvancedMappingCtrl {
     /*******************************************************************************************************
     * @description Instance of BDI_MappingServiceAdvanced
     */
-    private static BDI_MappingServiceAdvanced bdiCMT = BDI_MappingServiceAdvanced.getInstance();
+    private static BDI_MappingServiceAdvanced bdiMsAdv = BDI_MappingServiceAdvanced.getInstance();
 
     /*******************************************************************************************************
     * @description Current package namespace
@@ -89,7 +89,7 @@ public class BDI_ManageAdvancedMappingCtrl {
     */
     @AuraEnabled(cacheable=true)
     public static String getFieldMappingSetName() {
-        return UTIL_CustomSettings_API.getDataImportSettings().Default_Data_Import_Field_Mapping_Set__c;
+        return bdiMsAdv.fieldMappingSet.DeveloperName;
     }
 
     /*******************************************************************************************************
@@ -104,29 +104,20 @@ public class BDI_ManageAdvancedMappingCtrl {
     * @return List: List of Data Import Object Mapping
     */
     @AuraEnabled(cacheable=false)
-    public static DataImportObjectMappingWrapper[] getObjectMappings(){
+    public static BDI_ObjectMapping[] getObjectMappings(){
 
-        DataImportObjectMappingWrapper[] objMappingWrappers = new DataImportObjectMappingWrapper[]{};
-        Data_Import_Object_Mapping__mdt[] objMappings = bdiCMT.objMappingsByDevName.values();
-
-        Map<String,DataImportObjectMappingWrapper> objMappingWrappersByDevName = new Map<String,DataImportObjectMappingWrapper>();
-
-        for (Data_Import_Object_Mapping__mdt objMapping : objMappings) {
-            DataImportObjectMappingWrapper objMappingWrapper = new DataImportObjectMappingWrapper(objMapping);
-            objMappingWrappers.add(objMappingWrapper);
-            objMappingWrappersByDevName.put(objMappingWrapper.DeveloperName, objMappingWrapper);
-        }
+        BDI_ObjectMapping[] objMappings = bdiMsAdv.objectMappingByDevName.values();
 
         //Assign the label name field for the predecessor using the constructed map by dev name.
-        for (DataImportObjectMappingWrapper objMappingWrapper : objMappingWrappers) {
+        for (BDI_ObjectMapping objMapping : objMappings) {
 
-            DataImportObjectMappingWrapper predecessorObjMappingWrapper = objMappingWrappersByDevName.get(objMappingWrapper.Predecessor);
-            if(predecessorObjMappingWrapper != null) {
-                objMappingWrapper.Predecessor_Label_Name = predecessorObjMappingWrapper.MasterLabel;
+            BDI_ObjectMapping predecessorObjMapping = bdiMsAdv.objectMappingByDevName.get(objMapping.Predecessor);
+            if(predecessorObjMapping != null) {
+                objMapping.Predecessor_Label_Name = predecessorObjMapping.MasterLabel;
             }
         }
 
-        return objMappingWrappers;
+        return objMappings;
     }
 
     /*******************************************************************************************************
@@ -199,14 +190,14 @@ public class BDI_ManageAdvancedMappingCtrl {
         DataImportFieldMappingWrapper[] fieldMappingWrappers =
             new List<DataImportFieldMappingWrapper>();
 
-        Data_Import_Field_Mapping__mdt[] fieldMappings =
-            bdiCMT.fieldMappingsByObjMappingDevName.get(objectName);
+        BDI_FieldMapping[] fieldMappings =
+            bdiMsAdv.fieldMappingsByObjMappingDevName.get(objectName);
 
         if (fieldMappings != null) {
-            for (Data_Import_Field_Mapping__mdt fieldMapping : fieldMappings) {
+            for (BDI_FieldMapping fieldMapping : fieldMappings) {
 
-            if (fieldMapping.Data_Import_Field_Mapping_Set__r.DeveloperName == fieldMappingSetname &&
-                fieldMapping.Is_Deleted__c == false) {
+                if (bdiMsAdv.fieldMappingSet.DeveloperName == fieldMappingSetname &&
+                    fieldMapping.Is_Deleted == false) {
 
                     fieldMappingWrappers.add(new DataImportFieldMappingWrapper(fieldMapping));
                 }
@@ -221,7 +212,7 @@ public class BDI_ManageAdvancedMappingCtrl {
     *
     * @param fieldMappingString: DataImportFieldMappingWrapper as JSON
     *
-    * @return String: Deployment Id or Data_Import_Field_Mapping__mdt instance JSON when in tests
+    * @return String: Deployment Id or BDI_FieldMapping instance JSON when in tests
     */
     @AuraEnabled
     public static String createDataImportFieldMapping(String fieldMappingString) {
@@ -244,7 +235,7 @@ public class BDI_ManageAdvancedMappingCtrl {
     *
     * @param fieldMappingString: DataImportFieldMappingWrapper as JSON
     *
-    * @return String: Deployment Id or Data_Import_Field_Mapping__mdt instance JSON when in tests
+    * @return String: Deployment Id or BDI_FieldMapping instance JSON when in tests
     */
     private static Data_Import_Field_Mapping__mdt constructDataImportFieldMapping(String fieldMappingString) {
         DataImportFieldMappingWrapper fieldMappingWrapper =
@@ -264,21 +255,21 @@ public class BDI_ManageAdvancedMappingCtrl {
             '{ "' + diFieldMappingSetFieldName + '" : "' +
             UTIL_Namespace.StrAllNSPrefix(fieldMappingWrapper.Data_Import_Field_Mapping_Set) + '",' +
             '"' + targetObjectMappingFieldName + '": "' +
-            UTIL_Namespace.StrAllNSPrefix(fieldMappingWrapper.Target_Object_Mapping)  + '"}';
+            UTIL_Namespace.StrAllNSPrefix(fieldMappingWrapper.Target_Object_Mapping_Dev_Name)  + '"}';
 
-        Data_Import_Field_Mapping__mdt fieldMapping =
+        Data_Import_Field_Mapping__mdt diFieldMapping =
             (Data_Import_Field_Mapping__mdt)JSON.deserialize(
                 tempFieldMappingString,
                 Data_Import_Field_Mapping__mdt.class);
 
-        fieldMapping.MasterLabel = fieldMappingWrapper.MasterLabel;
-        fieldMapping.DeveloperName = fieldMappingWrapper.DeveloperName;
-        fieldMapping.Is_Deleted__c = fieldMappingWrapper.Is_Deleted;
-        fieldMapping.Required__c = fieldMappingWrapper.Required;
-        fieldMapping.Source_Field_API_Name__c = fieldMappingWrapper.Source_Field_API_Name;
-        fieldMapping.Target_Field_API_Name__c = fieldMappingWrapper.Target_Field_API_Name;
+        diFieldMapping.MasterLabel = fieldMappingWrapper.MasterLabel;
+        diFieldMapping.DeveloperName = fieldMappingWrapper.DeveloperName;
+        diFieldMapping.Is_Deleted__c = fieldMappingWrapper.Is_Deleted;
+        diFieldMapping.Required__c = fieldMappingWrapper.Required;
+        diFieldMapping.Source_Field_API_Name__c = fieldMappingWrapper.Source_Field_API_Name;
+        diFieldMapping.Target_Field_API_Name__c = fieldMappingWrapper.Target_Field_API_Name;
 
-        return fieldMapping;
+        return diFieldMapping;
     }
 
     /*******************************************************************************************************
@@ -492,70 +483,33 @@ public class BDI_ManageAdvancedMappingCtrl {
     }
 
     /*******************************************************************************************************
-    * @description Data_Import_Field_Mapping__mdt wrapper class used in the Field Mapping UI and for
+    * @description BDI_FieldMapping wrapper class used in the Field Mapping UI and for
     * building corresponding custom metadata type records.
     */
-    public class DataImportFieldMappingWrapper {
-        @AuraEnabled public String DeveloperName;
-        @AuraEnabled public String MasterLabel;
+    public class DataImportFieldMappingWrapper extends BDI_FieldMapping {
         @AuraEnabled public String Label;
         @AuraEnabled public String Maps_To_Icon;
-        @AuraEnabled public String Source_Field_Label;
-        @AuraEnabled public String Source_Field_API_Name;
-        @AuraEnabled public String Source_Field_Data_Type;
-        @AuraEnabled public String Target_Field_Label;
-        @AuraEnabled public String Target_Field_API_Name;
-        @AuraEnabled public String Target_Field_Data_Type;
-        @AuraEnabled public String Data_Import_Field_Mapping_Set;
-        @AuraEnabled public String Target_Object_Mapping;
-        @AuraEnabled public String Required;
-        @AuraEnabled public Boolean Is_Deleted;
-        @AuraEnabled public String Source_Field_Display_Type_Label;
-        @AuraEnabled public String Target_Field_Display_Type_Label;
 
-        public DataImportFieldMappingWrapper(Data_Import_Field_Mapping__mdt fieldMapping) {
-            String dataImport = SobjectType.DataImport__c.Name;
-            String objectAPIName = fieldMapping.Target_Object_Mapping__r.Object_API_Name__c;
-            String sourceFieldAPIName = fieldMapping.Source_Field_API_Name__c;
-            String targetFieldAPIName = fieldMapping.Target_Field_API_Name__c;
-
-            if (UTIL_Namespace.shouldAlignNamespace) {
-                objectAPIName =
-                    UTIL_Namespace.alignSchemaNSWithEnvironment(
-                        fieldMapping.Target_Object_Mapping__r.Object_API_Name__c);
-                sourceFieldAPIName =
-                    UTIL_Namespace.alignSchemaNSWithEnvironment(fieldMapping.Source_Field_API_Name__c);
-                targetFieldAPIName =
-                    UTIL_Namespace.alignSchemaNSWithEnvironment(fieldMapping.Target_Field_API_Name__c);
-            }
-
-            Schema.DescribeFieldResult sourceFieldDescribe = UTIL_Describe.getFieldDescribe(
-                dataImport,
-                sourceFieldAPIName);
-
-            Schema.DescribeFieldResult targetFieldDescribe = UTIL_Describe.getFieldDescribe(
-                objectAPIName,
-                targetFieldAPIName);
-
+        public DataImportFieldMappingWrapper(BDI_FieldMapping fieldMapping) {
             this.DeveloperName = fieldMapping.DeveloperName;
             this.MasterLabel = fieldMapping.MasterLabel;
-            this.Label =fieldMapping.MasterLabel;
-            this.Source_Field_Label = sourceFieldDescribe.label;
-            this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name__c;
-            this.Source_Field_Data_Type = String.valueOf(sourceFieldDescribe.type);
-            this.Source_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Source_Field_Data_Type);
+            this.Label = fieldMapping.MasterLabel;
+            this.Source_Field_Label = fieldMapping.Source_Field_Label;
+            this.Source_Field_API_Name = fieldMapping.Source_Field_API_Name;
+            this.Source_Field_Data_Type = fieldMapping.Source_Field_Data_Type;
+            this.Source_Field_Display_Type_Label = fieldMapping.Source_Field_Display_Type_Label;
 
-            this.Target_Field_Label = targetFieldDescribe.label;
-            this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name__c;
-            this.Target_Field_Data_Type = String.valueOf(targetFieldDescribe.type);
-            this.Target_Field_Display_Type_Label = UTIL_Describe.getLabelForDisplayType(this.Target_Field_Data_Type);
+            this.Target_Field_Label = fieldMapping.Target_Field_Label;
+            this.Target_Field_API_Name = fieldMapping.Target_Field_API_Name;
+            this.Target_Field_Data_Type = fieldMapping.Target_Field_Data_Type;
+            this.Target_Field_Display_Type_Label = fieldMapping.Target_Field_Display_Type_Label;
 
             this.Maps_To_Icon = UTILITY_FORWARD_SLDS_ICON;
 
-            this.Data_Import_Field_Mapping_Set = fieldMapping.Data_Import_Field_Mapping_Set__r.DeveloperName;
-            this.Target_Object_Mapping = fieldMapping.Target_Object_Mapping__r.DeveloperName;
-            this.Required = fieldMapping.Required__c;
-            this.Is_Deleted = fieldMapping.Is_Deleted__c;
+            this.Data_Import_Field_Mapping_Set = fieldMapping.Data_Import_Field_Mapping_Set;
+            this.Target_Object_Mapping_Dev_Name = fieldMapping.Target_Object_Mapping_Dev_Name;
+            this.Required = fieldMapping.Required;
+            this.Is_Deleted = fieldMapping.Is_Deleted;
         }
     }
 
@@ -798,14 +752,14 @@ public class BDI_ManageAdvancedMappingCtrl {
 
         Set<String> mappedFieldNamesSet = new Set<String>();
 
-        if (bdiCMT.fieldMappingsByObjMappingDevName != null) {
-            for (String objMappingDevName : bdiCMT.fieldMappingsByObjMappingDevName.keySet()) {
-                Data_Import_Field_Mapping__mdt[] fieldMappings =
-                    bdiCMT.fieldMappingsByObjMappingDevName.get(objMappingDevName);
+        if (bdiMsAdv.fieldMappingsByObjMappingDevName != null) {
+            for (String objMappingDevName : bdiMsAdv.fieldMappingsByObjMappingDevName.keySet()) {
+                BDI_FieldMapping[] fieldMappings =
+                    bdiMsAdv.fieldMappingsByObjMappingDevName.get(objMappingDevName);
 
                 if (fieldMappings != null) {
-                    for (Data_Import_Field_Mapping__mdt fieldMapping : fieldMappings) {
-                        mappedFieldNamesSet.add(fieldMapping.Source_Field_API_Name__c.toLowerCase());
+                    for (BDI_FieldMapping fieldMapping : fieldMappings) {
+                        mappedFieldNamesSet.add(fieldMapping.Source_Field_API_Name.toLowerCase());
                     }
                 }
             }

--- a/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
+++ b/src/classes/BDI_ManageAdvancedMappingCtrl_TEST.cls
@@ -79,7 +79,7 @@ private class BDI_ManageAdvancedMappingCtrl_TEST {
         '"Required":"No",' +
         '"Source_Field_API_Name":"Account1_Test_Field__c",' +
         '"Target_Field_API_Name":"Test_Field__c",' +
-        '"Target_Object_Mapping":"Account1"}';
+        '"Target_Object_Mapping_Dev_Name":"Account1"}';
 
     /*******************************************************************************************************
     * @description Instance of Data_Import_Object_Mapping__mdt as JSON
@@ -140,7 +140,7 @@ private class BDI_ManageAdvancedMappingCtrl_TEST {
             FROM Data_Import_Object_Mapping__mdt
             WHERE Data_Import_Object_Mapping_Set__c = :objectMappingSet.Id];
 
-        BDI_ManageAdvancedMappingCtrl.DataImportObjectMappingWrapper[] objectMappingWrappers =
+        BDI_ObjectMapping[] objectMappingWrappers =
             BDI_ManageAdvancedMappingCtrl.getObjectMappings();
 
         System.assertEquals(defaultObjectMappings.size(), objectMappingWrappers.size());

--- a/src/classes/BDI_MappingServiceAdvanced.cls
+++ b/src/classes/BDI_MappingServiceAdvanced.cls
@@ -44,14 +44,11 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
     public Data_Import_Field_Mapping_Set__mdt diFieldMappingSet;
     public String fieldMappingSetName;
 
-    public Map<String,Data_Import_Object_Mapping__mdt> objMappingsByDevName =
-        new Map<String,Data_Import_Object_Mapping__mdt>();
-    public Map<String,Data_Import_Field_Mapping__mdt[]> fieldMappingsByObjMappingDevName =
-        new Map<String,Data_Import_Field_Mapping__mdt[]>();
-    public Map<String,Data_Import_Field_Mapping__mdt[]> fieldMappingsByObjMappingLegacyName =
-        new Map<String,Data_Import_Field_Mapping__mdt[]>();
+    public Map<String,BDI_ObjectMapping> objectMappingByDevName = new Map<String,BDI_ObjectMapping>();
+    public Map<String,BDI_FieldMapping> fieldMappingByDevName = new Map<String,BDI_FieldMapping>();
+    public Map<String,BDI_FieldMapping[]> fieldMappingsByObjMappingDevName = new Map<String,BDI_FieldMapping[]>();
+    public Map<String,BDI_FieldMapping[]> fieldMappingsByObjMappingLegacyName = new Map<String,BDI_FieldMapping[]>();
 
-    
     public BDI_FieldMappingSet fieldMappingSet;
 
     private static BDI_MappingServiceAdvanced fieldMappingInstance = null;
@@ -65,24 +62,24 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
         Map<SObjectField, BDI_TargetFields> targetFieldsBySourceField =
                 new Map<SObjectField, BDI_TargetFields>();
 
+        String sourceObject = DataImport__c.SObjectType.getDescribe().getName();
         for (String dataImportObjectName : fieldMappingsByObjMappingDevName.keySet()) {
 
             String targetObject =
-                    objMappingsByDevName.get(dataImportObjectName).Object_API_Name__c;
-            List<Data_Import_Field_Mapping__mdt> fieldMappingsForThisDataImportObject =
+                    objectMappingByDevName.get(dataImportObjectName).Object_API_Name;
+            List<BDI_FieldMapping> fieldMappingsForThisDataImportObject =
                     fieldMappingsByObjMappingDevName.get(dataImportObjectName);
 
-            for (Data_Import_Field_Mapping__mdt dataImportFieldMapping :
+            for (BDI_FieldMapping dataImportFieldMapping :
                     fieldMappingsForThisDataImportObject) {
 
-                String sourceObject = DataImport__c.SObjectType.getDescribe().getName();
-                String sourceField = dataImportFieldMapping.Source_Field_API_Name__c;
+                String sourceField = dataImportFieldMapping.Source_Field_API_Name;
 
                 SObjectField sourceSObjectField =
                         UTIL_Describe.getFieldDescribe(
                                 sourceObject, sourceField).getSobjectField();
 
-                String targetField = dataImportFieldMapping.Target_Field_API_Name__c;
+                String targetField = dataImportFieldMapping.Target_Field_API_Name;
 
                 if (targetFieldsBySourceField.keySet().contains(sourceSObjectField)) {
                     targetFieldsBySourceField.get(
@@ -136,15 +133,17 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
     *
     */
 
-    public Map<String,String> getFieldMap(String dataImportObjectName, String targetObjectName, List<String> dataImportFields) {
+    public Map<String,String> getFieldMap(String dataImportObjectName, 
+                                            String targetObjectName, 
+                                            List<String> dataImportFields) {
+
         Map<String,String> targetFieldByDataImportField = new Map<String,String>();
 
-        Data_Import_Field_Mapping__mdt[] diFieldMappings = fieldMappingsByObjMappingLegacyName.get(dataImportObjectName);
+        BDI_FieldMapping[] fieldMappings = fieldMappingsByObjMappingLegacyName.get(dataImportObjectName);
 
-        if (diFieldMappings != null) {
-            for (Data_Import_Field_Mapping__mdt difm : diFieldMappings) {
-
-                targetFieldByDataImportField.put(difm.Source_Field_API_Name__c,difm.Target_Field_API_Name__c);
+        if (fieldMappings != null) {
+            for (BDI_FieldMapping fieldMapping : fieldMappings) {
+                targetFieldByDataImportField.put(fieldMapping.Source_Field_API_Name,fieldMapping.Target_Field_API_Name);
             }
         }
 
@@ -164,7 +163,8 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
 
     private void retrieveCustMetadata(){
         //If the code is not in the npsp namespace, then the npsp field prefixes will need to be systematically removed.
-        Boolean removeNPSPNamespace = (UTIL_Namespace.shouldAlignNamespace);
+        Map<String,Data_Import_Object_Mapping__mdt> objMappingsByDevName =
+            new Map<String,Data_Import_Object_Mapping__mdt>();
 
         diFieldMappingSet = [SELECT id, 
                                 MasterLabel, 
@@ -173,7 +173,9 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
                                 Data_Import_Object_Mapping_Set__r.DeveloperName    
                     FROM Data_Import_Field_Mapping_Set__mdt
                     WHERE DeveloperName =: fieldMappingSetName LIMIT 1];
-                    
+
+        Data_Import_Field_Mapping__mdt[] fieldMappings = new List<Data_Import_Field_Mapping__mdt>();
+
         for (Data_Import_Object_Mapping__mdt diom:[SELECT Id,
                                             MasterLabel,
                                             Custom_Mapping_Logic_Class__c,
@@ -208,54 +210,37 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
                                         AND Is_Deleted__c = false
                                     ORDER BY MasterLabel ASC]) {
 
-            // Removing the npsp namespace and potentially adding a new namespace if UTIL_Namespace is under a different namespace
-            if (removeNPSPNamespace) {
-               diom.Imported_Record_Field_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Imported_Record_Field_Name__c);
-               diom.Imported_Record_Status_Field_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Imported_Record_Status_Field_Name__c);
-               diom.Object_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Object_API_Name__c);
-               diom.Relationship_Field__c = UTIL_Namespace.alignSchemaNSWithEnvironment(diom.Relationship_Field__c);
+            if (diom.Data_Import_Field_Mappings__r != null &&
+                diom.Data_Import_Field_Mappings__r.size() > 0) {
+
+                fieldMappings.addAll(diom.Data_Import_Field_Mappings__r);
             }
 
-            objMappingsByDevName.put(diom.DeveloperName, diom);
+            BDI_ObjectMapping objectMapping = new BDI_ObjectMapping(diom);
+            this.objectMappingByDevName.put(objectMapping.DeveloperName,objectMapping);
         }
 
-        Data_Import_Field_Mapping__mdt[] fieldMappings = new List<Data_Import_Field_Mapping__mdt>();
 
-        for (String objectName : objMappingsByDevName.keySet()) {
-            Data_Import_Object_Mapping__mdt objectMapping = objMappingsByDevName.get(objectName);
-
-            if (objectMapping.Data_Import_Field_Mappings__r != null &&
-                objectMapping.Data_Import_Field_Mappings__r.size() > 0) {
-
-                fieldMappings.addAll(objectMapping.Data_Import_Field_Mappings__r);
-            }
-        }
-
-        if (objMappingsByDevName != null && objMappingsByDevName.size() > 0) {
+        if (fieldMappings != null) {
             for (Data_Import_Field_Mapping__mdt difm : fieldMappings) {
 
-                // Removing the npsp namespace since the code is not currently packaged.
-                if (removeNPSPNamespace) {
-                   difm.Target_Object_Mapping__r.Object_API_Name__c = 
-                       UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Target_Object_Mapping__r.Object_API_Name__c);
-                   difm.Source_Field_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Source_Field_API_Name__c);
-                   difm.Target_Field_API_Name__c = UTIL_Namespace.alignSchemaNSWithEnvironment(difm.Target_Field_API_Name__c);
+                BDI_FieldMapping fieldMapping = new BDI_FieldMapping(difm);
+
+                BDI_FieldMapping[] tempFieldMappings = new BDI_FieldMapping[]{};
+
+                if (fieldMappingsByObjMappingDevName.get(fieldMapping.Target_Object_Mapping_Dev_Name) != null) {
+                    tempFieldMappings = fieldMappingsByObjMappingDevName.get(fieldMapping.Target_Object_Mapping_Dev_Name);
                 }
 
-                Data_Import_Field_Mapping__mdt[] tempDifms = new Data_Import_Field_Mapping__mdt[]{};
-
-                if (fieldMappingsByObjMappingDevName.get(difm.Target_Object_Mapping__r.DeveloperName) != null) {
-                    tempDifms = fieldMappingsByObjMappingDevName.get(difm.Target_Object_Mapping__r.DeveloperName);
-                }
-
-                tempDifms.add(difm);
-                fieldMappingsByObjMappingDevName.put(difm.Target_Object_Mapping__r.DeveloperName,tempDifms);
+                tempFieldMappings.add(fieldMapping);
+                fieldMappingByDevName.put(fieldMapping.DeveloperName,fieldMapping);
+                fieldMappingsByObjMappingDevName.put(fieldMapping.Target_Object_Mapping_Dev_Name,tempFieldMappings);
                 fieldMappingsByObjMappingLegacyName.put(
                     difm.Target_Object_Mapping__r.Legacy_Data_Import_Object_Name__c,
-                    tempDifms);
+                    tempFieldMappings);
             }
         }
 
-        fieldMappingSet = new BDI_FieldMappingSet(diFieldMappingSet,objMappingsByDevName.values(),fieldMappings);
+        fieldMappingSet = new BDI_FieldMappingSet(diFieldMappingSet,objectMappingByDevName,fieldMappingByDevName);
     }
 }

--- a/src/classes/BDI_MappingServiceAdvanced_TEST.cls
+++ b/src/classes/BDI_MappingServiceAdvanced_TEST.cls
@@ -110,7 +110,6 @@ private class BDI_MappingServiceAdvanced_TEST {
         System.assert(bdiMSAdv.fieldMappingSet != null);
         System.assert(bdiMSAdv.fieldMappingSet.objectMappingByDevName.size() > 0);
         System.assert(bdiMSAdv.fieldMappingSet.fieldMappingByDevName.size() > 0);
-        System.assert(bdiMSAdv.fieldMappingSet.fieldMappingsByObjMappingDevName.size() > 0);
     }
     
 }

--- a/src/classes/BDI_ObjectMapping.cls
+++ b/src/classes/BDI_ObjectMapping.cls
@@ -50,10 +50,18 @@ public virtual with sharing class BDI_ObjectMapping {
     @AuraEnabled public String Relationship_Field;
     @AuraEnabled public String Relationship_To_Predecessor;
 
+
+    /*******************************************************************************************************
+    * @description No parameter constructor to enable use as virtual class.
+    */
     public BDI_ObjectMapping() {
         
     }
 
+    /*******************************************************************************************************
+    * @description Constructor that populates the wrapper with data from a Data_Import_Object_Mapping__mdt record.
+    * @param objectMapping the Data_Import_Object_Mapping__mdt to populate from.
+    */
     public BDI_ObjectMapping(Data_Import_Object_Mapping__mdt objectMapping) {
         this.Id = objectMapping.Id;
         this.MasterLabel = objectMapping.MasterLabel;

--- a/src/classes/BDI_ObjectMapping.cls
+++ b/src/classes/BDI_ObjectMapping.cls
@@ -34,7 +34,7 @@
 * @group-content ../../ApexDocContent/BatchDataImport.htm
 * @description Wrapper class to hold data related to the object mapping 
 */
-public with sharing class BDI_ObjectMapping {
+public virtual with sharing class BDI_ObjectMapping {
     @AuraEnabled public Id Id;
     @AuraEnabled public String DeveloperName;
     @AuraEnabled public String MasterLabel;
@@ -50,19 +50,36 @@ public with sharing class BDI_ObjectMapping {
     @AuraEnabled public String Relationship_Field;
     @AuraEnabled public String Relationship_To_Predecessor;
 
+    public BDI_ObjectMapping() {
+        
+    }
+
     public BDI_ObjectMapping(Data_Import_Object_Mapping__mdt objectMapping) {
         this.Id = objectMapping.Id;
         this.MasterLabel = objectMapping.MasterLabel;
         this.DeveloperName = objectMapping.DeveloperName;
+
+        //If the code is not in the npsp namespace, then the npsp field prefixes will need to be systematically removed.
+        if (UTIL_Namespace.shouldAlignNamespace) {
+            objectMapping.Imported_Record_Field_Name__c = 
+                UTIL_Namespace.alignSchemaNSWithEnvironment(objectMapping.Imported_Record_Field_Name__c);
+            objectMapping.Imported_Record_Status_Field_Name__c = 
+                UTIL_Namespace.alignSchemaNSWithEnvironment(objectMapping.Imported_Record_Status_Field_Name__c);
+            objectMapping.Object_API_Name__c = 
+                UTIL_Namespace.alignSchemaNSWithEnvironment(objectMapping.Object_API_Name__c);
+            objectMapping.Relationship_Field__c = 
+                UTIL_Namespace.alignSchemaNSWithEnvironment(objectMapping.Relationship_Field__c);
+        }
+
         this.Custom_Mapping_Logic_Class = objectMapping.Custom_Mapping_Logic_Class__c;
         this.Data_Import_Object_Mapping_Set = objectMapping.Data_Import_Object_Mapping_Set__c;
         this.Data_Import_Object_Mapping_Set_Dev_Name = objectMapping.Data_Import_Object_Mapping_Set__r.DeveloperName;
         this.Imported_Record_Field_Name = objectMapping.Imported_Record_Field_Name__c;
         this.Imported_Record_Status_Field_Name = objectMapping.Imported_Record_Status_Field_Name__c;
-        this.Is_Deleted = objectMapping.Is_Deleted__c;
         this.Object_API_Name = objectMapping.Object_API_Name__c;
-        this.Predecessor = objectMapping.Predecessor__c;
         this.Relationship_Field = objectMapping.Relationship_Field__c;
+        this.Is_Deleted = objectMapping.Is_Deleted__c;
+        this.Predecessor = objectMapping.Predecessor__c;
         this.Relationship_To_Predecessor = objectMapping.Relationship_To_Predecessor__c;
     }
 }

--- a/src/classes/BDI_ObjectMappingLogic.cls
+++ b/src/classes/BDI_ObjectMappingLogic.cls
@@ -42,13 +42,12 @@ public with sharing virtual class BDI_ObjectMappingLogic {
         if (objWraps == null) {
             return objWraps;
         }
-
-        Map<String, Schema.DescribeFieldResult> sourceFieldDescribeMap = UTIL_Describe.getAllFieldsDescribe(UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__DataImport__c'));
+        
+        String sourceObjName = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__DataImport__c');
         
         for (BDI_ObjectWrapper objWrap : objWraps) {
-            Map<String, Schema.DescribeFieldResult> targetFieldDescribeMap = UTIL_Describe.getAllFieldsDescribe(objWrap.objMapping.Object_API_Name__c);
 
-            objWrap.sObj = UTIL_Describe.getPrototypeObject(objWrap.objMapping.Object_API_Name__c);
+            objWrap.sObj = UTIL_Describe.getPrototypeObject(objWrap.objMapping.Object_API_Name);
 
             // If the object already has an existing SObject Id, then set it in the sObj
             if (objWrap.existingSObjectId != null) {
@@ -57,12 +56,12 @@ public with sharing virtual class BDI_ObjectMappingLogic {
 
             updateChildToPredecessorRelationship(objWrap);
             
-            for (Data_Import_Field_Mapping__mdt fieldMapping : objWrap.fieldMappings) {
-                String sourceFieldName = fieldMapping.Source_Field_API_Name__c;
-                String targetFieldName = fieldMapping.Target_Field_API_Name__c;
+            for (BDI_FieldMapping fieldMapping : objWrap.fieldMappings) {
+                String sourceFieldName = fieldMapping.Source_Field_API_Name;
+                String targetFieldName = fieldMapping.Target_Field_API_Name;
                 
-                Schema.DescribeFieldResult sourceFieldDescribe = sourceFieldDescribeMap.get(sourceFieldName.toLowerCase());
-                Schema.DescribeFieldResult targetFieldDescribe = targetFieldDescribeMap.get(targetFieldName.toLowerCase());
+                Schema.DescribeFieldResult sourceFieldDescribe = UTIL_Describe.getFieldDescribe(sourceObjName, sourceFieldName);
+                Schema.DescribeFieldResult targetFieldDescribe = UTIL_Describe.getFieldDescribe(objWrap.objMapping.Object_API_Name, targetFieldName);
 
                 //Confirm that it is real field, and that it is accessible to the running user.
                 if (targetFieldDescribe != null && targetFieldDescribe.isAccessible()) {
@@ -83,9 +82,9 @@ public with sharing virtual class BDI_ObjectMappingLogic {
     // of the predecessor into the defined relationship field on a new SObject.
     public static void updateChildToPredecessorRelationship(BDI_ObjectWrapper objWrap) {
         // If the object we are working on is a child to its predecessor then set the relationship field 
-        if (objWrap.sObj.Id == null && objWrap.objMapping.Relationship_To_Predecessor__c == 'Child') {
+        if (objWrap.sObj.Id == null && objWrap.objMapping.Relationship_To_Predecessor == 'Child') {
 
-            objWrap.sObj.put(objWrap.objMapping.Relationship_Field__c,objWrap.dataImport.get(objWrap.predecessorObjMapping.Imported_Record_Field_Name__c));
+            objWrap.sObj.put(objWrap.objMapping.Relationship_Field,objWrap.dataImport.get(objWrap.predecessorObjMapping.Imported_Record_Field_Name));
         }
     }
 

--- a/src/classes/BDI_ObjectMappingLogic.cls
+++ b/src/classes/BDI_ObjectMappingLogic.cls
@@ -43,7 +43,7 @@ public with sharing virtual class BDI_ObjectMappingLogic {
             return objWraps;
         }
         
-        String sourceObjName = UTIL_Namespace.alignSchemaNSWithEnvironment('npsp__DataImport__c');
+        String sourceObjName = SObjectType.DataImport__c.getName();
         
         for (BDI_ObjectWrapper objWrap : objWraps) {
 

--- a/src/classes/BDI_ObjectWrapper.cls
+++ b/src/classes/BDI_ObjectWrapper.cls
@@ -37,9 +37,9 @@
 
 public with sharing class BDI_ObjectWrapper {
 
-    public Data_Import_Object_Mapping__mdt objMapping;
-    public Data_Import_Object_Mapping__mdt predecessorObjMapping;
-    public Data_Import_Field_Mapping__mdt[] fieldMappings;
+    public BDI_ObjectMapping objMapping;
+    public BDI_ObjectMapping predecessorObjMapping;
+    public BDI_FieldMapping[] fieldMappings;
     public DataImport__c dataImport;
     public SObject sobj;
 
@@ -53,7 +53,7 @@ public with sharing class BDI_ObjectWrapper {
     * @param fieldMappings CMT records for field mappings from config
     * @param predessessorObjMapping CMT record of predessessor
     */
-    public BDI_ObjectWrapper(DataImport__c dataImport, Data_Import_Object_Mapping__mdt objMapping, Data_Import_Field_Mapping__mdt[] fieldMappings, Data_Import_Object_Mapping__mdt predecessorObjMapping) {
+    public BDI_ObjectWrapper(DataImport__c dataImport, BDI_ObjectMapping objMapping, BDI_FieldMapping[] fieldMappings, BDI_ObjectMapping predecessorObjMapping) {
         this.objMapping = objMapping;
         this.predecessorObjMapping = predecessorObjMapping;
         this.fieldMappings = fieldMappings;
@@ -71,7 +71,7 @@ public with sharing class BDI_ObjectWrapper {
     * @description Set error information on the DataImport__c
     */
     public void setImportedRecordStatusError(String errorMessage) {
-        String statusField = objMapping.Imported_Record_Status_Field_Name__c;
+        String statusField = objMapping.Imported_Record_Status_Field_Name;
         if (statusField != null && errorMessage != null) {
             dataImport.put(statusField, errorMessage.left(255));
         }

--- a/src/classes/GE_TemplateBuilderCtrl.cls
+++ b/src/classes/GE_TemplateBuilderCtrl.cls
@@ -92,16 +92,13 @@ public with sharing class GE_TemplateBuilderCtrl {
         bdiMSAdv = BDI_MappingServiceAdvanced.getInstance(fieldMappingSetName);
         ObjectMappingWrapper[] objectWrappers = new ObjectMappingWrapper[]{};
 
-        for (Data_Import_Object_Mapping__mdt objectMapping : bdiMSAdv.objMappingsByDevName.values()) {
+        for (BDI_ObjectMapping objectMapping : bdiMSAdv.objectMappingByDevName.values()) {
             ObjectMappingWrapper omw = new ObjectMappingWrapper(objectMapping);
 
-            if (objectMapping.Data_Import_Field_Mappings__r != null) {
-                for (Data_Import_Field_Mapping__mdt fieldMapping : objectMapping.Data_Import_Field_Mappings__r) {
-                    CheckboxWrapper fieldMappingWrapper = new CheckboxWrapper(
-                        fieldMapping.MasterLabel,
-                        fieldMapping.DeveloperName,
-                        false
-                    );
+            BDI_FieldMapping[] fieldMappings = bdiMSAdv.fieldMappingsByObjMappingDevName.get(objectMapping.Object_API_Name);
+            if (fieldMappings != null) {
+                for (BDI_FieldMapping fieldMapping : fieldMappings) {
+                    CheckboxWrapper fieldMappingWrapper = new CheckboxWrapper(fieldMapping,false);
                     omw.fieldMappingCheckboxes.add(fieldMappingWrapper);
                 }
             }
@@ -127,16 +124,13 @@ public with sharing class GE_TemplateBuilderCtrl {
         return wrappers;
     }
 
-    public class ObjectMappingWrapper {
-        @AuraEnabled public String DeveloperName;
-        @AuraEnabled public String MasterLabel;
-        @AuraEnabled public String Object_API_Name;
+    public class ObjectMappingWrapper extends BDI_ObjectMapping {
         @AuraEnabled public CheckboxWrapper[] fieldMappingCheckboxes;
 
-        ObjectMappingWrapper(Data_Import_Object_Mapping__mdt objectMapping) {
+        ObjectMappingWrapper(BDI_ObjectMapping objectMapping) {
             this.DeveloperName = objectMapping.DeveloperName;
             this.MasterLabel = objectMapping.MasterLabel;
-            this.Object_API_Name = objectMapping.Object_API_Name__c;
+            this.Object_API_Name = objectMapping.Object_API_Name;
             this.fieldMappingCheckboxes = new CheckboxWrapper[]{};
         }
     }
@@ -145,7 +139,7 @@ public with sharing class GE_TemplateBuilderCtrl {
         @AuraEnabled public String label;
         @AuraEnabled public String value;
         @AuraEnabled public Boolean checked;
-       // @AuraEnabled public String type;
+        @AuraEnabled public String type;
 
         public CheckboxWrapper(Schema.DescribeFieldResult describe) {
             this.label = describe.getLabel();
@@ -158,6 +152,13 @@ public with sharing class GE_TemplateBuilderCtrl {
         public CheckboxWrapper(String label, String value, Boolean checked) {
             this.label = label;
             this.value = value;
+            this.checked = checked;
+        }
+
+        public CheckboxWrapper(BDI_FieldMapping fieldMapping, Boolean checked){
+            this.label = fieldMapping.MasterLabel;
+            this.value = fieldMapping.Source_Field_API_Name;
+            this.type = fieldMapping.Source_Field_Data_Type;
             this.checked = checked;
         }
     }

--- a/src/classes/GE_TemplateBuilderCtrl.cls
+++ b/src/classes/GE_TemplateBuilderCtrl.cls
@@ -218,12 +218,5 @@ public with sharing class GE_TemplateBuilderCtrl {
             this.label = label;
             this.value = value;
         }
-
-        public CheckboxWrapper(BDI_FieldMapping fieldMapping, Boolean checked){
-            this.label = fieldMapping.MasterLabel;
-            this.value = fieldMapping.Source_Field_API_Name;
-            this.type = fieldMapping.Source_Field_Data_Type;
-            this.checked = checked;
-        }
     }
 }

--- a/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
+++ b/src/lwc/bdiFieldMappingModal/bdiFieldMappingModal.js
@@ -366,7 +366,7 @@ export default class bdiFieldMappingModal extends LightningElement {
                         Required: 'No',
                         Source_Field_API_Name: this.fieldMapping.Source_Field_API_Name,
                         Target_Field_API_Name: this.fieldMapping.Target_Field_API_Name,
-                        Target_Object_Mapping: this.objectMapping.DeveloperName
+                        Target_Object_Mapping_Dev_Name: this.objectMapping.DeveloperName
                     });
                 }
 

--- a/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
+++ b/src/lwc/bdiObjectMappingModal/bdiObjectMappingModal.js
@@ -202,7 +202,7 @@ export default class bdiObjectMappingModal extends LightningElement {
     /*******************************************************************************
     * @description Handles escape key press and closes the modal
     */
-    escapefunction(event) {
+    escapeFunction(event) {
         if (event.keyCode === 27) {
             this.handleCloseModal();
         }


### PR DESCRIPTION
Replaced direct use of Data_Import_Field_Mapping__mdt and Data_Import_Object_Mapping__mdt cmt objects and replaced them with BDI_FieldMapping and BDI_ObjectMapping wrappers.  

I also reorganized the logic in the BDI_MappingServiceAdvanced class to streamline the code.  

In addition, I changed how the object mapping classes were working with describe info to reduce the amount of unnecessary describe info that is retrieved.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
