### PR TITLE
RD2: If DayOfMonth is null, set using NextPaymentDate or DateEstablished

### DIFF
--- a/src/classes/RD2_DataMigrationMapper.cls
+++ b/src/classes/RD2_DataMigrationMapper.cls
@@ -194,11 +194,36 @@ public class RD2_DataMigrationMapper {
     private void setDayOfMonth(npe03__Recurring_Donation__c rd) {
         Set<String> lastDaysOfMonth = new Set<String>{ '29', '30', '31' };
 
+        if (rd.Always_Use_Last_Day_Of_Month__c == false
+            && String.isEmpty(rd.Day_of_Month__c)
+        ) {
+            rd.Day_of_Month__c = calculateDayOfMonth(rd);
+        }
+
         if (rd.Always_Use_Last_Day_Of_Month__c == true
             || lastDaysOfMonth.contains(rd.Day_of_Month__c)
         ) {
             rd.Day_of_Month__c = RD2_Constants.DAY_OF_MONTH_LAST_DAY;
         }
+    }
+
+    /**
+    * @description If the Day_Of_Month__c field is blank on the Recurring Donation record, use the
+    * NextPaymentDate (if there is one) or the DateEstablished to determine the DayOfMonth to
+    * start the logic with.
+    * @param rd RecurringDonation
+    * @return String representation of the DayOfMonth (1-31)
+    */
+    private String calculateDayOfMonth(npe03__Recurring_Donation__c rd) {
+
+        Date installmentDate;
+        if (rd.npe03__Next_Payment_Date__c != null) {
+            installmentDate = rd.npe03__Next_Payment_Date__c;
+        } else if (rd.npe03__Date_Established__c != null) {
+            installmentDate = rd.npe03__Date_Established__c;
+        }
+
+        return installmentDate.day().format();
     }
 
     /**

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -512,6 +512,78 @@ private class RD2_DataMigration_TEST {
     }
 
     /**
+     * @description Verifies Day of Month is set based on the NextPaymentDate
+     */
+    @IsTest
+    private static void shouldSetDayOfMonthUsingNextPaymentDate() {
+        List<npe03__Recurring_Donation__c> convertedRDs = new List<npe03__Recurring_Donation__c>();
+        TEST_RecurringDonationBuilder rdBuilder = getLegacyRecurringDonationBuilder();
+
+        for (Integer i = 1; i <= 31; i++) {
+            Boolean useLastDayOfMonth = i == 28;
+
+            convertedRDs.add(new RD2_DataMigrationMapper(
+                rdBuilder
+                    .withNextPaymentDate(Date.newInstance(2019, 10, i))
+                    .withDateEstablished(null)
+                    .withDayOfMonth(null)
+                    .build()
+                ).convertToEnhancedRD()
+            );
+        }
+
+        for (npe03__Recurring_Donation__c convertedRD : convertedRDs) {
+            System.assertNotEquals(null, convertedRD.Day_of_Month__c, 'Day of Month should not be null');
+
+            Integer dayOfMonth = convertedRD.npe03__Next_Payment_Date__c.day();
+            if (dayOfMonth < 29) {
+                System.assertEquals(dayOfMonth, Integer.valueOf(convertedRD.Day_of_Month__c),
+                    'Day of Month should match the Next Payment Date day when less than 29: '
+                        + JSON.serialize(convertedRD));
+            } else {
+                System.assertEquals(RD2_Constants.DAY_OF_MONTH_LAST_DAY, convertedRD.Day_of_Month__c,
+                    'Day of Month should be Last Day');
+            }
+        }
+    }
+
+    /**
+     * @description Verifies Day of Month is set based on the DateEstablished
+     */
+    @IsTest
+    private static void shouldSetDayOfMonthUsingDateEstablished() {
+        List<npe03__Recurring_Donation__c> convertedRDs = new List<npe03__Recurring_Donation__c>();
+        TEST_RecurringDonationBuilder rdBuilder = getLegacyRecurringDonationBuilder();
+
+        for (Integer i = 1; i <= 31; i++) {
+            Boolean useLastDayOfMonth = i == 28;
+
+            convertedRDs.add(new RD2_DataMigrationMapper(
+                rdBuilder
+                    .withDateEstablished(Date.newInstance(2019, 10, i))
+                    .withNextPaymentDate(null)
+                    .withDayOfMonth(null)
+                    .build()
+                ).convertToEnhancedRD()
+            );
+        }
+
+        for (npe03__Recurring_Donation__c convertedRD : convertedRDs) {
+            System.assertNotEquals(null, convertedRD.Day_of_Month__c, 'Day of Month should not be null');
+
+            Integer dayOfMonth = convertedRD.npe03__Date_Established__c.day();
+            if (dayOfMonth < 29) {
+                System.assertEquals(dayOfMonth, Integer.valueOf(convertedRD.Day_of_Month__c),
+                    'Day of Month should match the Date Established day when less than 29: '
+                        + JSON.serialize(convertedRD));
+            } else {
+                System.assertEquals(RD2_Constants.DAY_OF_MONTH_LAST_DAY, convertedRD.Day_of_Month__c,
+                    'Day of Month should be Last Day');
+            }
+        }
+    }
+
+    /**
      * @description Verifies Status field is set to Active when Open Ended Status is not Closed
      */
     @IsTest

--- a/unpackaged/config/rd2_post_config/objects/npe03__Recurring_Donation__c.object
+++ b/unpackaged/config/rd2_post_config/objects/npe03__Recurring_Donation__c.object
@@ -12,7 +12,6 @@
         <label>Enhanced Recurring Donations</label>
     </compactLayouts>
     <fields>
-        <description>The amount for each installment Opportunity.</description>
         <fullName>npe03__Amount__c</fullName>
         <description>The amount for each installment Opportunity.</description>
         <externalId>false</externalId>
@@ -26,7 +25,6 @@
         <type>Currency</type>
     </fields>
     <fields>
-        <description>The initial inception date for this Recurring Donation. The default is the current date.</description>
         <fullName>npe03__Date_Established__c</fullName>
         <defaultValue>Today()</defaultValue>
         <description>The initial inception date for this Recurring Donation. The default is the current date.</description>


### PR DESCRIPTION
- To match logic in legacy recurring donations, when the Day_Of_Month__c field is null on the Recurring Donation record, use the day value from either the NextPaymentDate (if not null) or DateEstablished fields.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
