### PR TITLE
RD2: Create Schedule records during data migration

### DIFF
--- a/src/classes/RD2_DataMigrationMapper.cls
+++ b/src/classes/RD2_DataMigrationMapper.cls
@@ -81,15 +81,6 @@ public class RD2_DataMigrationMapper {
     }
 
     /**
-     * @description Generate the RDSchedule Record(s) for the Recurring Donation
-     * @return List<RecurringDonationSchedule__c> Schedule records to insert
-     */
-    public List<RecurringDonationSchedule__c> getScheduleRecords() {
-        RD2_ScheduleService scheduleService = new RD2_ScheduleService();
-        return scheduleService.getNewSchedules(rd);
-    }
-
-    /**
      * @description Sets Installment Frequency and Installment Period fields where applicable
      * @param rd Recurring Donation in the legacy format
      * @return void
@@ -232,6 +223,15 @@ public class RD2_DataMigrationMapper {
      */
     private void setOtherFields(npe03__Recurring_Donation__c rd) {
         rd.RecurringType__c = RD2_Constants.RECURRING_TYPE_OPEN;
+    }
+
+    /**
+     * @description Builds the Schedule Record(s) for the Recurring Donation
+     * @return List<RecurringDonationSchedule__c> Schedule records to insert
+     */
+    public List<RecurringDonationSchedule__c> getScheduleRecords() {
+        RD2_ScheduleService scheduleService = new RD2_ScheduleService();
+        return scheduleService.getNewSchedules(rd);
     }
 
     public class MigrationException extends Exception { }

--- a/src/classes/RD2_DataMigrationMapper.cls
+++ b/src/classes/RD2_DataMigrationMapper.cls
@@ -68,7 +68,8 @@ public class RD2_DataMigrationMapper {
      * @return List<RecurringDonationSchedule__c> Schedule records to insert
      */
     public List<RecurringDonationSchedule__c> getScheduleRecords() {
-        return new List<RecurringDonationSchedule__c>();
+        RD2_ScheduleService scheduleService = new RD2_ScheduleService();
+        return scheduleService.getNewSchedules(rd);
     }
 
     /**

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -584,12 +584,13 @@ private class RD2_DataMigration_TEST {
     private static void shouldNotCreateScheduleForClosedEnhancedRDs() {
 
         List<RecurringDonationSchedule__c> rdSchedules  = new List<RecurringDonationSchedule__c>();
+        Id contactId = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
 
-        npe03__Recurring_Donation__c rd = getLegacyRecurringDonationBuilder(UTIL_UnitTestData_TEST.mockId(Contact.SObjectType))
-            .withStatusClosed()
+        npe03__Recurring_Donation__c rd = getLegacyRecurringDonationBuilder(contactId)
+            .withOpenEndedStatusClosed()
             .build();
 
-        RD2_DataMigrationMapper mapper = new RD2_DataMigrationMapper(rds);
+        RD2_DataMigrationMapper mapper = new RD2_DataMigrationMapper(rd);
         mapper.convertToEnhancedRD();
 
         rdSchedules = mapper.getScheduleRecords();

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -131,6 +131,22 @@ private class RD2_DataMigration_TEST {
             'This RD should be in Enhanced RD format');
     }
 
+     /**
+     * @description Verifies that a schedule record is created for Enhanced Recurring Donation record.
+     */
+    @IsTest
+    private static void shouldCreateScheduleForEnhancedRDs() {
+        List<RecurringDonationSchedule__c> rdSchedules  = new List<RecurringDonationSchedule__c>();
+        Id contactId = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
+
+        npe03__Recurring_Donation__c rd = getNewRecurringDonationEnhancedFormat(contactId);
+
+        RD2_DataMigrationMapper migrationService = new RD2_DataMigrationMapper(rd);
+        rdSchedules = migrationService.getScheduleRecords();
+
+        System.assertEquals(rdSchedules.size(), 1, 'Number of RDs should be 1');
+    }
+
     // HELPER METHODS
 
     /**
@@ -184,4 +200,5 @@ private class RD2_DataMigration_TEST {
 
         return oppBuilder.build();
     }
+
 }

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -135,16 +135,48 @@ private class RD2_DataMigration_TEST {
      * @description Verifies that a schedule record is created for Enhanced Recurring Donation record.
      */
     @IsTest
-    private static void shouldCreateScheduleForEnhancedRDs() {
+    private static void shouldCreateScheduleForActiveEnhancedRDs() {
         List<RecurringDonationSchedule__c> rdSchedules  = new List<RecurringDonationSchedule__c>();
         Id contactId = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
-
         npe03__Recurring_Donation__c rd = getNewRecurringDonationEnhancedFormat(contactId);
 
-        RD2_DataMigrationMapper migrationService = new RD2_DataMigrationMapper(rd);
-        rdSchedules = migrationService.getScheduleRecords();
+        RD2_DataMigrationMapper mapper = new RD2_DataMigrationMapper(rd);
+        mapper.convertToEnhancedRD();
 
-        System.assertEquals(rdSchedules.size(), 1, 'Number of RDs should be 1');
+        rdSchedules = mapper.getScheduleRecords();
+
+        System.assertEquals(1, rdSchedules.size(), 'Number of RDs should be 1');
+        System.assertEquals(100, rdSchedules[0].InstallmentAmount__c, 'Installment Amount should be 100');
+        System.assertEquals('1', rdSchedules[0].DayOfMonth__c,  'Day of Month should be 1');
+    }
+
+    /**
+     * @description Verifies that a schedule record is not created for Closed Enhanced Recurring Donation record.
+     */
+    @IsTest
+    private static void shouldNotCreateScheduleForClosedEnhancedRDs() {
+
+        List<RecurringDonationSchedule__c> rdSchedules  = new List<RecurringDonationSchedule__c>();
+
+        npe03__Recurring_Donation__c rds =
+            TEST_RecurringDonationBuilder.constructEnhancedBuilder()
+                .withMockId()
+                .withContact(UTIL_UnitTestData_TEST.mockId(Contact.SObjectType))
+                .withAmount(400)
+                .withPaymentMethod('Check')
+                .withInstallmentPeriodWeekly()
+                .withInstallmentFrequency(1)
+                .withDateEstablished(Date.newInstance(2019, 9, 15))
+                .withStartDate(Date.newInstance(2019, 11, 1))
+                .withRecurringDonationStatusClosed()
+                .build();
+
+        RD2_DataMigrationMapper mapper = new RD2_DataMigrationMapper(rds);
+        mapper.convertToEnhancedRD();
+
+        rdSchedules = mapper.getScheduleRecords();
+
+        System.assertEquals(0, rdSchedules.size(), 'Number of RDs should be 0');
     }
 
     // HELPER METHODS


### PR DESCRIPTION
# Critical Changes

# Changes
When Data Migration occurs, a schedule record will be created from the values of the Recurring Donation when status is active.

# Issues Closed

# New Metadata

# Deleted Metadata
