### PR TITLE
Update Help Text For Payment Allocations Enabled Flag

### DIFF
--- a/force-app/main/default/objects/Allocations_Settings__c/fields/Payment_Allocations_Enabled__c.field-meta.xml
+++ b/force-app/main/default/objects/Allocations_Settings__c/fields/Payment_Allocations_Enabled__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>false</defaultValue>
     <description>Indicates whether Allocations can be set at the Payment level. If selected, you can manually create Allocation records for each Payment, or let NPSP automatically create Payment Allocation records based on the related Opportunity Allocation settings.</description>
     <externalId>false</externalId>
-    <inlineHelpText>Indicates whether Allocations can be set at the Payment Level. Only for use with Accounting Subledger. Contact your Salesforce Account Executive for more information.</inlineHelpText>
+    <inlineHelpText>Indicates whether Allocations can be set at the Payment level. Only for use with Accounting Subledger. Contact your Salesforce Account Executive for more information.</inlineHelpText>
     <label>Payment Allocations Enabled</label>
     <trackTrending>false</trackTrending>
     <type>Checkbox</type>


### PR DESCRIPTION
WI: [W-9963895](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000BejufYAB/view)

# Critical Changes

# Changes
  - We updated the help text for the Enable Payment Allocations setting to make it clear that you must have Accounting Subledger present in your org before enabling the setting.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
