### PR TITLE
Fix missed rename of BDI classes

### DIFF
--- a/src/classes/BDI_MappingServiceAdvanced.cls
+++ b/src/classes/BDI_MappingServiceAdvanced.cls
@@ -125,10 +125,10 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
     /**
     * @description Sets instance member variable holding instance of this class.  Primarily
     * used to facilitate dependency injection in tests.
-    * @param bdiFieldMappingInstance An instance of the BDI_FieldMappingCustomMetadata class.
+    * @param bdiFieldMappingInstance An instance of the BDI_MappingServiceAdvanced class.
     */
     @TestVisible
-    private static void setInstance(BDI_FieldMappingCustomMetadata bdiFieldMappingInstance){
+    private static void setInstance(BDI_MappingServiceAdvanced bdiFieldMappingInstance){
         fieldMappingInstance = bdiFieldMappingInstance;
     }
 

--- a/src/classes/BDI_MappingServiceHelpText.cls
+++ b/src/classes/BDI_MappingServiceHelpText.cls
@@ -59,10 +59,10 @@ public with sharing class BDI_MappingServiceHelpText implements BDI_MappingServi
     /**
     * @description Sets instance member variable holding instance of this class.  Primarily
     * used to facilitate dependency injection in tests.
-    * @param bdiFieldMappingInstance An instance of the BDI_FieldMappingHelpText class.
+    * @param bdiFieldMappingInstance An instance of the BDI_MappingServiceHelpText class.
     */
     @TestVisible
-    private static void setInstance(BDI_FieldMappingHelpText bdiFieldMappingInstance){
+    private static void setInstance(BDI_MappingServiceHelpText bdiFieldMappingInstance){
         fieldMappingInstance = bdiFieldMappingInstance;
     }
 

--- a/src/classes/BGE_DataImportBatchEntry_CTRL_TEST.cls
+++ b/src/classes/BGE_DataImportBatchEntry_CTRL_TEST.cls
@@ -446,14 +446,14 @@ private class BGE_DataImportBatchEntry_CTRL_TEST {
             () {
         UTIL_CustomSettingsFacade.enableAdvancedMapping();
 
-        //Create a stub of BDI_FieldMappingCustomMetadata, to mock the scenario where some
+        //Create a stub of BDI_MappingServiceAdvanced, to mock the scenario where some
         //active/selected fields on the Batch are not mapped.
         BDIFieldMappingMock mock = new BDIFieldMappingMock();
-        BDI_FieldMappingCustomMetadata stub = (BDI_FieldMappingCustomMetadata) Test.createStub(
-                BDI_FieldMappingCustomMetadata.class,
+        BDI_MappingServiceAdvanced stub = (BDI_MappingServiceAdvanced) Test.createStub(
+                BDI_MappingServiceAdvanced.class,
                 mock
         );
-        BDI_FieldMappingCustomMetadata.setInstance(stub);
+        BDI_MappingServiceAdvanced.setInstance(stub);
 
         givenActiveFieldIsUnmappedWhenLoadedThenColumnNotIncludedOnBGEForm(mock);
     }
@@ -464,14 +464,14 @@ private class BGE_DataImportBatchEntry_CTRL_TEST {
             () {
         UTIL_CustomSettingsFacade.enableHelpTextMapping();
 
-        //Create a stub of BDI_FieldMappingHelpText, to mock the scenario where some
+        //Create a stub of BDI_MappingServiceHelpText, to mock the scenario where some
         //active/selected fields on the Batch are not mapped.
         BDIFieldMappingMock mock = new BDIFieldMappingMock();
-        BDI_FieldMappingHelpText stub = (BDI_FieldMappingHelpText) Test.createStub(
-                BDI_FieldMappingHelpText.class,
+        BDI_MappingServiceHelpText stub = (BDI_MappingServiceHelpText) Test.createStub(
+                BDI_MappingServiceHelpText.class,
                 mock
         );
-        BDI_FieldMappingHelpText.setInstance(stub);
+        BDI_MappingServiceHelpText.setInstance(stub);
 
         givenActiveFieldIsUnmappedWhenLoadedThenColumnNotIncludedOnBGEForm(mock);
     }

--- a/src/classes/UTIL_CustomSettingsFacade.cls
+++ b/src/classes/UTIL_CustomSettingsFacade.cls
@@ -1019,7 +1019,7 @@ public without sharing class UTIL_CustomSettingsFacade {
         Data_Import_Settings__c dis = getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
         dis.Default_Data_Import_Field_Mapping_Set__c =
-                BDI_FieldMappingCustomMetadata.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+                BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         setDataImportSettings(dis);
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes
- Fix renames of BDI_FieldMappingCustomMetadata and BDI_FieldMappingHelpText
# Issues Closed

# New Metadata

# Deleted Metadata
