### PR TITLE
Enable test retries

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -331,6 +331,14 @@ tasks:
                 errSettings.%%%NAMESPACE%%%OverrideFeature_PilotEnabled__c = true;
                 upsert errSettings;
 
+    run_tests:
+        options:
+            retry_failures:
+                - "unable to obtain exclusive access to this record"
+                - "UNABLE_TO_LOCK_ROW"
+                - "connection was cancelled here"
+            retry_always: True
+
 flows:
     config_dev:
         steps:


### PR DESCRIPTION
This PR activates unit test retries for row locks. When any test fails for row locks, all failed tests will be retried serially.

This PR does not activate parallel unit test runs, which do not work effectively for NPSP. These changes should have minimal impact on test run time, but will ameliorate needs to rebuild row-locked builds.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
