### PR TITLE
BDI AM Fix case mis-match on field mapping keys

### DIFF
--- a/src/classes/BDI_MappingServiceAdvanced.cls
+++ b/src/classes/BDI_MappingServiceAdvanced.cls
@@ -154,7 +154,7 @@ public with sharing class BDI_MappingServiceAdvanced implements BDI_MappingServi
         if (fieldMappings != null) {
             for (BDI_FieldMapping fieldMapping : fieldMappings) {
                 targetFieldByDataImportField.put(
-                    fieldMapping.Source_Field_API_Name,
+                    fieldMapping.Source_Field_API_Name.toLowerCase(),
                     fieldMapping.Target_Field_API_Name);
             }
         }


### PR DESCRIPTION
Fixes a potential source of case mis-match on fieldnames used as keys to the fieldmapping returned by the mapping source. This fix was already delivered in the master branch but appears to have not propagated downstream since this class was renamed during refactor.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
