### PR TITLE
CCI flow for RD2 testing

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -112,7 +112,7 @@ tasks:
             record_type_label: NPSP Default
             record_type_developer_name: NPSP_Default
             sobject: Opportunity
-    
+
     is_rd2_enabled:
         description: This preflight check ensures that Enhanced Recurring Donations is enabled
         class_path: tasks.is_rd2_enabled
@@ -405,6 +405,16 @@ flows:
                     path: unpackaged/config/crlp_testing
             2:
                 task: update_admin_profile
+
+    deploy_rd2_testing:
+        description: 'Configure everything for enhanced recurring donations testing in a scratch org'
+        steps:
+            1:
+                task: enable_customizable_rollups
+            2:
+                task: enable_pilot_in_scratch_org
+            3:
+                task: deploy_rd2_config
 
     config_managed:
         steps:


### PR DESCRIPTION
Adding the `deploy_rd2_testing` flow that can be used by devs to quickly configure a scratch org for RD2 related work. This flow does the following:
- Enables Customizable Rollups
- Sets the ErrorSettings.PilotEnabledOverride field to true
- Deploy the RD2 unmanaged configuration

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
