### PR TITLE
NPSP process HH naming as asyc when operating in bulk

### DIFF
--- a/src/classes/ACCT_AccountMerge_TDTM.cls
+++ b/src/classes/ACCT_AccountMerge_TDTM.cls
@@ -107,7 +107,7 @@ public class ACCT_AccountMerge_TDTM extends TDTM_Runnable {
         }
         
         if (listHHId.size() > 0) 
-            ACCT_IndividualAccounts_TDTM.renameHHAccounts(listHHId);
+            HH_HouseholdNaming.renameHHAccounts(listHHId);
 
         listTemp.addAll(listHHId);
         listTemp.addAll(listOne2OneId);

--- a/src/classes/ACCT_IndividualAccounts_TDTM.cls
+++ b/src/classes/ACCT_IndividualAccounts_TDTM.cls
@@ -241,7 +241,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         }
 
         updatePrimaryContactOnAccount(primaryContactByAccountId);
-        renameHHAccounts(householdIdsToRename);
+        HH_HouseholdNaming.renameHHAccounts(householdIdsToRename);
     }
 
     /**
@@ -280,7 +280,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         updateOneToOneAccounts(oneToOneContactsToUpdate);
         moveOppsToContactAccount(newHouseholdIdByContactId, oldHouseholdIdByContactId);
         updateHouseholds(householdIdsToUpdate);
-        renameHHAccounts(householdIdsToRename);
+        HH_HouseholdNaming.renameHHAccounts(householdIdsToRename);
         updateOwners(newOwnerContactById);
     }
 
@@ -346,7 +346,7 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
         }
 
         resetPrimaryContactForAccount(accountIds);
-        renameHHAccounts(accountIds);
+        HH_HouseholdNaming.renameHHAccounts(accountIds);
         rollupAccounts(accountIds);
     }
 
@@ -918,24 +918,6 @@ public class ACCT_IndividualAccounts_TDTM extends TDTM_Runnable {
             UTIL_DMLService.updateRecords(opportunities);
         }
 
-    }
-
-    /*******************************************************************************************************
-    * @description for the list of HH AccountId's, update their Household Names
-    * @param accountIds the list of Account (Id's) that need updating.
-    * @return void
-    */
-    public static void renameHHAccounts(List<Id> accountIds) {
-        if (accountIds.isEmpty()) {
-            return;
-        }
-
-        if (accountIds.size() == 1 || System.isFuture() || System.isBatch() || System.isQueueable()) {
-            HH_HouseholdNaming hhName = new HH_HouseholdNaming();
-            hhName.UpdateNames(accountIds);
-        } else {
-            HH_HouseholdNaming.FutureUpdateNames(accountIds);
-        }
     }
 
     /*******************************************************************************************************

--- a/src/classes/CON_ContactMerge_TDTM.cls
+++ b/src/classes/CON_ContactMerge_TDTM.cls
@@ -288,7 +288,7 @@ public class CON_ContactMerge_TDTM extends TDTM_Runnable {
                 return;
             }
 
-            ACCT_IndividualAccounts_TDTM.renameHHAccounts(householdIds);
+            HH_HouseholdNaming.renameHHAccounts(householdIds);
             ACCT_IndividualAccounts_TDTM.moveOppsToContactAccount(
                 newIndividualAcctIdByMasterId,
                 oldIndividualAcctIdByMasterId

--- a/src/classes/CON_ContactMerge_TEST.cls
+++ b/src/classes/CON_ContactMerge_TEST.cls
@@ -462,22 +462,28 @@ public class CON_ContactMerge_TEST {
     //the second contact's org should be deleted
     static void merge2OneToOne(string strProcessor) {
 
-        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = UTIL_CustomSettingsFacade.getContactsSettingsForTests(new npe01__Contacts_and_Orgs_Settings__c (npe01__Account_Processor__c = strProcessor));
+        Test.startTest();  
+        npe01__Contacts_and_Orgs_Settings__c contactSettingsForTests = 
+            UTIL_CustomSettingsFacade.getContactsSettingsForTests(
+                new npe01__Contacts_and_Orgs_Settings__c(npe01__Account_Processor__c = strProcessor));
 
         Contact con = UTIL_UnitTestData_TEST.getContact();
 
 		Contact con2 = UTIL_UnitTestData_TEST.getContact();
 		con2.LastName = '2Contact_forTests_Merge';
 
-        insert new Contact[]{con, con2};
-
-        con = [Select id, accountId, FirstName, LastName, MailingStreet from Contact where Id = :con.id];
-        con2 = [Select id, accountId, FirstName, LastName, MailingStreet from Contact where Id = :con2.id];
+        insert new Contact[] {con, con2};
 
         Test.setCurrentPageReference(new PageReference('Page.CON_ContactMerge'));
 
-        CON_ContactMerge_CTRL controller = new CON_ContactMerge_CTRL(new ApexPages.Standardsetcontroller(new list<Contact>()));
-
+        CON_ContactMerge_CTRL controller = 
+            new CON_ContactMerge_CTRL(new ApexPages.Standardsetcontroller(new list<Contact>()));
+            
+        Test.stopTest();          
+            
+        con = [SELECT Id, AccountId, FirstName, LastName, MailingStreet FROM Contact WHERE Id = :con.id];
+        con2 = [SELECT Id, AccountId, FirstName, LastName, MailingStreet FROM Contact WHERE Id = :con2.id];
+      
         controller.searchText = 'test';
         //SOSL always returns nothing in tests, unless you use the setFixedSearchResults value
         Id[] fixedSearchResults=new Id[2];
@@ -485,6 +491,7 @@ public class CON_ContactMerge_TEST {
         fixedSearchResults[1]=con2.Id;
 
         Test.setFixedSearchResults(fixedSearchResults);
+        
         //search for contacts
         controller.search();
         //select the two contacts and grab them
@@ -507,7 +514,6 @@ public class CON_ContactMerge_TEST {
         //Second contact's account id should not have changed
         system.assertEquals(con2.accountId,[select AccountId from Contact where id=:con2.id].AccountId);
     }
-
 
     static testMethod void merge2OneToOneOppsOne2One(){
         //skip the test if Advancement is installed

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -435,7 +435,7 @@ public without sharing class HH_HouseholdNaming {
                 if (hhlist.size() == 1 || System.isFuture() || System.isBatch() || System.isQueueable()) {
                     HH_HouseholdNaming hn = new HH_HouseholdNaming();
                     hn.UpdateNames(hhlist);
-                } else {
+                } else (!hhlist.isEmpty()) {
                     HH_HouseholdNaming.FutureUpdateNames(hhlist);
                 }
             }

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -435,7 +435,7 @@ public without sharing class HH_HouseholdNaming {
                 if (hhlist.size() == 1 || System.isFuture() || System.isBatch() || System.isQueueable()) {
                     HH_HouseholdNaming hn = new HH_HouseholdNaming();
                     hn.UpdateNames(hhlist);
-                } else (!hhlist.isEmpty()) {
+                } else if (!hhlist.isEmpty()) {
                     HH_HouseholdNaming.FutureUpdateNames(hhlist);
                 }
             }

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -368,7 +368,7 @@ public without sharing class HH_HouseholdNaming {
             
             if (hs != null && hs.npo02__Advanced_Household_Naming__c == true) {
                 // AfterUpdate data
-                list<id> hhlist = new list<id>();
+                list<id> hhList = new list<id>();
 
                 for (SObject h : listHHNew) {
                     string customname = '';
@@ -421,24 +421,37 @@ public without sharing class HH_HouseholdNaming {
 
                     } else if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
                         if (h.get('Name') == system.Label.npo02.NameReplacementText)
-                           hhlist.add(h.id);
+                           hhList.add(h.id);
                         else if (h.get('npo02__Informal_Greeting__c') == system.Label.npo02.NameReplacementText)
-                           hhlist.add(h.id);
+                           hhList.add(h.id);
                         else if (h.get('npo02__Formal_Greeting__c') == system.Label.npo02.NameReplacementText)
-                            hhlist.add(h.id);
+                            hhList.add(h.id);
                         else if (h.get('npo02__SYSTEM_CUSTOM_NAMING__c') != mapIdHHOld.get(h.id).get('npo02__SYSTEM_CUSTOM_NAMING__c'))
-                            hhlist.add(h.id);
+                            hhList.add(h.id);
                         else if (h.getSObjectType() == Account.sObjectType && h.get('npe01__One2OneContact__c') != mapIdHHOld.get(h.id).get('npe01__One2OneContact__c'))
-                            hhlist.add(h.id);
+                            hhList.add(h.id);
                     }
                 }
-                if (hhlist.size() == 1 || System.isFuture() || System.isBatch() || System.isQueueable()) {
-                    HH_HouseholdNaming hn = new HH_HouseholdNaming();
-                    hn.UpdateNames(hhlist);
-                } else if (!hhlist.isEmpty()) {
-                    HH_HouseholdNaming.FutureUpdateNames(hhlist);
-                }
+                renameHHAccounts(hhList);
             }
         }
     }
+
+    /*******************************************************************************************************
+    * @description for the list of HH AccountId's, update their Household Names
+    * @param accountIds the list of Account (Id's) that need updating.
+    * @return void
+    */
+    public static void renameHHAccounts(List<Id> accountIds) {
+        if (accountIds.isEmpty()) {
+            return;
+        }
+
+        if (accountIds.size() == 1 || System.isFuture() || System.isBatch() || System.isQueueable()) {
+            HH_HouseholdNaming hhName = new HH_HouseholdNaming();
+            hhName.UpdateNames(accountIds);
+        } else {
+            HH_HouseholdNaming.FutureUpdateNames(accountIds);
+        }
+    }    
 }

--- a/src/classes/HH_HouseholdNaming.cls
+++ b/src/classes/HH_HouseholdNaming.cls
@@ -432,13 +432,13 @@ public without sharing class HH_HouseholdNaming {
                             hhlist.add(h.id);
                     }
                 }
-                if (!hhlist.isEmpty()){
+                if (hhlist.size() == 1 || System.isFuture() || System.isBatch() || System.isQueueable()) {
                     HH_HouseholdNaming hn = new HH_HouseholdNaming();
                     hn.UpdateNames(hhlist);
+                } else {
+                    HH_HouseholdNaming.FutureUpdateNames(hhlist);
                 }
             }
         }
-
     }
-
 }


### PR DESCRIPTION
Updates the processing of HH naming when handling bulk cases to an asynchronous call. This addresses issues with performance on inserting bulk contacts that were potentially affected by attempting to synchronously update HH name.

It also updates a unit test to deploy Test.startTest() and Test.stopTest() in order to process the asynchronous update from above ahead of evaluating the test results. 

# Critical Changes

# Changes

# Issues Closed
Fixes #4535
# New Metadata

# Deleted Metadata
