### PR TITLE
NPSP: BDI-AM fix bug caused by case mismatch on fieldname map key

### DIFF
--- a/src/classes/BDI_FieldMappingCustomMetadata.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata.cls
@@ -133,7 +133,7 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
         if (diFieldMappings != null) {
             for (Data_Import_Field_Mapping__mdt difm : diFieldMappings) {
 
-                targetFieldByDataImportField.put(difm.Source_Field_API_Name__c,difm.Target_Field_API_Name__c);
+                targetFieldByDataImportField.put(difm.Source_Field_API_Name__c.toLowerCase(),difm.Target_Field_API_Name__c);
             }
         }
 

--- a/src/classes/BDI_FieldMappingCustomMetadata.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata.cls
@@ -133,7 +133,9 @@ public with sharing class BDI_FieldMappingCustomMetadata implements BDI_FieldMap
         if (diFieldMappings != null) {
             for (Data_Import_Field_Mapping__mdt difm : diFieldMappings) {
 
-                targetFieldByDataImportField.put(difm.Source_Field_API_Name__c.toLowerCase(),difm.Target_Field_API_Name__c);
+                targetFieldByDataImportField.put(
+                    difm.Source_Field_API_Name__c.toLowerCase(),
+                    difm.Target_Field_API_Name__c);
             }
         }
 

--- a/src/classes/BDI_FieldMappingCustomMetadata_TEST.cls
+++ b/src/classes/BDI_FieldMappingCustomMetadata_TEST.cls
@@ -61,7 +61,7 @@ private class BDI_FieldMappingCustomMetadata_TEST {
         System.assert(accountFieldMapping.size() >= 8);
 
         String namespace = UTIL_Namespace.getNamespace();
-        String sampleField = 'npsp__Account1_City__c';
+        String sampleField = 'npsp__account1_city__c';
         
         if (UTIL_Namespace.shouldAlignNamespace) {
             sampleField = UTIL_Namespace.alignSchemaNSWithEnvironment(sampleField);


### PR DESCRIPTION
The map of Data Import Field -> Target field generated from Advanced Mapping was using a mixed case field name for the map key, unlike the help text variant which was forcing map keys to lowercase. There was at least one bug attached to this behavior, and this work correctly lowercases the map keys for advanced mapping.

# Critical Changes

# Changes

# Issues Closed

Fixes #4744 

# New Metadata

# Deleted Metadata
